### PR TITLE
优化搜索中的收藏人数筛选机制

### DIFF
--- a/app/src/main/java/ceui/lisa/fragments/FragmentFilter.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentFilter.java
@@ -21,10 +21,18 @@ public class FragmentFilter extends BaseFragment {
             "exact_match_for_tags", "title_and_caption"};
 
 
-    public static final String[] ALL_SIZE = new String[]{" 无限制", " 500人收藏", " 1000人收藏", " 2000人收藏",
-            " 5000人收藏(建议)", " 7500人收藏", " 10000人收藏", " 20000人收藏", " 50000人收藏"};
-    public static final String[] ALL_SIZE_VALUE = new String[]{"", "500users入り", "1000users入り", "2000users入り",
-            "5000users入り", "7500users入り", "10000users入り", "20000users入り", "50000users入り"};
+    public static final String[] ALL_SIZE = new String[]{" 无限制", " 500人以上收藏", " 1000人以上收藏", " 2000人以上收藏",
+            " 5000人以上收藏(建议)", " 7500人以上收藏", " 10000人以上藏", " 20000人以上收藏", " 50000人以上收藏"};
+    public static final String[] ALL_SIZE_VALUE = new String[]{
+            "",
+            "500users入り 1000users入り 2000users入り 5000users入り 7500users入り 10000users入り 20000users入り 50000users入り",
+            "1000users入り 2000users入り 5000users入り 7500users入り 10000users入り 20000users入り 50000users入り",
+            "2000users入り 5000users入り 7500users入り 10000users入り 20000users入り 50000users入り",
+            "5000users入り 7500users入り 10000users入り 20000users入り 50000users入り",
+            "7500users入り 10000users入り 20000users入り 50000users入り",
+            "10000users入り 20000users入り 50000users入り",
+            "20000users入り 50000users入り",
+            "50000users入り"};
 
 
     public static final String[] DATE_SORT = new String[]{"最新作品(建议)", "由旧到新"};


### PR DESCRIPTION
之前的搜索是 `keywords 20000users入り`，获取到的结果仅为20000收藏档次的作品；可以优化成 `keywords 20000users入り 50000users入り` ，这样将同时获取20000和50000档次的作品，更符合用户的使用逻辑。

PS. 编译时报错 `cannot find symbol class WorkThread`，看了一下 http 目录下没有 WorkThread 文件，不知道注释掉 `import ceui.lisa.http.WorkThread` 这条会怎么样。。