### PR TITLE
添加使用Gtihub Action的持续集成编译

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,8 +39,9 @@ jobs:
         gradle wrapper
         bash gradlew assembleDebug
     
-    - name: Upload articact
+    - name: Upload artifact
       uses: actions/upload-artifact@v2
       if: ${{ !github.head_ref }}
       with:
+        name: debug-apk
         path: app/build/outputs/apk

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,46 @@
+name: Build CI
+
+on:
+  - push
+  - pull_request
+
+env:
+  WARN_ON_PR: "artifact upload is disabled due to the workflow is trigged by pull request."
+
+jobs:
+  build:
+    name: Gradle CI
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      name: Clone repository
+
+    - name: Prepare Java 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+        java-package: jdk
+
+    - name: Cache Gradle packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ hashFiles('**/*gradle*') }}
+        restore-keys: ${{ runner.os }}
+
+    - name: Build project
+      env:
+        DEBUG_KEY_PASSWORD: android
+        DEBUG_STORE_PASSWORD: android
+        DEBUG_KEY_ALIAS: androiddebugkey
+      run: |
+        if ${{ !!github.head_ref }}; then echo "::warning:: Gradle $WARN_ON_PR"; fi
+        gradle wrapper
+        bash gradlew assembleDebug
+    
+    - name: Upload articact
+      uses: actions/upload-artifact@v2
+      if: ${{ !github.head_ref }}
+      with:
+        path: app/build/outputs/apk


### PR DESCRIPTION
- 在每次push时进行编译
- 上传编译后的debug apk文件
  - 对pull request触发的action不会上传, 确保构建文件安全可靠

[![Build CI](https://github.com/mnixry/Pixiv-Shaft/actions/workflows/gradle.yml/badge.svg)](https://github.com/mnixry/Pixiv-Shaft/actions/runs/716169366)