### PR TITLE
一些功能和修复

### DIFF
--- a/app/src/main/java/ceui/lisa/activities/BaseActivity.java
+++ b/app/src/main/java/ceui/lisa/activities/BaseActivity.java
@@ -12,6 +12,8 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.view.View;
 
+import com.blankj.utilcode.util.BarUtils;
+
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.databinding.DataBindingUtil;
@@ -56,12 +58,9 @@ public abstract class BaseActivity<Layout extends ViewDataBinding> extends AppCo
             }
 
             if (hideStatusBar()) {
-                getWindow().setStatusBarColor(Color.TRANSPARENT);
-                getWindow().getDecorView().setSystemUiVisibility(
-                        View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN |
-                                View.SYSTEM_UI_FLAG_LAYOUT_STABLE);
+                BarUtils.transparentStatusBar(this);
             } else {
-                getWindow().setStatusBarColor(Common.resolveThemeAttribute(mContext, R.attr.colorPrimary));
+                BarUtils.setStatusBarColor(this, Common.resolveThemeAttribute(mContext, R.attr.colorPrimary));
             }
             try {
                 baseBind = DataBindingUtil.setContentView(mActivity, mLayoutID);

--- a/app/src/main/java/ceui/lisa/activities/BaseActivity.java
+++ b/app/src/main/java/ceui/lisa/activities/BaseActivity.java
@@ -60,7 +60,7 @@ public abstract class BaseActivity<Layout extends ViewDataBinding> extends AppCo
             if (hideStatusBar()) {
                 BarUtils.transparentStatusBar(this);
             } else {
-                BarUtils.setStatusBarColor(this, Common.resolveThemeAttribute(mContext, R.attr.colorPrimary));
+                getWindow().setStatusBarColor(Common.resolveThemeAttribute(mContext, R.attr.colorPrimary));
             }
             try {
                 baseBind = DataBindingUtil.setContentView(mActivity, mLayoutID);

--- a/app/src/main/java/ceui/lisa/activities/ImageDetailActivity.java
+++ b/app/src/main/java/ceui/lisa/activities/ImageDetailActivity.java
@@ -112,7 +112,7 @@ public class ImageDetailActivity extends BaseActivity<ActivityImageDetailBinding
                     return localIllust.size();
                 }
             });
-            currentPage.setVisibility(View.GONE);
+            currentPage.setVisibility(View.INVISIBLE);
             baseBind.viewPager.setCurrentItem(index);
             baseBind.viewPager.addOnPageChangeListener(new ViewPager.OnPageChangeListener() {
                 @Override
@@ -145,7 +145,7 @@ public class ImageDetailActivity extends BaseActivity<ActivityImageDetailBinding
     }
 
     private void checkDownload(int i) {
-        downloadSingle.setVisibility(Common.isIllustDownloaded(mIllustsBean, i) ? View.GONE : View.VISIBLE);
+        downloadSingle.setVisibility(Common.isIllustDownloaded(mIllustsBean, i) ? View.INVISIBLE : View.VISIBLE);
     }
 
     @Override

--- a/app/src/main/java/ceui/lisa/activities/ImageDetailActivity.java
+++ b/app/src/main/java/ceui/lisa/activities/ImageDetailActivity.java
@@ -21,6 +21,7 @@ import ceui.lisa.databinding.ActivityImageDetailBinding;
 import ceui.lisa.download.IllustDownload;
 import ceui.lisa.fragments.FragmentImageDetail;
 import ceui.lisa.fragments.FragmentLocalImageDetail;
+import ceui.lisa.helper.PageTransformerHelper;
 import ceui.lisa.models.IllustsBean;
 import ceui.lisa.utils.Common;
 
@@ -47,7 +48,7 @@ public class ImageDetailActivity extends BaseActivity<ActivityImageDetailBinding
     @Override
     protected void initView() {
         String dataType = getIntent().getStringExtra("dataType");
-        baseBind.viewPager.setPageTransformer(true, new CubeOutTransformer());
+        baseBind.viewPager.setPageTransformer(true, PageTransformerHelper.getCurrentTransformer());
         if ("二级详情".equals(dataType)) {
             currentSize = findViewById(R.id.current_size);
             currentPage = findViewById(R.id.current_page);

--- a/app/src/main/java/ceui/lisa/activities/ImageDetailActivity.java
+++ b/app/src/main/java/ceui/lisa/activities/ImageDetailActivity.java
@@ -36,10 +36,11 @@ public class ImageDetailActivity extends BaseActivity<ActivityImageDetailBinding
 
     @Override
     protected int initLayout() {
-        BarUtils.setStatusBarColor(this, ColorUtils.getColor(R.color.qmui_config_color_transparent));
         if (BarUtils.isSupportNavBar()) {
             BarUtils.setNavBarVisibility(this, false);
         }
+        getWindow().getDecorView().setSystemUiVisibility(getWindow().getDecorView().getSystemUiVisibility()
+                | View.SYSTEM_UI_FLAG_FULLSCREEN);
         return R.layout.activity_image_detail;
     }
 
@@ -159,16 +160,6 @@ public class ImageDetailActivity extends BaseActivity<ActivityImageDetailBinding
         } else {
             mActivity.finish();
         }
-    }
-
-    @Override
-    public void onWindowFocusChanged(boolean hasFocus) {
-        super.onWindowFocusChanged(hasFocus);
-            getWindow().getDecorView().setSystemUiVisibility(
-                    View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                            | View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                            | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-                            | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION);
     }
 
     @Override

--- a/app/src/main/java/ceui/lisa/activities/VActivity.java
+++ b/app/src/main/java/ceui/lisa/activities/VActivity.java
@@ -162,7 +162,7 @@ public class VActivity extends BaseActivity<ActivityViewPagerBinding> {
 
     @Override
     protected void onDestroy() {
-        PixivOperate.setBack(null);
+        PixivOperate.clearBack();
         super.onDestroy();
     }
 

--- a/app/src/main/java/ceui/lisa/adapters/MultiDownldAdapter.java
+++ b/app/src/main/java/ceui/lisa/adapters/MultiDownldAdapter.java
@@ -8,7 +8,6 @@ import android.widget.CompoundButton;
 
 import com.bumptech.glide.Glide;
 
-import java.util.Collections;
 import java.util.List;
 
 import ceui.lisa.R;
@@ -45,33 +44,39 @@ public class MultiDownldAdapter extends BaseAdapter<IllustsBean, RecyMultiDownlo
         params.height = imageSize;
         params.width = imageSize;
         bindView.baseBind.illustImage.setLayoutParams(params);
-        Glide.with(mContext)
-                .load(GlideUtil.getMediumImg(allIllust.get(position)))
-                .placeholder(R.color.light_bg)
-                .into(bindView.baseBind.illustImage);
+        final IllustsBean illustsBean = allIllust.get(position);
+        Object tag = bindView.itemView.getTag(R.id.tag_image_url);
+        if ((tag == null) || !(tag instanceof String) || !((String) tag).equals(illustsBean.getImage_urls().getMedium())) {
+            Glide.with(mContext)
+                    .load(GlideUtil.getMediumImg(illustsBean))
+                    .placeholder(R.color.light_bg)
+                    .into(bindView.baseBind.illustImage);
+
+            bindView.itemView.setTag(R.id.tag_image_url, illustsBean.getImage_urls().getMedium());
+        }
 
         bindView.baseBind.checkbox.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 if (isChecked) {
-                    allIllust.get(position).setChecked(true);
+                    illustsBean.setChecked(true);
                 } else {
-                    allIllust.get(position).setChecked(false);
+                    illustsBean.setChecked(false);
                 }
                 mCallback.doSomething(null);
             }
         });
 
-        if (allIllust.get(position).isChecked()) {
+        if (illustsBean.isChecked()) {
             bindView.baseBind.checkbox.setChecked(true);
         } else {
             bindView.baseBind.checkbox.setChecked(false);
         }
 
-        bindView.itemView.setOnClickListener(v -> bindView.baseBind.checkbox.performClick());
-        bindView.itemView.setOnLongClickListener(new View.OnLongClickListener() {
+//        bindView.itemView.setOnClickListener(v -> bindView.baseBind.checkbox.performClick());
+        bindView.itemView.setOnClickListener(new View.OnClickListener() {
             @Override
-            public boolean onLongClick(View v) {
+            public void onClick(View v) {
                 final PageData pageData = new PageData(allIllust);
                 Container.get().addPageToMap(pageData);
 
@@ -79,9 +84,17 @@ public class MultiDownldAdapter extends BaseAdapter<IllustsBean, RecyMultiDownlo
                 intent.putExtra(Params.POSITION, position);
                 intent.putExtra(Params.PAGE_UUID, pageData.getUUID());
                 mContext.startActivity(intent);
-                return true;
             }
         });
+        if (mOnItemLongClickListener != null) {
+            bindView.itemView.setOnLongClickListener(new View.OnLongClickListener() {
+                @Override
+                public boolean onLongClick(View view) {
+                    mOnItemLongClickListener.onItemLongClick(view, position, 0);
+                    return true;
+                }
+            });
+        }
     }
 
     @Override

--- a/app/src/main/java/ceui/lisa/adapters/UserHAdapter.kt
+++ b/app/src/main/java/ceui/lisa/adapters/UserHAdapter.kt
@@ -24,6 +24,7 @@ class UserHAdapter(targetList: MutableList<UserPreviewsBean>, context: Context) 
         Glide.with(mContext)
             .load(GlideUtil.getUrl(allIllust[position].user.profile_image_urls.medium))
             .placeholder(R.color.light_bg)
+            .error(R.drawable.no_profile)
             .into(bindView.baseBind.userHead)
         if (mOnItemClickListener != null) {
             bindView.itemView.setOnClickListener { v: View? ->

--- a/app/src/main/java/ceui/lisa/fragments/FragmentSettings.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSettings.java
@@ -543,13 +543,12 @@ public class FragmentSettings extends SwipeFragment<FragmentSettingsBinding> {
         });
 
         String[] transformerNames = PageTransformerHelper.getTransformerNames();
-        int transformerTypeIndex = PageTransformerHelper.getCurrentTransformerIndex();
-        baseBind.transformType.setText(transformerNames[transformerTypeIndex]);
+        baseBind.transformType.setText(transformerNames[PageTransformerHelper.getCurrentTransformerIndex()]);
         baseBind.transformTypeRela.setOnClickListener(new View.OnClickListener(){
             @Override
             public void onClick(View v) {
                 new QMUIDialog.CheckableDialogBuilder(mActivity)
-                        .setCheckedIndex(transformerTypeIndex)
+                        .setCheckedIndex(PageTransformerHelper.getCurrentTransformerIndex())
                         .setSkinManager(QMUISkinManager.defaultInstance(mContext))
                         .addItems(transformerNames, new DialogInterface.OnClickListener() {
                             @Override

--- a/app/src/main/java/ceui/lisa/fragments/FragmentSettings.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSettings.java
@@ -30,6 +30,7 @@ import ceui.lisa.activities.Shaft;
 import ceui.lisa.activities.TemplateActivity;
 import ceui.lisa.databinding.FragmentSettingsBinding;
 import ceui.lisa.file.LegacyFile;
+import ceui.lisa.helper.PageTransformerHelper;
 import ceui.lisa.helper.ThemeHelper;
 import ceui.lisa.utils.Common;
 import ceui.lisa.utils.Local;
@@ -533,6 +534,30 @@ public class FragmentSettings extends SwipeFragment<FragmentSettingsBinding> {
                                     baseBind.downloadWay.setText(downloadWays[which]);
                                     Local.setSettings(Shaft.sSettings);
                                     updateIllustPathUI();
+                                }
+                                dialog.dismiss();
+                            }
+                        })
+                        .show();
+            }
+        });
+
+        String[] transformerNames = PageTransformerHelper.getTransformerNames();
+        int transformerTypeIndex = PageTransformerHelper.getCurrentTransformerIndex();
+        baseBind.transformType.setText(transformerNames[transformerTypeIndex]);
+        baseBind.transformTypeRela.setOnClickListener(new View.OnClickListener(){
+            @Override
+            public void onClick(View v) {
+                new QMUIDialog.CheckableDialogBuilder(mActivity)
+                        .setCheckedIndex(transformerTypeIndex)
+                        .setSkinManager(QMUISkinManager.defaultInstance(mContext))
+                        .addItems(transformerNames, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
+                                if (which != PageTransformerHelper.getCurrentTransformerIndex()) {
+                                    PageTransformerHelper.setCurrentTransformer(which);
+                                    baseBind.transformType.setText(transformerNames[which]);
+                                    Local.setSettings(Shaft.sSettings);
                                 }
                                 dialog.dismiss();
                             }

--- a/app/src/main/java/ceui/lisa/fragments/FragmentSingleUgora.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSingleUgora.java
@@ -175,14 +175,12 @@ public class FragmentSingleUgora extends BaseFragment<FragmentUgoraBinding> {
             LocalBroadcastManager.getInstance(mContext).registerReceiver(mPlayReceiver, intentFilter);
         }
 
-        if (illust.getId() == Manager.get().getCurrentIllustID()) {
-            PixivOperate.setBack(new Back() {
-                @Override
-                public void invoke(float progress) {
-                    baseBind.progressLayout.donutProgress.setProgress((float) (Math.round(progress * 100)));
-                }
-            });
-        }
+        PixivOperate.setBack(illust.getId(), new Back() {
+            @Override
+            public void invoke(float progress) {
+                baseBind.progressLayout.donutProgress.setProgress((float) (Math.round(progress * 100)));
+            }
+        });
 
 //        File gifFile = new LegacyFile().gifResultFile(mContext, illust);
 //        if (gifFile.exists() && gifFile.length() > 1024) {
@@ -208,7 +206,7 @@ public class FragmentSingleUgora extends BaseFragment<FragmentUgoraBinding> {
 
     public void nowPlayGif() {
         File gifFile = new LegacyFile().gifResultFile(mContext, illust);
-        PixivOperate.setBack(new Back() {
+        PixivOperate.setBack(illust.getId(), new Back() {
             @Override
             public void invoke(float progress) {
                 baseBind.progressLayout.donutProgress.setProgress((float) (Math.round(progress * 100)));

--- a/app/src/main/java/ceui/lisa/helper/IndexedLinkedHashMap.java
+++ b/app/src/main/java/ceui/lisa/helper/IndexedLinkedHashMap.java
@@ -1,0 +1,42 @@
+package ceui.lisa.helper;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+
+import androidx.annotation.Nullable;
+
+public class IndexedLinkedHashMap<K, V> extends LinkedHashMap<K, V> {
+
+    HashMap<Integer, K> index;
+    int curr = 0;
+
+    public IndexedLinkedHashMap() {
+        super();
+        index = new HashMap<>();
+    }
+
+    @Nullable
+    @Override
+    public V put(K key, V value) {
+        V v = super.put(key, value);
+        index.put(curr++, key);
+        return v;
+    }
+
+    // Bad implementation, should override "merge" function but it has api version requirements
+    public IndexedLinkedHashMap<K, V> tidyIndexes() {
+        curr = 0;
+        if (index == null) {
+            index = new HashMap<>();
+        }
+        index.clear();
+        for (K key : keySet()) {
+            index.put(curr++, key);
+        }
+        return this;
+    }
+
+    public V getIndexed(int i) {
+        return super.get(index.get(i));
+    }
+}

--- a/app/src/main/java/ceui/lisa/helper/PageTransformerHelper.java
+++ b/app/src/main/java/ceui/lisa/helper/PageTransformerHelper.java
@@ -20,82 +20,80 @@ import com.ToxicBakery.viewpager.transforms.ZoomInTransformer;
 import com.ToxicBakery.viewpager.transforms.ZoomOutSlideTransformer;
 import com.ToxicBakery.viewpager.transforms.ZoomOutTransformer;
 
-import java.util.Arrays;
-import java.util.List;
+import java.util.ArrayList;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import ceui.lisa.activities.Shaft;
 
 public class PageTransformerHelper {
-    private final static List<TransformerType> transformers = Arrays.asList(
-            new TransformerType(DefaultTransformer.class),
-            new TransformerType(AccordionTransformer.class),
 
-            new TransformerType(BackgroundToForegroundTransformer.class),
-            new TransformerType(ForegroundToBackgroundTransformer.class),
+    private final static IndexedLinkedHashMap<Integer, TransformerType> transformerMap = Stream.of(
+            new TransformerType(0, DefaultTransformer.class),
+            new TransformerType(1, AccordionTransformer.class),
+            new TransformerType(2, BackgroundToForegroundTransformer.class),
+            new TransformerType(3, ForegroundToBackgroundTransformer.class),
+            new TransformerType(4, CubeInTransformer.class),
+            new TransformerType(5, CubeOutTransformer.class),
+            new TransformerType(6, DepthPageTransformer.class),
+            new TransformerType(7, FlipHorizontalTransformer.class),
+            new TransformerType(8, FlipVerticalTransformer.class),
+            new TransformerType(9, RotateDownTransformer.class),
+            new TransformerType(10, RotateUpTransformer.class),
+            new TransformerType(11, ScaleInOutTransformer.class),
+            new TransformerType(12, ZoomOutSlideTransformer.class),
+            new TransformerType(13, ZoomInTransformer.class),
+            new TransformerType(14, ZoomOutTransformer.class),
+            new TransformerType(15, StackTransformer.class),
+            new TransformerType(16, TabletTransformer.class),
+            new TransformerType(17, DrawerTransformer.class)
+    ).collect(Collectors.toMap(TransformerType::getTypeId, t -> t, (v1, v2) -> v1, IndexedLinkedHashMap::new)).tidyIndexes();
 
-            new TransformerType(CubeInTransformer.class),
-            new TransformerType(CubeOutTransformer.class),
-
-            new TransformerType(DepthPageTransformer.class),
-
-            new TransformerType(FlipHorizontalTransformer.class),
-            new TransformerType(FlipVerticalTransformer.class),
-
-            new TransformerType(RotateDownTransformer.class),
-            new TransformerType(RotateUpTransformer.class),
-
-            new TransformerType(ScaleInOutTransformer.class),
-            new TransformerType(ZoomOutSlideTransformer.class),
-
-            new TransformerType(ZoomInTransformer.class),
-            new TransformerType(ZoomOutTransformer.class),
-
-            new TransformerType(StackTransformer.class),
-            new TransformerType(TabletTransformer.class),
-            new TransformerType(DrawerTransformer.class)
-    );
-
-    public static int getCurrentTransformerIndex(){
-        return Shaft.sSettings.getTransformerType();
+    public static int getCurrentTransformerIndex() {
+        int transformerType = Shaft.sSettings.getTransformerType();
+        if (!transformerMap.containsKey(transformerType)) {
+            return 0;
+        }
+        int index = new ArrayList<>(transformerMap.keySet()).indexOf(transformerType);
+        return Math.min(Math.max(index, 0), transformerMap.size() - 1);
     }
 
-    public static ABaseTransformer getCurrentTransformer(){
+    public static ABaseTransformer getCurrentTransformer() {
         try {
-            return transformers.get(Shaft.sSettings.getTransformerType()).pageTransformer.newInstance();
-        } catch (IllegalAccessException e) {
-            e.printStackTrace();
-        } catch (InstantiationException e) {
+            return transformerMap.get(Shaft.sSettings.getTransformerType()).pageTransformer.newInstance();
+        } catch (IllegalAccessException | InstantiationException e) {
             e.printStackTrace();
         }
         return new DefaultTransformer();
     }
 
-    public static String[] getTransformerNames(){
-        return transformers.stream().map(TransformerType::getName).toArray(String[]::new);
+    public static String[] getTransformerNames() {
+        return transformerMap.values().stream().map(TransformerType::getName).toArray(String[]::new);
     }
 
-    public static void setCurrentTransformer(int index){
-        if (index < 0 || index >= transformers.size()){
-            return;
+    public static void setCurrentTransformer(int index) {
+        if (index < 0 || index >= transformerMap.size()) {
+            index = 0;
         }
-        Shaft.sSettings.setTransformerType(index);
+        Shaft.sSettings.setTransformerType(transformerMap.getIndexed(index).getTypeId());
     }
 
     private static class TransformerType {
+
+        private int typeId;
         private int nameResId;
         private Class<? extends ABaseTransformer> pageTransformer;
 
-        public TransformerType(Class<? extends ABaseTransformer> pageTransformer) {
+        public TransformerType(int typeId, Class<? extends ABaseTransformer> pageTransformer) {
+            this.typeId = typeId;
             this.pageTransformer = pageTransformer;
         }
 
-        public TransformerType(int nameResId, Class<? extends ABaseTransformer> pageTransformer) {
-            this.nameResId = nameResId;
-            this.pageTransformer = pageTransformer;
+        public int getTypeId() {
+            return typeId;
         }
 
-        public String getName(){
+        public String getName() {
             return pageTransformer.getSimpleName().replace("Transformer", "");
         }
     }

--- a/app/src/main/java/ceui/lisa/helper/PageTransformerHelper.java
+++ b/app/src/main/java/ceui/lisa/helper/PageTransformerHelper.java
@@ -1,0 +1,102 @@
+package ceui.lisa.helper;
+
+import com.ToxicBakery.viewpager.transforms.ABaseTransformer;
+import com.ToxicBakery.viewpager.transforms.AccordionTransformer;
+import com.ToxicBakery.viewpager.transforms.BackgroundToForegroundTransformer;
+import com.ToxicBakery.viewpager.transforms.CubeInTransformer;
+import com.ToxicBakery.viewpager.transforms.CubeOutTransformer;
+import com.ToxicBakery.viewpager.transforms.DefaultTransformer;
+import com.ToxicBakery.viewpager.transforms.DepthPageTransformer;
+import com.ToxicBakery.viewpager.transforms.DrawerTransformer;
+import com.ToxicBakery.viewpager.transforms.FlipHorizontalTransformer;
+import com.ToxicBakery.viewpager.transforms.FlipVerticalTransformer;
+import com.ToxicBakery.viewpager.transforms.ForegroundToBackgroundTransformer;
+import com.ToxicBakery.viewpager.transforms.RotateDownTransformer;
+import com.ToxicBakery.viewpager.transforms.RotateUpTransformer;
+import com.ToxicBakery.viewpager.transforms.ScaleInOutTransformer;
+import com.ToxicBakery.viewpager.transforms.StackTransformer;
+import com.ToxicBakery.viewpager.transforms.TabletTransformer;
+import com.ToxicBakery.viewpager.transforms.ZoomInTransformer;
+import com.ToxicBakery.viewpager.transforms.ZoomOutSlideTransformer;
+import com.ToxicBakery.viewpager.transforms.ZoomOutTransformer;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import ceui.lisa.activities.Shaft;
+
+public class PageTransformerHelper {
+    private final static List<TransformerType> transformers = Arrays.asList(
+            new TransformerType(DefaultTransformer.class),
+            new TransformerType(AccordionTransformer.class),
+
+            new TransformerType(BackgroundToForegroundTransformer.class),
+            new TransformerType(ForegroundToBackgroundTransformer.class),
+
+            new TransformerType(CubeInTransformer.class),
+            new TransformerType(CubeOutTransformer.class),
+
+            new TransformerType(DepthPageTransformer.class),
+
+            new TransformerType(FlipHorizontalTransformer.class),
+            new TransformerType(FlipVerticalTransformer.class),
+
+            new TransformerType(RotateDownTransformer.class),
+            new TransformerType(RotateUpTransformer.class),
+
+            new TransformerType(ScaleInOutTransformer.class),
+            new TransformerType(ZoomOutSlideTransformer.class),
+
+            new TransformerType(ZoomInTransformer.class),
+            new TransformerType(ZoomOutTransformer.class),
+
+            new TransformerType(StackTransformer.class),
+            new TransformerType(TabletTransformer.class),
+            new TransformerType(DrawerTransformer.class)
+    );
+
+    public static int getCurrentTransformerIndex(){
+        return Shaft.sSettings.getTransformerType();
+    }
+
+    public static ABaseTransformer getCurrentTransformer(){
+        try {
+            return transformers.get(Shaft.sSettings.getTransformerType()).pageTransformer.newInstance();
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+        } catch (InstantiationException e) {
+            e.printStackTrace();
+        }
+        return new DefaultTransformer();
+    }
+
+    public static String[] getTransformerNames(){
+        return transformers.stream().map(TransformerType::getName).toArray(String[]::new);
+    }
+
+    public static void setCurrentTransformer(int index){
+        if (index < 0 || index >= transformers.size()){
+            return;
+        }
+        Shaft.sSettings.setTransformerType(index);
+    }
+
+    private static class TransformerType {
+        private int nameResId;
+        private Class<? extends ABaseTransformer> pageTransformer;
+
+        public TransformerType(Class<? extends ABaseTransformer> pageTransformer) {
+            this.pageTransformer = pageTransformer;
+        }
+
+        public TransformerType(int nameResId, Class<? extends ABaseTransformer> pageTransformer) {
+            this.nameResId = nameResId;
+            this.pageTransformer = pageTransformer;
+        }
+
+        public String getName(){
+            return pageTransformer.getSimpleName().replace("Transformer", "");
+        }
+    }
+}

--- a/app/src/main/java/ceui/lisa/interfaces/MultiDownload.java
+++ b/app/src/main/java/ceui/lisa/interfaces/MultiDownload.java
@@ -18,9 +18,9 @@ public interface MultiDownload {
     default void startDownload() {
         DataChannel dataChannel = DataChannel.get();
         List<IllustsBean> list = getIllustList();
-        for (IllustsBean illustsBean : list) {
-            illustsBean.setChecked(true);
-        }
+//        for (IllustsBean illustsBean : list) {
+//            illustsBean.setChecked(true);
+//        }
         dataChannel.setDownloadList(list);
         Intent intent = new Intent(getContext(), TemplateActivity.class);
         intent.putExtra(TemplateActivity.EXTRA_FRAGMENT, "批量下载");

--- a/app/src/main/java/ceui/lisa/utils/PixivOperate.java
+++ b/app/src/main/java/ceui/lisa/utils/PixivOperate.java
@@ -25,7 +25,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import ceui.lisa.R;
 import ceui.lisa.activities.OutWakeActivity;
@@ -569,15 +571,17 @@ public class PixivOperate {
                 if (gifResponse != null) {
                     if (allFiles.size() == gifResponse.getUgoira_metadata().getFrames().size()) {
                         Common.showLog("使用返回的delay 00");
+                        Back back = sBack.get(illustsBean.getId());
                         for (int i = 0; i < allFiles.size(); i++) {
                             Common.showLog("编码中 00 " + allFiles.size() + " " + (i + 1));
                             gifEncoder.encodeFrame(BitmapFactory.decodeFile(allFiles.get(i).getPath()),
                                     gifResponse.getUgoira_metadata().getFrames().get(i).getDelay());
-                            if (sBack != null) {
+                            if (back != null) {
                                 float proc = i / (float) (allFiles.size() - 1);
-                                sBack.invoke(proc);
+                                back.invoke(proc);
                             }
                         }
+                        sBack.remove(illustsBean.getId());
                     } else {
                         delayMs = gifResponse.getDelay();
                         Common.showLog("使用返回的delay 11");
@@ -651,17 +655,19 @@ public class PixivOperate {
                     if (frameCount == framesBeans.size()) {
                         Common.showLog("使用返回的delay 00");
 
+                        Back back = sBack.get(illustsBean.getId());
                         for (int i = 0; i < frameCount; i++) {
                             Bitmap bitmap = BitmapFactory.decodeFile(allFiles.get(i).getPath());
                             Common.showLog("编码中 00 " + frameCount + " " + (i + 1));
                             animatedGifEncoder.setDelay(framesBeans.get(i).getDelay());
                             animatedGifEncoder.addFrame(bitmap);
 
-                            if (sBack != null) {
+                            if (back != null) {
                                 float proc = i / (float) (frameCount - 1);
-                                sBack.invoke(proc);
+                                back.invoke(proc);
                             }
                         }
+                        sBack.remove(illustsBean.getId());
                     } else {
                         delayMs = gifResponse.getDelay();
                         Common.showLog("使用返回的delay 11");
@@ -714,10 +720,14 @@ public class PixivOperate {
         }
     }
 
-    private static Back sBack = null;
+    private static Map<Integer,Back> sBack =  new HashMap<Integer,Back>();
 
-    public static void setBack(Back back) {
-        sBack = back;
+    public static void setBack(int illustId, Back back) {
+        sBack.put(illustId, back);
+    }
+
+    public static void clearBack(){
+        sBack.clear();
     }
 
     public static void postNovelMarker(NovelDetail.NovelMarkerBean novelMarkerBean, int novelId, int page, View view) {

--- a/app/src/main/java/ceui/lisa/utils/Settings.java
+++ b/app/src/main/java/ceui/lisa/utils/Settings.java
@@ -152,6 +152,8 @@ public class Settings {
 
     private boolean filterComment = false; // 过滤垃圾评论，默认不开启
 
+    private int transformerType = 5; // 二级详情转场动画，默认是3D盒子
+
     public String getAppLanguage() {
         if(!TextUtils.isEmpty(appLanguage)){
             return appLanguage;
@@ -472,5 +474,13 @@ public class Settings {
 
     public void setFilterComment(boolean filterComment) {
         this.filterComment = filterComment;
+    }
+
+    public int getTransformerType() {
+        return transformerType;
+    }
+
+    public void setTransformerType(int transformerType) {
+        this.transformerType = transformerType;
     }
 }

--- a/app/src/main/res/layout/activity_image_detail.xml
+++ b/app/src/main/res/layout/activity_image_detail.xml
@@ -46,12 +46,12 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_centerHorizontal="true"
-                    android:layout_margin="@dimen/twelve_dip"
+                    android:layout_margin="@dimen/four_dp"
                     android:background="@drawable/follow_user_bg"
                     android:paddingStart="@dimen/sixteen_dp"
-                    android:paddingTop="@dimen/six_dp"
+                    android:paddingTop="@dimen/four_dp"
                     android:paddingEnd="@dimen/sixteen_dp"
-                    android:paddingBottom="@dimen/six_dp"
+                    android:paddingBottom="@dimen/four_dp"
                     android:text="@string/string_7"
                     android:textColor="@android:color/white" />
 

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -741,6 +741,31 @@
                         <View style="@style/half_divider" />
 
                         <RelativeLayout
+                            android:id="@+id/transform_type_rela"
+                            style="@style/ripple_rela">
+
+                            <TextView
+                                style="@style/setting_text_left"
+                                android:text="@string/string_393" />
+
+                            <TextView
+                                android:id="@+id/transform_type"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_alignParentEnd="true"
+                                android:layout_marginEnd="@dimen/sixteen_dp"
+                                android:layout_centerVertical="true"
+                                android:text=""
+                                android:textColor="?attr/colorPrimary"
+                                android:textSize="14sp">
+
+                            </TextView>
+
+                        </RelativeLayout>
+
+                        <View style="@style/half_divider" />
+
+                        <RelativeLayout
                             android:id="@+id/is_firebase_enable_rela"
                             style="@style/ripple_rela">
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -559,4 +559,5 @@
   <string name="string_390">All</string>
   <string name="string_391">Public</string>
   <string name="string_392">Private</string>
+  <string name="string_393">Illustration Page Transform</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -559,4 +559,5 @@
   <string name="string_390">すべて</string>
   <string name="string_391">公開</string>
   <string name="string_392">非公開</string>
+  <string name="string_393">イラストページ変換</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -559,4 +559,5 @@
   <string name="string_390">모두</string>
   <string name="string_391">공공의</string>
   <string name="string_392">은밀한</string>
+  <string name="string_393">일러스트레이션 페이지 변환</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -559,4 +559,5 @@
   <string name="string_392">Частный</string>
   <string name="string_391">Общественные</string>
   <string name="string_390">Все</string>
+  <string name="string_393">Преобразование страницы иллюстрации</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -559,4 +559,5 @@
   <string name="string_390">全部</string>
   <string name="string_391">公開</string>
   <string name="string_392">私人</string>
+  <string name="string_393">作品詳情翻頁模式</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -580,4 +580,5 @@
     <string name="string_390">全部</string>
     <string name="string_391">公开</string>
     <string name="string_392">私人</string>
+    <string name="string_393">作品详情翻页模式</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -581,4 +581,5 @@
     <string name="string_391">公开</string>
     <string name="string_392">私人</string>
     <string name="string_393">作品详情翻页模式</string>
+    <item type="id" name="tag_image_url"></item>
 </resources>


### PR DESCRIPTION
新增：
可选择二级详情翻页动画（翻译太难了，先用类名表示）
批量下载拖拽多选

修改：
二级插画详情页完全隐藏状态栏
调整 GIF 合成回调方式

修复：
二级详情右下角页数位置跳变问题
BarUtils 类修改状态栏颜色，导致搜索页 layout 问题


其中批量下载
进入页面默认不全选
点击图像进入插画详情
点击框框选择/取消
长按进入拖选模式/手指抬起自动关闭
长按模式下，框选住的item变为选中/取消选中（取决于第一个按下的item的状态，如果开始没选中则拖拽区域都是选中，反之亦然）