### PR TITLE
还原 okhttp3:logging-interceptor 版本

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -50,7 +50,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -108,7 +108,7 @@ dependencies {
     api 'com.scwang.smartrefresh:SmartRefreshLayout:1.1.2'
     api 'com.scwang.smartrefresh:SmartRefreshHeader:1.1.2'
 
-    implementation 'com.squareup.okhttp3:logging-interceptor:4.9.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.4.0'
     implementation 'com.rengwuxian.materialedittext:library:2.1.4'
     implementation 'jp.wasabeef:glide-transformations:4.3.0'
     implementation 'de.hdodenhof:circleimageview:3.1.0'

--- a/app/src/main/java/ceui/lisa/http/AccountTokenApi.java
+++ b/app/src/main/java/ceui/lisa/http/AccountTokenApi.java
@@ -8,9 +8,6 @@ import retrofit2.http.POST;
 
 public interface AccountTokenApi {
 
-    //用作登录，刷新token
-    String ACCOUNT_BASE_URL = "https://oauth.secure.pixiv.net/";
-
     @FormUrlEncoded
     @POST("/auth/token")
     Call<UserModel> newRefreshToken(@Field("client_id") String client_id,


### PR DESCRIPTION
升级到 4.9.0 会导致直连失败，原因不明，可能是和其他包版本存在冲突
尝试将 build.gradle 中 okhttp 依赖全部升级到 4.9.0 无效