### PR TITLE
Add version tag to release apk

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -96,7 +96,7 @@ jobs:
             SHA-256: ${{ env.APK_SHA256 }}
             ```
           files: |
-            app-release.apk
+            PixShaft_${{ env.VERSION_TAG }}.apk
           draft: true
           prerelease: false
         env:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -68,10 +68,13 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/') && github.repository == env.ORIGINAL_PROJECT
         run: |
           cp app/build/outputs/apk/release/app-release.apk app-release.apk
+          cp app/build/outputs/apk/release/app-release.apk PixShaft_$version.apk
           sha1=`sha1sum app-release.apk | awk '{ print toupper($1) }'`
           sha256=`sha256sum app-release.apk | awk '{ print toupper($1) }'`
           echo "APK_SHA1=$sha1" >> $GITHUB_ENV
           echo "APK_SHA256=$sha256" >> $GITHUB_ENV
+        env:
+          version: ${{ env.VERSION_TAG }}
 
       - name: Draft release
         if: startsWith(github.ref, 'refs/tags/') && github.repository == env.ORIGINAL_PROJECT


### PR DESCRIPTION
## Changes
#### Change
* Include tag in release apk to avoid multiple `app-release.apk` in downloads directory
* 在release apk档案名增加tag以避免下载位置出现多个`app-release.apk`、`app-release(1).apk`等

https://github.com/CeuiLiSA/Pixiv-Shaft/issues/370#issuecomment-895159512