### PR TITLE
优化apk大小（135 MB -> 48.5 MB）

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -124,7 +124,8 @@ dependencies {
 
     implementation 'com.github.lzyzsd:circleprogress:1.2.1'
 
-    implementation 'com.arthenica:mobile-ffmpeg-video:4.4'
+    //implementation 'com.arthenica:mobile-ffmpeg-video:4.4'
+    implementation("io.github.wangwang-code:mobile-ffmpeg-mini:4.4-mini")
 
     def refresh_version = "3.0.0-alpha"
     implementation "io.github.scwang90:refresh-layout-kernel:$refresh_version"     //核心必须依赖

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,6 @@ plugins {
 
 allprojects {
     repositories {
-        maven { url 'https://jitpack.io' }
         maven { url 'https://jcenter.bintray.com/' }
         maven { url "https://repository.jboss.org/maven2" }
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
@@ -47,6 +46,7 @@ allprojects {
         mavenCentral()
         google()
         maven { url 'https://maven.aliyun.com/repository/public/' }
+        maven { url 'https://jitpack.io' }
 //        mavenLocal()
     }
 }


### PR DESCRIPTION
重新编译了mobile-ffmpeg，砍了不需要的，并发到maven上了

重新编译的方法见[此处](https://github.com/wangwang-code/mobile-ffmpeg?tab=readme-ov-file#%E5%A6%82%E4%BD%95%E5%8A%A8%E6%89%8B%E5%8A%A0%E6%96%99)

如果需要aar包见[此处](https://github.com/wangwang-code/mobile-ffmpeg/releases/tag/4.4-minimize)

不过16K对齐是不用想了Ndk太低了，除非换ffmpeg-kit再重新研究遍编译，但ffmpeg-kit也停止维护了（有社区版