### PR TITLE
fix(main): set utf-8 in main

### DIFF
--- a/scripts/count_prime_illusts.py
+++ b/scripts/count_prime_illusts.py
@@ -14,7 +14,7 @@ def main():
     file_stats = []
 
     for f in sorted(glob.glob(os.path.join(ASSET_DIR, "*.txt"))):
-        with open(f, "r") as fp:
+        with open(f, "r", encoding="utf-8") as fp:
             data = json.load(fp)
 
         tag = data.get("tag", {})


### PR DESCRIPTION
The current code in scripts/count_prime_illusts.py likely works fine most of the time, but It relies on the process default encoding. this patch makes the file open explicit about utf-8 so it behaves the same across environments. Close this if it’s not worth it.

Happy to revise the approach or close this if it doesn’t fit — you know the codebase far better than I do.