### PR TITLE
Fix misleading download folder error message

### DIFF
--- a/app/src/main/java/ceui/lisa/fragments/FragmentSettings.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSettings.java
@@ -780,7 +780,7 @@ public class FragmentSettings extends SwipeFragment<FragmentSettingsBinding> {
             baseBind.singleIllustPath.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    if (Shaft.sSettings.getDownloadWay() == 0) {
+                    if (Shaft.sSettings.getDownloadWay() == 0 && Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
                         Common.showToast(getString(R.string.string_329), true);
                     } else {
                         Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -508,7 +508,7 @@
     <string name="string_326">开始</string>
     <string name="string_327">暂停</string>
     <string name="string_328">清空任务</string>
-    <string name="string_329">传统模式暂时不支持自定义文件夹</string>
+    <string name="string_329">系统版本低于 Android 10，无法自定义文件夹</string>
     <string name="string_330">暂未设置</string>
     <string name="string_331">使用 PixivCat 代理</string>
     <string name="string_332">二级详情页面显示原图</string>


### PR DESCRIPTION
The error message was blaming traditional mode when the actual issue is the Android version. Updated it to say Android 10+ is required instead. Fixes #827