### PR TITLE
feat(download/v3): debug_v6 优化清单全量实现 + UX review + 关键 bug 修复

### DIFF
--- a/app/src/main/java/ceui/lisa/core/Manager.java
+++ b/app/src/main/java/ceui/lisa/core/Manager.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import ceui.lisa.R;
@@ -48,7 +49,12 @@ public class Manager {
 
     private final Context mContext = Shaft.getContext();
     private List<DownloadItem> content = new ArrayList<>();
-    private Disposable handle = null;
+    /**
+     * 多任务并发下载的运行 disposable 表（key = item.uuid）。
+     * 旧设计是单一 `Disposable handle`（串行），现在支持 1-5 并发：每个正在传的
+     * page 各占一个 entry。stopOne(uuid) 只 dispose 那一个；stopAll() dispose 全部。
+     */
+    private final Map<String, Disposable> handles = new ConcurrentHashMap<>();
     private boolean isRunning = false;
 
     private Manager() {
@@ -217,12 +223,10 @@ public class Manager {
                 }
             }
         }
-        if (isRunning) {
-            Common.showLog("Manager 正在下载中，不用多次start");
-            return;
-        }
         isRunning = true;
-        loop();
+        // 之前 isRunning=true 时会 short-circuit return，假设单线程串行用 doFinally
+        // 自动驱动下一条；并发模式下需要每次都 pumpAvailableSlots() 来填满空闲槽位。
+        pumpAvailableSlots();
     }
 
     public void startOne(String uuid) {
@@ -239,12 +243,8 @@ public class Manager {
             }
         }
 
-        if (isRunning) {
-            Common.showLog("Manager 正在下载中，不用多次start");
-            return;
-        }
         isRunning = true;
-        loop();
+        pumpAvailableSlots();
     }
 
     public void stopAll() {
@@ -252,9 +252,11 @@ public class Manager {
             item.setPaused(true);
         }
         isRunning = false;
-        if (handle != null) {
-            handle.dispose();
+        // dispose 全部正在传输的下载（snapshot 防 CME）
+        for (Disposable d : new ArrayList<>(handles.values())) {
+            try { d.dispose(); } catch (Exception ignored) {}
         }
+        handles.clear();
         Common.showLog("已经停止");
     }
 
@@ -266,8 +268,9 @@ public class Manager {
                 break;
             }
         }
-        if(this.uuid.equals(uuid) && handle != null){
-            handle.dispose();
+        Disposable d = handles.remove(uuid);
+        if (d != null) {
+            try { d.dispose(); } catch (Exception ignored) {}
         }
     }
 
@@ -291,30 +294,57 @@ public class Manager {
         }
     }
 
-    private void loop() {
-        if (Common.isEmpty(content.stream().filter(it->!it.isPaused()).collect(Collectors.toList()))) {
-            isRunning = false;
-            Common.showLog("Manager 已经全部下载完成");
-            return;
-        }
-        if(!isRunning){
-            return;
+    /**
+     * 每次有任务变化（startAll / 一条传输完成 / 用户改并发数）都调一次：把 INIT 队首
+     * 拉出来，状态置 DOWNLOADING 后异步派发，直到正在传输的数量达到用户设置的
+     * 并发数上限或没有 INIT 可用为止。
+     *
+     * synchronized 关键：state 检查 + 状态置 DOWNLOADING + handles.put 必须原子，
+     * 否则两个 doFinally 同时回调可能挑到同一条 INIT 派发两次。
+     */
+    private synchronized void pumpAvailableSlots() {
+        if (!isRunning) return;
+        int max = Shaft.sSettings.getMaxConcurrentDownloads();
+        if (max < 1) max = 1;
+        if (max > 5) max = 5;
+
+        int active = activeCount();
+        while (active < max) {
+            DownloadItem next = getFirstReady();
+            if (next == null) break;
+            // 抢占式置 DOWNLOADING：阻止下一次 pump 再挑到这条；progress callback
+            // 进来再细化为带 nonius 的 DOWNLOADING（语义不变，只是同名状态）。
+            next.setState(DownloadItem.DownloadState.DOWNLOADING);
+            // 兼容字段：第一个进入的当前下载 = 老 API 返回的 currentIllustID/uuid
+            currentIllustID = next.getIllust().getId();
+            uuid = next.getUuid();
+            downloadOne(mContext, next);
+            active++;
         }
 
-        DownloadItem item = getFirstOne();
-        if (item != null) {
-            downloadOne(mContext, item);
-        } else {
-            stopAll();
+        if (active == 0 && getFirstReady() == null) {
+            // 没活儿了
+            isRunning = false;
+            Common.showLog("Manager 已经全部下载完成");
         }
     }
 
-    private DownloadItem getFirstOne() {
-        for (int i = 0; i < content.size(); i++) {
-            DownloadItem downloadItem = content.get(i);
-            if (downloadItem.getState() == DownloadItem.DownloadState.INIT || downloadItem.getState() == DownloadItem.DownloadState.DOWNLOADING) {
-                return downloadItem;
-            }
+    /** 兼容老调用点：等价于 pumpAvailableSlots()。 */
+    private void loop() { pumpAvailableSlots(); }
+
+    /** 当前正在传输的 page 数（state=DOWNLOADING 且 !paused）。 */
+    private int activeCount() {
+        int n = 0;
+        for (DownloadItem it : content) {
+            if (!it.isPaused() && it.getState() == DownloadItem.DownloadState.DOWNLOADING) n++;
+        }
+        return n;
+    }
+
+    /** 找出可以 dispatch 的下一条：state=INIT 且未暂停。 */
+    private DownloadItem getFirstReady() {
+        for (DownloadItem it : content) {
+            if (!it.isPaused() && it.getState() == DownloadItem.DownloadState.INIT) return it;
         }
         return null;
     }
@@ -327,8 +357,6 @@ public class Manager {
             return;
         }
 
-        currentIllustID = downloadItem.getIllust().getId();
-        uuid = downloadItem.getUuid();
         Common.showLog("Manager 下载单个 当前进度" + downloadItem.getNonius());
 
         // SAF factory 创建、文件查询、insert 全部在 IO 线程执行，
@@ -347,7 +375,8 @@ public class Manager {
                 AndroidSchedulers.mainThread().scheduleDirect(() -> {
                     Common.showToast(mContext.getString(R.string.string_365));
                     complete(downloadItem, false);
-                    stopAll();
+                    // 单条失败不再 stopAll —— 并发模式下其它正在传的 page 不应受牵连。
+                    pumpAvailableSlots();
                 });
                 return;
             }
@@ -360,7 +389,7 @@ public class Manager {
                 complete(downloadItem, true);
                 AndroidSchedulers.mainThread().scheduleDirect(() -> {
                     content.remove(downloadItem);
-                    loop();
+                    pumpAvailableSlots();
                 });
                 return;
             }
@@ -381,7 +410,7 @@ public class Manager {
                 AndroidSchedulers.mainThread().scheduleDirect(() -> {
                     Common.showToast(mContext.getString(R.string.string_365));
                     complete(downloadItem, false);
-                    stopAll();
+                    pumpAvailableSlots();
                 });
                 return;
             }
@@ -391,7 +420,7 @@ public class Manager {
                 AndroidSchedulers.mainThread().scheduleDirect(() -> {
                     Common.showToast(mContext.getString(R.string.string_365));
                     complete(downloadItem, false);
-                    stopAll();
+                    pumpAvailableSlots();
                 });
                 return;
             }
@@ -434,7 +463,9 @@ public class Manager {
         }
         Request request = reqBuilder.build();
 
-        handle = io.reactivex.rxjava3.core.Observable.<String>create(emitter -> {
+        // 并发模式下：每个传输的 disposable 单独存到 handles，按 uuid key
+        final String itemUuid = downloadItem.getUuid();
+        Disposable d = io.reactivex.rxjava3.core.Observable.<String>create(emitter -> {
             Response response = null;
             InputStream inputStream = null;
             OutputStream outputStream = null;
@@ -505,7 +536,9 @@ public class Manager {
                                 downloadItem.setState(DownloadItem.DownloadState.DOWNLOADING);
                                 Common.showLog("currentProgress " + progress);
                                 try {
-                                    Callback<DownloadProgress> c = getCallback(uuid);
+                                    // 用 item 自己的 uuid 查 callback —— 之前用 Manager 的静态
+                                    // uuid 字段，并发模式下会拿错（被后启动的覆盖了）。
+                                    Callback<DownloadProgress> c = getCallback(downloadItem.getUuid());
                                     if (c != null) {
                                         c.doSomething(dp);
                                     }
@@ -534,13 +567,13 @@ public class Manager {
         })
         .subscribeOn(Schedulers.io())
         // 完成回调保持在 IO 线程，Gson 序列化 + DB 操作 + finishWrite 不阻塞主线程。
-        // 只有 UI 通知（广播、Toast）和 loop() 回主线程。
+        // 只有 UI 通知（广播、Toast）和 pump 回主线程。
         .observeOn(Schedulers.io())
         .doFinally(() -> {
-            currentIllustID = 0;
-            Common.showLog("doFinally ");
-            // loop 需要回主线程，因为它可能操作 UI 状态
-            AndroidSchedulers.mainThread().scheduleDirect(this::loop);
+            // 这条传完了，把它的 disposable 从表里移除，主线程上 pump 下一个空闲槽位。
+            handles.remove(itemUuid);
+            Common.showLog("doFinally uuid=" + itemUuid);
+            AndroidSchedulers.mainThread().scheduleDirect(this::pumpAvailableSlots);
         })
         .subscribe(s -> {
             Common.showLog("downloadOne " + s);
@@ -615,6 +648,7 @@ public class Manager {
                 LocalBroadcastManager.getInstance(Shaft.getContext()).sendBroadcast(intent);
             }
         });
+        handles.put(itemUuid, d);
     }
 
     private String uuid;

--- a/app/src/main/java/ceui/lisa/core/Manager.java
+++ b/app/src/main/java/ceui/lisa/core/Manager.java
@@ -301,8 +301,11 @@ public class Manager {
      *
      * synchronized 关键：state 检查 + 状态置 DOWNLOADING + handles.put 必须原子，
      * 否则两个 doFinally 同时回调可能挑到同一条 INIT 派发两次。
+     *
+     * public：用户改并发设置时希望"扩大槽位继续跑"但不希望像 startAll 那样
+     * 把手动暂停的 item 也强制恢复 —— FragmentSettings 调这个。
      */
-    private synchronized void pumpAvailableSlots() {
+    public synchronized void pumpAvailableSlots() {
         if (!isRunning) return;
         int max = Shaft.sSettings.getMaxConcurrentDownloads();
         if (max < 1) max = 1;

--- a/app/src/main/java/ceui/lisa/fragments/FragmentSettings.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSettings.java
@@ -1112,8 +1112,9 @@ public class FragmentSettings extends SwipeFragment<FragmentSettingsBinding> {
                                         Local.setSettings(Shaft.sSettings);
                                         refreshConcurrencyLabel.run();
                                         Common.showToast(getString(R.string.setting_max_concurrent_downloads_changed, chosen));
-                                        // 即时生效：让 Manager 把新增的并发槽位填上
-                                        try { Manager.get().startAll(); } catch (Exception ignored) {}
+                                        // 即时生效：仅 pump 新增的槽位，不要 startAll —— 那会把
+                                        // 用户手动暂停的 item 一并恢复，违反用户预期。
+                                        try { Manager.get().pumpAvailableSlots(); } catch (Exception ignored) {}
                                     }
                                     dialog.dismiss();
                                 }

--- a/app/src/main/java/ceui/lisa/fragments/FragmentSettings.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSettings.java
@@ -36,6 +36,7 @@ import ceui.lisa.R;
 import ceui.lisa.activities.BaseActivity;
 import ceui.lisa.activities.Shaft;
 import ceui.lisa.activities.TemplateActivity;
+import ceui.lisa.core.Manager;
 import ceui.lisa.databinding.FragmentSettingsBinding;
 import ceui.lisa.download.IllustDownload;
 import ceui.lisa.file.LegacyFile;
@@ -1077,6 +1078,53 @@ public class FragmentSettings extends SwipeFragment<FragmentSettingsBinding> {
                 @Override
                 public void onClick(View v) {
                     baseBind.downloadLimitType.performClick();
+                }
+            });
+
+            // 同时下载数 1-5（issue #859：用户希望多任务下载，默认 1=旧串行行为）
+            final String[] CONCURRENCY_NAMES = new String[]{
+                    getString(R.string.setting_max_concurrent_downloads_one),
+                    getString(R.string.setting_max_concurrent_downloads_n, 2),
+                    getString(R.string.setting_max_concurrent_downloads_n, 3),
+                    getString(R.string.setting_max_concurrent_downloads_n, 4),
+                    getString(R.string.setting_max_concurrent_downloads_n, 5),
+            };
+            final Runnable refreshConcurrencyLabel = () -> {
+                int n = Shaft.sSettings.getMaxConcurrentDownloads();
+                if (n < 1) n = 1; if (n > 5) n = 5;
+                baseBind.maxConcurrentDownloads.setText(CONCURRENCY_NAMES[n - 1]);
+            };
+            refreshConcurrencyLabel.run();
+            baseBind.maxConcurrentDownloads.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    int current = Shaft.sSettings.getMaxConcurrentDownloads();
+                    if (current < 1) current = 1; if (current > 5) current = 5;
+                    new QMUIDialog.CheckableDialogBuilder(mActivity)
+                            .setCheckedIndex(current - 1)
+                            .setSkinManager(QMUISkinManager.defaultInstance(mContext))
+                            .addItems(CONCURRENCY_NAMES, new DialogInterface.OnClickListener() {
+                                @Override
+                                public void onClick(DialogInterface dialog, int which) {
+                                    int chosen = which + 1;
+                                    if (chosen != Shaft.sSettings.getMaxConcurrentDownloads()) {
+                                        Shaft.sSettings.setMaxConcurrentDownloads(chosen);
+                                        Local.setSettings(Shaft.sSettings);
+                                        refreshConcurrencyLabel.run();
+                                        Common.showToast(getString(R.string.setting_max_concurrent_downloads_changed, chosen));
+                                        // 即时生效：让 Manager 把新增的并发槽位填上
+                                        try { Manager.get().startAll(); } catch (Exception ignored) {}
+                                    }
+                                    dialog.dismiss();
+                                }
+                            })
+                            .show();
+                }
+            });
+            baseBind.maxConcurrentDownloadsRela.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    baseBind.maxConcurrentDownloads.performClick();
                 }
             });
 

--- a/app/src/main/java/ceui/lisa/utils/Settings.java
+++ b/app/src/main/java/ceui/lisa/utils/Settings.java
@@ -213,6 +213,12 @@ public class Settings {
 
     private int downloadLimitType = 0; // 下载限制类型 0:无限制 1:仅Wifi下自动下载 2:不自动下载
 
+    /** 同时下载的最大任务数（1-5）。1 = 严格串行（旧默认行为）。 */
+    private int maxConcurrentDownloads = 1;
+
+    /** 已完成 tab 的列表展示模式（0=横向列表，1=网格 2 列，2=紧凑缩图 4 列）。1 = 旧默认。 */
+    private int doneListLayoutMode = 1;
+
     private boolean illustDetailKeepScreenOn = false; //插画二级详情保持屏幕常亮
 
     // 收藏夹过滤已失效作品（已删除/不可见），默认不过滤
@@ -670,6 +676,32 @@ public class Settings {
 
     public void setDownloadLimitType(int downloadLimitType) {
         this.downloadLimitType = downloadLimitType;
+    }
+
+    /** clamp 到 [1,5]；老用户/损坏配置（值为 0 / 负数 / 大于 5）都按 1 处理 */
+    public int getMaxConcurrentDownloads() {
+        if (maxConcurrentDownloads < 1) return 1;
+        if (maxConcurrentDownloads > 5) return 5;
+        return maxConcurrentDownloads;
+    }
+
+    public void setMaxConcurrentDownloads(int n) {
+        if (n < 1) n = 1;
+        if (n > 5) n = 5;
+        this.maxConcurrentDownloads = n;
+    }
+
+    /** clamp 到 [0,2]，0=LIST, 1=GRID, 2=COMPACT */
+    public int getDoneListLayoutMode() {
+        if (doneListLayoutMode < 0) return 1;
+        if (doneListLayoutMode > 2) return 1;
+        return doneListLayoutMode;
+    }
+
+    public void setDoneListLayoutMode(int n) {
+        if (n < 0) n = 1;
+        if (n > 2) n = 1;
+        this.doneListLayoutMode = n;
     }
 
     public boolean isShowLargeThumbnailImage() {

--- a/app/src/main/java/ceui/pixiv/download/backend/MediaStoreBackend.kt
+++ b/app/src/main/java/ceui/pixiv/download/backend/MediaStoreBackend.kt
@@ -53,6 +53,24 @@ class MediaStoreBackend(
      * On Q+, update the existing MediaStore row in place instead of
      * delete + insert. This avoids `contentResolver.delete()` which
      * triggers media-deletion alerts on HarmonyOS and similar skins.
+     *
+     * Two distinct failure modes are handled here:
+     *
+     *  1. **Orphan rows from external scanners.** A file may exist on disk
+     *     but its row's `RELATIVE_PATH` was normalised differently by a
+     *     system migration / 3rd-party scanner so [findUri] misses. The
+     *     `findUri ?: reclaimOrphanRow` chain forces MediaScanner to ingest
+     *     it before we fall through, otherwise [openModern] would trigger
+     *     OEM-side directory auto-rename
+     *     (`Pictures/ShaftImages (1)/`, `(2)/`, ...).
+     *
+     *  2. **Row exists but not owned by us.** Typical after app reinstall
+     *     or when another package created the row first. On Q+
+     *     MediaProvider rejects our `update`/`delete` with
+     *     `SecurityException`, breaking the download chain. We catch it
+     *     and fall through to insert; MediaStore auto-suffixes DISPLAY_NAME
+     *     on conflict so bytes land on a sibling " (1)" file. Net better
+     *     than failing the download outright — price is a duplicate file.
      */
     override fun replace(relPath: RelativePath, mime: String): StorageBackend.WriteHandle {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -64,56 +82,84 @@ class MediaStoreBackend(
             // [openModern]'s rename guard for the matching diagnostic).
             val existing = findUri(relPath) ?: reclaimOrphanRow(relPath)
             if (existing != null) {
-                val values = ContentValues().apply {
-                    put(MediaStore.MediaColumns.MIME_TYPE, mime)
-                    put(MediaStore.MediaColumns.IS_PENDING, 1)
+                try {
+                    return openExistingForReplace(existing, mime)
+                } catch (se: SecurityException) {
+                    // Row exists but we don't own it; cannot in-place update.
+                    // Log + fall through to fresh insert below. MediaStore on
+                    // Q+ auto-resolves DISPLAY_NAME conflicts within the same
+                    // RELATIVE_PATH by appending a counter, so the bytes still
+                    // land on disk just under a "(1)" filename.
+                    android.util.Log.w(
+                        "MediaStoreBackend",
+                        "replace() denied on $existing — row not owned by us " +
+                            "(reinstall or external scanner). Falling back to insert.",
+                        se,
+                    )
                 }
-                context.contentResolver.update(existing, values, null, null)
-                // If openOutputStream throws, restore IS_PENDING=0 on the
-                // existing row before propagating — otherwise the pre-existing
-                // file gets stuck as a `.pending-` orphan even though we never
-                // wrote a byte (issue #857 manifested via "replace" path).
-                val stream = try {
-                    context.contentResolver.openOutputStream(existing, "rwt")
-                        ?: error("openOutputStream returned null for $existing")
-                } catch (e: Exception) {
-                    runCatching {
-                        context.contentResolver.update(
-                            existing,
-                            ContentValues().apply { put(MediaStore.MediaColumns.IS_PENDING, 0) },
-                            null, null,
-                        )
-                    }
-                    throw e
-                }
-                val onFinish: () -> Unit = {
-                    val update = ContentValues().apply {
-                        put(MediaStore.MediaColumns.IS_PENDING, 0)
-                    }
-                    context.contentResolver.update(existing, update, null, null)
-                }
-                // On abort during replace, restore IS_PENDING=0 — the row
-                // pre-existed before we touched it, so deleting it would
-                // unilaterally erase a file the user already had.
-                val onAbort: () -> Unit = {
-                    runCatching {
-                        context.contentResolver.update(
-                            existing,
-                            ContentValues().apply { put(MediaStore.MediaColumns.IS_PENDING, 0) },
-                            null, null,
-                        )
-                    }
-                }
-                return StorageBackend.WriteHandle(existing, stream, onFinish, onAbort)
             }
-            // Three lookups (canonical / _DATA / scanFile) all missed — there
-            // is no row to update. Skip [super.replace], whose default impl
-            // would call `exists()` again (one more redundant findUri round
-            // trip), and go straight to insert. The inserted row carries our
-            // OEM-rename guard, so this is the safe entry to a fresh write.
+            // Reach here under two distinct conditions:
+            //   1. All three lookups (canonical / _DATA / scanFile reclaim) missed —
+            //      no row to update; this is a clean fresh write.
+            //   2. A row was found but [openExistingForReplace] hit SecurityException
+            //      because we don't own it (reinstall / external scanner). Fall back
+            //      to insert; MediaStore Q+ auto-suffixes DISPLAY_NAME on conflict,
+            //      so bytes land on a sibling "(1)" file.
+            // In both cases skip [super.replace], whose default impl would call
+            // `exists()` again (one more redundant findUri round-trip), and go
+            // straight to insert. The inserted row carries our OEM-rename guard,
+            // so this is the safe entry to a fresh write.
             return openModern(relPath, mime)
         }
         return super.replace(relPath, mime)
+    }
+
+    /**
+     * In-place update path of [replace] — extracted so we can wrap it in a
+     * single try/catch SecurityException and cleanly fall back to insert.
+     */
+    private fun openExistingForReplace(existing: Uri, mime: String): StorageBackend.WriteHandle {
+        val values = ContentValues().apply {
+            put(MediaStore.MediaColumns.MIME_TYPE, mime)
+            put(MediaStore.MediaColumns.IS_PENDING, 1)
+        }
+        context.contentResolver.update(existing, values, null, null)
+        // If openOutputStream throws, restore IS_PENDING=0 on the
+        // existing row before propagating — otherwise the pre-existing
+        // file gets stuck as a `.pending-` orphan even though we never
+        // wrote a byte (issue #857 manifested via "replace" path).
+        val stream = try {
+            context.contentResolver.openOutputStream(existing, "rwt")
+                ?: error("openOutputStream returned null for $existing")
+        } catch (e: Exception) {
+            runCatching {
+                context.contentResolver.update(
+                    existing,
+                    ContentValues().apply { put(MediaStore.MediaColumns.IS_PENDING, 0) },
+                    null, null,
+                )
+            }
+            throw e
+        }
+        val onFinish: () -> Unit = {
+            val update = ContentValues().apply {
+                put(MediaStore.MediaColumns.IS_PENDING, 0)
+            }
+            context.contentResolver.update(existing, update, null, null)
+        }
+        // On abort during replace, restore IS_PENDING=0 — the row
+        // pre-existed before we touched it, so deleting it would
+        // unilaterally erase a file the user already had.
+        val onAbort: () -> Unit = {
+            runCatching {
+                context.contentResolver.update(
+                    existing,
+                    ContentValues().apply { put(MediaStore.MediaColumns.IS_PENDING, 0) },
+                    null, null,
+                )
+            }
+        }
+        return StorageBackend.WriteHandle(existing, stream, onFinish, onAbort)
     }
 
     private fun openModern(relPath: RelativePath, mime: String): StorageBackend.WriteHandle {

--- a/app/src/main/java/ceui/pixiv/ui/bulk/BulkSelectV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/bulk/BulkSelectV3Fragment.kt
@@ -137,14 +137,18 @@ class BulkSelectV3Fragment : Fragment() {
         val total = items.size
         val selected = items.count { it.selected && it.selectable }
         val gifSkipped = items.count { !it.selectable }
+        // 求和已选作品的页数 —— 每个 illust 的 page_count 累加；page_count<=0 当 1 算
+        val selectedImageCount = items.asSequence()
+            .filter { it.selected && it.selectable }
+            .sumOf { (it.illust.page_count.takeIf { c -> c > 0 } ?: 1) }
         hint.text = if (gifSkipped > 0) {
-            getString(R.string.bulk_select_summary_with_gif, total, selected, gifSkipped)
+            getString(R.string.bulk_select_summary_with_gif, total, selected, selectedImageCount, gifSkipped)
         } else {
-            getString(R.string.bulk_select_summary, total, selected)
+            getString(R.string.bulk_select_summary, total, selected, selectedImageCount)
         }
         btnConfirm.isEnabled = selected > 0
         btnConfirm.text = if (selected > 0) {
-            getString(R.string.bulk_select_confirm, selected)
+            getString(R.string.bulk_select_confirm, selected, selectedImageCount)
         } else {
             getString(R.string.bulk_select_confirm_empty)
         }

--- a/app/src/main/java/ceui/pixiv/ui/bulk/QueueDownloadManager.kt
+++ b/app/src/main/java/ceui/pixiv/ui/bulk/QueueDownloadManager.kt
@@ -224,6 +224,24 @@ object QueueDownloadManager {
         }
         val pageCount = if (bean.page_count <= 0) 1 else bean.page_count
 
+        // 重试路径检测：如果 Manager.content 里还有这个 illust 的 page（必为 FAILED —
+        // SUCCESS 在完成时已 remove；INIT/DOWNLOADING 不会触发 retry），说明这是
+        // bumpRetry → PENDING → consume 又拿回来的同一个 item。直接 startAll() 让
+        // Manager 把这些 FAILED page 重置为 INIT 继续下，不要再 addTask 全部 pageCount
+        // 页 —— 那会让上一轮已经 SUCCESS 的页又重新入队，用户看到 100 张图重新跑一遍。
+        // (issue #859: failed page → 整批 illust 重新加载下载)
+        val target = item.illustId.toInt()
+        val existing = snapshotManagerContent().filter { it.illust?.id == target }
+        if (existing.isNotEmpty()) {
+            Timber.tag(TAG).i(
+                "retry path illust=${item.illustId}: ${existing.size}/$pageCount page(s) still in Manager.content, skipping addTask"
+            )
+            startAllWithRetry()
+            awaitIllustSettled(item.illustId, expectedPageCount = pageCount)
+            return
+        }
+
+        // 首次或被清空后的全新执行：addTask 全部页。
         // 同步 addTask（每次调用都 synchronized 写 content + DB）。
         // 关键：addTask 返回时 items 一定已经在 Manager.content 里，awaitIllustSettled 不会 race 误判。
         for (i in 0 until pageCount) {

--- a/app/src/main/java/ceui/pixiv/ui/download/ActiveListV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/download/ActiveListV3Fragment.kt
@@ -32,6 +32,9 @@ import ceui.lisa.utils.Params
 import ceui.pixiv.db.queue.DownloadQueueDao
 import ceui.pixiv.ui.bulk.QueueDownloadManager
 import com.bumptech.glide.Glide
+import com.qmuiteam.qmui.skin.QMUISkinManager
+import com.qmuiteam.qmui.widget.dialog.QMUIDialog
+import com.qmuiteam.qmui.widget.dialog.QMUIDialogAction
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -41,15 +44,13 @@ import timber.log.Timber
 /**
  * V3 风格 "正在下载" — 监听 Manager.content。
  *
- * 关于"看似多个并发下载"的澄清：
- *   一个 N-page illust 进入下载时，[Manager.content] 会同时挂 N 个 DownloadItem，
- *   但 [Manager.loop] 严格串行下载（每完成一个才启下一个）。任意时刻 **只有 1 个**
- *   item 处于 DOWNLOADING，其余都是 INIT（等待）。本 UI 用以下方式让区分一目了然：
- *
- *     - 顶部统计行明确写 "1 正在 · N 等待"
- *     - DOWNLOADING 卡：完整不透明 + 蓝色进度条 + 实时大小/百分比
- *     - INIT 卡：半透明 0.55 + 隐藏进度条/大小 + 文字 "等待中…"
- *     - 运行时 invariant：snapshot 里 DOWNLOADING > 1 直接 warn 到日志
+ * 并发下载（Settings.maxConcurrentDownloads，默认 1，上限 5）：
+ *   - 任意时刻 DOWNLOADING 数量 ≤ 用户配置的并发数
+ *   - 其余可下载的 page 处于 INIT（等待）
+ *   - DOWNLOADING 卡：完整不透明 + 蓝色进度条 + 实时大小/百分比
+ *   - INIT 卡：半透明 0.55 + 隐藏进度条/大小 + 文字 "等待中…"
+ *   - 顶部状态行明确写 "N 正在 · M 等待"
+ *   - 运行时 invariant：snapshot 里 DOWNLOADING > 配置上限 直接 warn 到日志
  */
 class ActiveListV3Fragment : Fragment() {
 
@@ -98,10 +99,14 @@ class ActiveListV3Fragment : Fragment() {
             text = getString(R.string.dlmgr_active_action_clear)
             // 联动：清空 active 同时把批量队列 DB 也清掉，避免用户清完 active 又被
             // 队列消费者重新填回去，看起来"清不掉"。
+            //
+            // 加确认 dialog：destructive 操作不应一键直行 —— 用户误点损失大。
             setOnClickListener {
-                Manager.get().clearAll()
-                viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
-                    runCatching { queueDao.deleteAll() }
+                showClearConfirmDialog {
+                    Manager.get().clearAll()
+                    viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+                        runCatching { queueDao.deleteAll() }
+                    }
                 }
             }
         }
@@ -127,10 +132,13 @@ class ActiveListV3Fragment : Fragment() {
                         it.state == DownloadItem.DownloadState.FAILED
                     }
 
-                    // 运行时不变量：DOWNLOADING 应当永远 <= 1（Manager.loop 串行）
-                    if (downloadingCount > 1) {
+                    // 运行时不变量：DOWNLOADING 数量永远不应该超过绝对上限 5。
+                    // 注意不要拿当前 maxConcurrent 比 —— 用户从 5 调到 2 后那 5 条
+                    // 在传的不会立即被掐，会自然消化，期间 downloadingCount > 2
+                    // 是正常现象，不能误报。
+                    if (downloadingCount > 5) {
                         Timber.tag(TAG).w(
-                            "INVARIANT: ${downloadingCount} items in DOWNLOADING state simultaneously! " +
+                            "INVARIANT: ${downloadingCount} DOWNLOADING > absolute max 5! " +
                                 snapshot.filter { it.state == DownloadItem.DownloadState.DOWNLOADING }
                                     .joinToString { "${it.uuid}/${it.illust?.id}" }
                         )
@@ -167,6 +175,21 @@ class ActiveListV3Fragment : Fragment() {
             DownloadReceiver.NOTIFY_FRAGMENT_DOWNLOADING,
         )
         LocalBroadcastManager.getInstance(requireContext()).registerReceiver(receiver!!, intentFilter)
+    }
+
+    private fun showClearConfirmDialog(onConfirm: () -> Unit) {
+        val act = activity ?: return
+        if (act.isFinishing || act.isDestroyed) return
+        QMUIDialog.MessageDialogBuilder(act)
+            .setTitle(R.string.dlmgr_clear_active_queue_title)
+            .setMessage(R.string.dlmgr_clear_active_queue_message)
+            .setSkinManager(QMUISkinManager.defaultInstance(act))
+            .addAction(R.string.cancel) { d, _ -> d.dismiss() }
+            .addAction(0, R.string.sure, QMUIDialogAction.ACTION_PROP_NEGATIVE) { d, _ ->
+                d.dismiss()
+                onConfirm()
+            }
+            .show()
     }
 
     override fun onDestroyView() {
@@ -259,9 +282,13 @@ private class ActiveAdapterV3 : ListAdapter<DownloadItem, ActiveAdapterV3.VH>(Ac
         h.pauseBtn.setOnClickListener {
             if (item.isPaused) Manager.get().startOne(item.uuid)
             else Manager.get().stopOne(item.uuid)
-            // 状态变化通过下一轮 polling + DiffUtil 推 payload 即可，不再 notifyItemChanged
+            // 即时反馈：state 同步翻转后立刻 payload-bind 一次，让按钮 icon /
+            // 状态徽章 / size 文案立即变。等下一轮 1s polling 才更新 = UX 觉得卡。
+            notifyItemChanged(h.bindingAdapterPosition, PROGRESS_PAYLOAD)
         }
         h.cancelBtn.setOnClickListener {
+            // Manager.clearOne 会从 content 移除该 item，下一轮 polling 通过
+            // DiffUtil 自动消失，不需要手动通知。
             Manager.get().clearOne(item.uuid)
         }
 

--- a/app/src/main/java/ceui/pixiv/ui/download/ActiveListV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/download/ActiveListV3Fragment.kt
@@ -16,19 +16,26 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import ceui.lisa.R
+import ceui.lisa.activities.Shaft
 import ceui.lisa.core.DownloadItem
 import ceui.lisa.core.Manager
+import ceui.lisa.database.AppDatabase
 import ceui.lisa.download.FileSizeUtil
 import ceui.lisa.notification.DownloadReceiver
 import ceui.lisa.utils.GlideUtil
 import ceui.lisa.utils.Params
+import ceui.pixiv.db.queue.DownloadQueueDao
 import ceui.pixiv.ui.bulk.QueueDownloadManager
 import com.bumptech.glide.Glide
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import timber.log.Timber
 
 /**
@@ -49,6 +56,9 @@ class ActiveListV3Fragment : Fragment() {
     private val adapter = ActiveAdapterV3()
     private var receiver: DownloadReceiver<*>? = null
     private var statusHeader: TextView? = null
+    private val queueDao: DownloadQueueDao by lazy {
+        AppDatabase.getAppDatabase(Shaft.getContext()).downloadQueueDao()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -74,17 +84,26 @@ class ActiveListV3Fragment : Fragment() {
         }
 
         // 操作 bar
-        view.findViewById<Button>(R.id.btn1).apply {
+        val btnResume = view.findViewById<Button>(R.id.btn1).apply {
             text = getString(R.string.dlmgr_active_action_resume_all)
+            // 联动：恢复 active 同时恢复批量队列
             setOnClickListener { Manager.get().startAll(); QueueDownloadManager.resume() }
         }
-        view.findViewById<Button>(R.id.btn2).apply {
+        val btnPause = view.findViewById<Button>(R.id.btn2).apply {
             text = getString(R.string.dlmgr_active_action_pause_all)
-            setOnClickListener { Manager.get().stopAll() }
+            // 联动：暂停 active 同时暂停批量队列消费者
+            setOnClickListener { Manager.get().stopAll(); QueueDownloadManager.pause() }
         }
-        view.findViewById<Button>(R.id.btn4).apply {
+        val btnClear = view.findViewById<Button>(R.id.btn4).apply {
             text = getString(R.string.dlmgr_active_action_clear)
-            setOnClickListener { Manager.get().clearAll() }
+            // 联动：清空 active 同时把批量队列 DB 也清掉，避免用户清完 active 又被
+            // 队列消费者重新填回去，看起来"清不掉"。
+            setOnClickListener {
+                Manager.get().clearAll()
+                viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+                    runCatching { queueDao.deleteAll() }
+                }
+            }
         }
 
         // Snapshot polling（1s）
@@ -128,6 +147,14 @@ class ActiveListV3Fragment : Fragment() {
 
                     adapter.submit(snapshot.toList())
                     empty.visibility = if (snapshot.isEmpty()) View.VISIBLE else View.GONE
+                    // 没有任何活跃任务时把操作按钮置灰，避免用户在空列表上反复点
+                    val hasWork = snapshot.isNotEmpty()
+                    btnResume.isEnabled = hasWork
+                    btnResume.alpha = if (hasWork) 1f else 0.4f
+                    btnPause.isEnabled = hasWork
+                    btnPause.alpha = if (hasWork) 1f else 0.4f
+                    btnClear.isEnabled = hasWork
+                    btnClear.alpha = if (hasWork) 1f else 0.4f
                     delay(REFRESH_INTERVAL_MS)
                 }
             }
@@ -158,14 +185,36 @@ class ActiveListV3Fragment : Fragment() {
     }
 }
 
-private class ActiveAdapterV3 : RecyclerView.Adapter<ActiveAdapterV3.VH>() {
+/**
+ * DiffUtil 让"看起来没变"的 item 不重 bind。issue: 1s polling 用
+ * notifyDataSetChanged() 全量重 bind，每次都重 Glide.load 缩略图 → 视觉上闪烁
+ * （即使在暂停态也闪，因为 polling 不区分状态）。
+ *
+ * 行为：
+ *   - 标识相同（uuid）+ 内容完全一致 → 不 bind
+ *   - 仅进度/状态变化 → 走 payload，仅刷新进度条/百分比/大小/徽章
+ *   - 缩略图 URL 没变就根本不调 Glide.load
+ */
+private object ActiveDiff : DiffUtil.ItemCallback<DownloadItem>() {
+    override fun areItemsTheSame(a: DownloadItem, b: DownloadItem): Boolean = a.uuid == b.uuid
+    override fun areContentsTheSame(a: DownloadItem, b: DownloadItem): Boolean =
+        a.state == b.state &&
+            a.isPaused == b.isPaused &&
+            a.nonius == b.nonius &&
+            a.currentSize == b.currentSize &&
+            a.totalSize == b.totalSize &&
+            a.name == b.name &&
+            a.showUrl == b.showUrl
+    override fun getChangePayload(oldItem: DownloadItem, newItem: DownloadItem): Any = PROGRESS_PAYLOAD
+}
 
-    private val items = mutableListOf<DownloadItem>()
+private const val PROGRESS_PAYLOAD = "progress"
+
+private class ActiveAdapterV3 : ListAdapter<DownloadItem, ActiveAdapterV3.VH>(ActiveDiff) {
 
     fun submit(newItems: List<DownloadItem>) {
-        items.clear()
-        items.addAll(newItems)
-        notifyDataSetChanged()
+        // ListAdapter.submitList copies + diff —— 引用比较失败也会进 DiffUtil
+        submitList(ArrayList(newItems))
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
@@ -174,19 +223,63 @@ private class ActiveAdapterV3 : RecyclerView.Adapter<ActiveAdapterV3.VH>() {
     }
 
     override fun onBindViewHolder(h: VH, pos: Int) {
-        val item = items[pos]
-        h.taskName.text = item.name
+        bindFull(h, getItem(pos))
+    }
 
+    override fun onBindViewHolder(h: VH, pos: Int, payloads: List<Any>) {
+        if (payloads.isEmpty()) {
+            bindFull(h, getItem(pos))
+        } else {
+            // payload-only：进度/状态变了，但缩略图、文件名没变
+            bindStateAndProgress(h, getItem(pos))
+        }
+    }
+
+    private fun bindFull(h: VH, item: DownloadItem) {
+        h.taskName.text = item.name
+        bindStateAndProgress(h, item)
+
+        // 缩略图：原始 showUrl 没变就不 Glide.load —— 这是消除闪烁的关键。
+        // 用原始 String 比较（GlideUrl 没实现稳定的 equals，比较起来不靠谱）
+        val newShowUrl = item.showUrl?.takeIf { !TextUtils.isEmpty(it) }
+        if (newShowUrl != h.lastLoadedUrl) {
+            if (!newShowUrl.isNullOrEmpty()) {
+                Glide.with(h.thumb)
+                    .load(GlideUtil.getUrl(newShowUrl))
+                    .placeholder(android.R.color.transparent)
+                    .into(h.thumb)
+            } else {
+                Glide.with(h.thumb).clear(h.thumb)
+                h.thumb.setImageDrawable(null)
+            }
+            h.lastLoadedUrl = newShowUrl
+        }
+
+        // 暂停/继续 + 取消（每次 full bind 重设，保证 lambda 引用最新 item）
+        h.pauseBtn.setOnClickListener {
+            if (item.isPaused) Manager.get().startOne(item.uuid)
+            else Manager.get().stopOne(item.uuid)
+            // 状态变化通过下一轮 polling + DiffUtil 推 payload 即可，不再 notifyItemChanged
+        }
+        h.cancelBtn.setOnClickListener {
+            Manager.get().clearOne(item.uuid)
+        }
+
+        // 故意不再 Manager.get().setCallback(item.uuid) { ... } —— 之前每次 bind 都
+        // 注册一个 lambda，Manager.mCallback HashMap 按 uuid 存且永远不清，长跑下
+        // 100000+ 闭包会持有 ViewHolder 引用 → 内存堆积 OOM。
+        // 进度更新依赖 1s polling + DiffUtil payload 触发 bindStateAndProgress。
+    }
+
+    private fun bindStateAndProgress(h: VH, item: DownloadItem) {
         // —— 状态分类决定视觉权重 ——
         val isActive = item.state == DownloadItem.DownloadState.DOWNLOADING
         val isWaiting = item.state == DownloadItem.DownloadState.INIT
         val isPaused = item.isPaused || item.state == DownloadItem.DownloadState.PAUSED
         val isFailed = item.state == DownloadItem.DownloadState.FAILED
 
-        // 等待中的卡片显著弱化
         h.itemView.alpha = if (isActive || isFailed) 1.0f else 0.55f
 
-        // 进度条：只对 DOWNLOADING 显示
         h.progress.visibility = if (isActive) View.VISIBLE else View.GONE
         h.percentText.visibility = if (isActive) View.VISIBLE else View.GONE
         if (isActive) {
@@ -194,7 +287,6 @@ private class ActiveAdapterV3 : RecyclerView.Adapter<ActiveAdapterV3.VH>() {
             h.percentText.text = "${item.nonius}%"
         }
 
-        // size 文本：DOWNLOADING 显示实际大小；其它用人话替代
         when {
             isActive -> {
                 h.sizeText.text = if (item.totalSize > 0) {
@@ -211,16 +303,6 @@ private class ActiveAdapterV3 : RecyclerView.Adapter<ActiveAdapterV3.VH>() {
             else -> h.sizeText.text = "—"
         }
 
-        if (!TextUtils.isEmpty(item.showUrl)) {
-            Glide.with(h.thumb)
-                .load(GlideUtil.getUrl(item.showUrl))
-                .placeholder(android.R.color.transparent)
-                .into(h.thumb)
-        } else {
-            Glide.with(h.thumb).clear(h.thumb)
-            h.thumb.setImageDrawable(null)
-        }
-
         val (label, color) = when {
             isActive -> "DOWNLOADING" to "#5EB3FF"
             isPaused -> "PAUSED" to "#FFB454"
@@ -232,28 +314,11 @@ private class ActiveAdapterV3 : RecyclerView.Adapter<ActiveAdapterV3.VH>() {
         h.stateBadge.text = label
         h.stateBadge.setTextColor(Color.parseColor(color))
 
-        // 暂停/继续切换 icon
         h.pauseBtn.setImageResource(
             if (item.isPaused) R.drawable.ic_baseline_play_arrow_24
             else R.drawable.ic_baseline_pause_24
         )
-        h.pauseBtn.setOnClickListener {
-            if (item.isPaused) Manager.get().startOne(item.uuid)
-            else Manager.get().stopOne(item.uuid)
-            notifyItemChanged(h.bindingAdapterPosition)
-        }
-        h.cancelBtn.setOnClickListener {
-            Manager.get().clearOne(item.uuid)
-        }
-
-        // 故意不再 Manager.get().setCallback(item.uuid) { ... } —— 之前每次 bind 都
-        // 注册一个 lambda，Manager.mCallback HashMap 按 uuid 存且永远不清，长跑下
-        // 100000+ 闭包会持有 ViewHolder 引用 → 内存堆积 OOM。
-        // 进度更新依赖 1s polling 重新 submit() 触发 onBindViewHolder 时读 item.nonius，
-        // 1Hz 已足够顺滑。
     }
-
-    override fun getItemCount(): Int = items.size
 
     class VH(v: View) : RecyclerView.ViewHolder(v) {
         val thumb: ImageView = v.findViewById(R.id.thumb)
@@ -264,5 +329,7 @@ private class ActiveAdapterV3 : RecyclerView.Adapter<ActiveAdapterV3.VH>() {
         val percentText: TextView = v.findViewById(R.id.percentText)
         val pauseBtn: ImageView = v.findViewById(R.id.pauseBtn)
         val cancelBtn: ImageView = v.findViewById(R.id.cancelBtn)
+        /** 上次 Glide.load 的 URL（含 referer 拼接后）；URL 不变就跳过加载，消除闪烁 */
+        var lastLoadedUrl: String? = null
     }
 }

--- a/app/src/main/java/ceui/pixiv/ui/download/ActiveListV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/download/ActiveListV3Fragment.kt
@@ -209,6 +209,42 @@ class ActiveListV3Fragment : Fragment() {
 }
 
 /**
+ * 关键陷阱：[Manager] 原地修改 [DownloadItem]（setNonius / setPaused / ...），
+ * 不会创建新对象。如果 ListAdapter 直接拿 DownloadItem 做 DiffUtil 元素，旧
+ * snapshot 列表和新 snapshot 列表持有**同一份对象引用**，DiffUtil 调
+ * areContentsTheSame 时 a 和 b 是同一个 obj，所有字段比较恒等 → 永不发现变化
+ * → 进度条视觉上冻死。这是 ListAdapter + 可变模型的经典 aliasing 陷阱。
+ *
+ * 修法：每次 submit 时把 DownloadItem 的"渲染相关字段"拍进一个 immutable
+ * data class [ActiveSnapshot]。新旧 ActiveSnapshot 之间字段比较真实反映变化；
+ * data class auto equals 让 DiffUtil 干净工作。
+ */
+private data class ActiveSnapshot(
+    /** 持有原 DownloadItem 引用，让 click handler 能拿到 uuid 给 Manager 调命令 */
+    val item: DownloadItem,
+    val state: Int,
+    val isPaused: Boolean,
+    val nonius: Int,
+    val currentSize: Long,
+    val totalSize: Long,
+    val name: String?,
+    val showUrl: String?,
+) {
+    companion object {
+        fun of(d: DownloadItem) = ActiveSnapshot(
+            item = d,
+            state = d.state,
+            isPaused = d.isPaused,
+            nonius = d.nonius,
+            currentSize = d.currentSize,
+            totalSize = d.totalSize,
+            name = d.name,
+            showUrl = d.showUrl,
+        )
+    }
+}
+
+/**
  * DiffUtil 让"看起来没变"的 item 不重 bind。issue: 1s polling 用
  * notifyDataSetChanged() 全量重 bind，每次都重 Glide.load 缩略图 → 视觉上闪烁
  * （即使在暂停态也闪，因为 polling 不区分状态）。
@@ -218,26 +254,21 @@ class ActiveListV3Fragment : Fragment() {
  *   - 仅进度/状态变化 → 走 payload，仅刷新进度条/百分比/大小/徽章
  *   - 缩略图 URL 没变就根本不调 Glide.load
  */
-private object ActiveDiff : DiffUtil.ItemCallback<DownloadItem>() {
-    override fun areItemsTheSame(a: DownloadItem, b: DownloadItem): Boolean = a.uuid == b.uuid
-    override fun areContentsTheSame(a: DownloadItem, b: DownloadItem): Boolean =
-        a.state == b.state &&
-            a.isPaused == b.isPaused &&
-            a.nonius == b.nonius &&
-            a.currentSize == b.currentSize &&
-            a.totalSize == b.totalSize &&
-            a.name == b.name &&
-            a.showUrl == b.showUrl
-    override fun getChangePayload(oldItem: DownloadItem, newItem: DownloadItem): Any = PROGRESS_PAYLOAD
+private object ActiveDiff : DiffUtil.ItemCallback<ActiveSnapshot>() {
+    override fun areItemsTheSame(a: ActiveSnapshot, b: ActiveSnapshot): Boolean =
+        a.item.uuid == b.item.uuid
+    override fun areContentsTheSame(a: ActiveSnapshot, b: ActiveSnapshot): Boolean = a == b
+    override fun getChangePayload(oldItem: ActiveSnapshot, newItem: ActiveSnapshot): Any = PROGRESS_PAYLOAD
 }
 
 private const val PROGRESS_PAYLOAD = "progress"
 
-private class ActiveAdapterV3 : ListAdapter<DownloadItem, ActiveAdapterV3.VH>(ActiveDiff) {
+private class ActiveAdapterV3 : ListAdapter<ActiveSnapshot, ActiveAdapterV3.VH>(ActiveDiff) {
 
     fun submit(newItems: List<DownloadItem>) {
-        // ListAdapter.submitList copies + diff —— 引用比较失败也会进 DiffUtil
-        submitList(ArrayList(newItems))
+        // 把可变 DownloadItem 拍成 immutable snapshot 后再交给 ListAdapter，
+        // 让 DiffUtil 拿到的新旧元素是不同对象、字段比较真实反映变化。
+        submitList(newItems.map { ActiveSnapshot.of(it) })
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
@@ -258,13 +289,13 @@ private class ActiveAdapterV3 : ListAdapter<DownloadItem, ActiveAdapterV3.VH>(Ac
         }
     }
 
-    private fun bindFull(h: VH, item: DownloadItem) {
-        h.taskName.text = item.name
-        bindStateAndProgress(h, item)
+    private fun bindFull(h: VH, snap: ActiveSnapshot) {
+        h.taskName.text = snap.name
+        bindStateAndProgress(h, snap)
 
         // 缩略图：原始 showUrl 没变就不 Glide.load —— 这是消除闪烁的关键。
         // 用原始 String 比较（GlideUrl 没实现稳定的 equals，比较起来不靠谱）
-        val newShowUrl = item.showUrl?.takeIf { !TextUtils.isEmpty(it) }
+        val newShowUrl = snap.showUrl?.takeIf { !TextUtils.isEmpty(it) }
         if (newShowUrl != h.lastLoadedUrl) {
             if (!newShowUrl.isNullOrEmpty()) {
                 Glide.with(h.thumb)
@@ -280,16 +311,22 @@ private class ActiveAdapterV3 : ListAdapter<DownloadItem, ActiveAdapterV3.VH>(Ac
 
         // 暂停/继续 + 取消（每次 full bind 重设，保证 lambda 引用最新 item）
         h.pauseBtn.setOnClickListener {
-            if (item.isPaused) Manager.get().startOne(item.uuid)
-            else Manager.get().stopOne(item.uuid)
-            // 即时反馈：state 同步翻转后立刻 payload-bind 一次，让按钮 icon /
-            // 状态徽章 / size 文案立即变。等下一轮 1s polling 才更新 = UX 觉得卡。
-            notifyItemChanged(h.bindingAdapterPosition, PROGRESS_PAYLOAD)
+            // 即时反馈：snapshot 列表是 immutable，无法靠 notifyItemChanged 让
+            // payload-bind 看到新状态（snapshot 还是旧的）。直接操作 view —
+            // 下一轮 1s polling 来重 snapshot 时 DiffUtil 会再 reconcile 一次。
+            val live = snap.item
+            val wasPaused = live.isPaused
+            if (wasPaused) Manager.get().startOne(live.uuid)
+            else Manager.get().stopOne(live.uuid)
+            h.pauseBtn.setImageResource(
+                if (wasPaused) R.drawable.ic_baseline_pause_24
+                else R.drawable.ic_baseline_play_arrow_24
+            )
         }
         h.cancelBtn.setOnClickListener {
             // Manager.clearOne 会从 content 移除该 item，下一轮 polling 通过
             // DiffUtil 自动消失，不需要手动通知。
-            Manager.get().clearOne(item.uuid)
+            Manager.get().clearOne(snap.item.uuid)
         }
 
         // 故意不再 Manager.get().setCallback(item.uuid) { ... } —— 之前每次 bind 都
@@ -298,29 +335,29 @@ private class ActiveAdapterV3 : ListAdapter<DownloadItem, ActiveAdapterV3.VH>(Ac
         // 进度更新依赖 1s polling + DiffUtil payload 触发 bindStateAndProgress。
     }
 
-    private fun bindStateAndProgress(h: VH, item: DownloadItem) {
+    private fun bindStateAndProgress(h: VH, snap: ActiveSnapshot) {
         // —— 状态分类决定视觉权重 ——
-        val isActive = item.state == DownloadItem.DownloadState.DOWNLOADING
-        val isWaiting = item.state == DownloadItem.DownloadState.INIT
-        val isPaused = item.isPaused || item.state == DownloadItem.DownloadState.PAUSED
-        val isFailed = item.state == DownloadItem.DownloadState.FAILED
+        val isActive = snap.state == DownloadItem.DownloadState.DOWNLOADING
+        val isWaiting = snap.state == DownloadItem.DownloadState.INIT
+        val isPaused = snap.isPaused || snap.state == DownloadItem.DownloadState.PAUSED
+        val isFailed = snap.state == DownloadItem.DownloadState.FAILED
 
         h.itemView.alpha = if (isActive || isFailed) 1.0f else 0.55f
 
         h.progress.visibility = if (isActive) View.VISIBLE else View.GONE
         h.percentText.visibility = if (isActive) View.VISIBLE else View.GONE
         if (isActive) {
-            h.progress.progress = item.nonius
-            h.percentText.text = "${item.nonius}%"
+            h.progress.progress = snap.nonius
+            h.percentText.text = "${snap.nonius}%"
         }
 
         when {
             isActive -> {
-                h.sizeText.text = if (item.totalSize > 0) {
+                h.sizeText.text = if (snap.totalSize > 0) {
                     String.format(
                         "%s / %s",
-                        FileSizeUtil.formatFileSize(item.currentSize),
-                        FileSizeUtil.formatFileSize(item.totalSize)
+                        FileSizeUtil.formatFileSize(snap.currentSize),
+                        FileSizeUtil.formatFileSize(snap.totalSize)
                     )
                 } else "—"
             }
@@ -335,14 +372,14 @@ private class ActiveAdapterV3 : ListAdapter<DownloadItem, ActiveAdapterV3.VH>(Ac
             isPaused -> "PAUSED" to "#FFB454"
             isFailed -> "FAILED" to "#FF8B8B"
             isWaiting -> "QUEUED" to "#9DA3AB"
-            item.state == DownloadItem.DownloadState.SUCCESS -> "DONE" to "#7CB668"
+            snap.state == DownloadItem.DownloadState.SUCCESS -> "DONE" to "#7CB668"
             else -> "—" to "#9DA3AB"
         }
         h.stateBadge.text = label
         h.stateBadge.setTextColor(Color.parseColor(color))
 
         h.pauseBtn.setImageResource(
-            if (item.isPaused) R.drawable.ic_baseline_play_arrow_24
+            if (snap.isPaused) R.drawable.ic_baseline_play_arrow_24
             else R.drawable.ic_baseline_pause_24
         )
     }

--- a/app/src/main/java/ceui/pixiv/ui/download/DoneListV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/download/DoneListV3Fragment.kt
@@ -31,6 +31,9 @@ import ceui.lisa.utils.GlideUtil
 import ceui.lisa.utils.Local
 import ceui.lisa.utils.Params
 import com.bumptech.glide.Glide
+import com.qmuiteam.qmui.skin.QMUISkinManager
+import com.qmuiteam.qmui.widget.dialog.QMUIDialog
+import com.qmuiteam.qmui.widget.dialog.QMUIDialogAction
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
@@ -111,9 +114,13 @@ class DoneListV3Fragment : Fragment() {
         view.findViewById<Button>(R.id.btn4).apply {
             text = getString(R.string.dlmgr_done_action_clear_history)
             setOnClickListener {
-                viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
-                    runCatching { dao.deleteAllDownload() }
-                    refreshTickle.trySend(Unit)
+                // destructive 操作前必须确认。文案明确告知"文件不会被删除"，避免
+                // 用户因恐慌而不敢清理记录。
+                showClearDoneConfirmDialog {
+                    viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+                        runCatching { dao.deleteAllDownload() }
+                        refreshTickle.trySend(Unit)
+                    }
                 }
             }
         }
@@ -205,7 +212,7 @@ class DoneListV3Fragment : Fragment() {
                 return@launch
             }
             val title = getString(R.string.dlmgr_done_export_share_title)
-            val summary = getString(R.string.dlmgr_done_export_summary, illustCount, illustCount)
+            val summary = getString(R.string.dlmgr_done_export_summary, illustCount)
             Toast.makeText(ctx, summary, Toast.LENGTH_SHORT).show()
             val send = Intent(Intent.ACTION_SEND).apply {
                 type = "text/plain"
@@ -214,6 +221,21 @@ class DoneListV3Fragment : Fragment() {
             }
             startActivity(Intent.createChooser(send, title))
         }
+    }
+
+    private fun showClearDoneConfirmDialog(onConfirm: () -> Unit) {
+        val act = activity ?: return
+        if (act.isFinishing || act.isDestroyed) return
+        QMUIDialog.MessageDialogBuilder(act)
+            .setTitle(R.string.dlmgr_clear_done_title)
+            .setMessage(R.string.dlmgr_clear_done_message)
+            .setSkinManager(QMUISkinManager.defaultInstance(act))
+            .addAction(R.string.cancel) { d, _ -> d.dismiss() }
+            .addAction(0, R.string.sure, QMUIDialogAction.ACTION_PROP_NEGATIVE) { d, _ ->
+                d.dismiss()
+                onConfirm()
+            }
+            .show()
     }
 
     /** 切换布局：换 LayoutManager + 通知 adapter 切 viewType 重 inflate。 */

--- a/app/src/main/java/ceui/pixiv/ui/download/DoneListV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/download/DoneListV3Fragment.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
+import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -16,6 +17,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import ceui.lisa.R
@@ -26,6 +28,7 @@ import ceui.lisa.database.DownloadDao
 import ceui.lisa.database.DownloadEntity
 import ceui.lisa.models.IllustsBean
 import ceui.lisa.utils.GlideUtil
+import ceui.lisa.utils.Local
 import ceui.lisa.utils.Params
 import com.bumptech.glide.Glide
 import kotlinx.coroutines.Dispatchers
@@ -57,7 +60,9 @@ class DoneListV3Fragment : Fragment() {
     private val dao: DownloadDao by lazy {
         AppDatabase.getAppDatabase(Shaft.getContext()).downloadDao()
     }
-    private val adapter = DoneAdapterV3 { group, action ->
+    private val adapter = DoneAdapterV3(
+        initialMode = DoneLayoutMode.fromInt(Shaft.sSettings.doneListLayoutMode),
+    ) { group, action ->
         when (action) {
             DoneAction.OPEN -> openDetail(group)
             DoneAction.DELETE -> deleteOne(group)
@@ -74,18 +79,34 @@ class DoneListV3Fragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val list = view.findViewById<RecyclerView>(R.id.list)
-        list.layoutManager = GridLayoutManager(requireContext(), 2)
         list.adapter = adapter
+        applyLayoutMode(list, DoneLayoutMode.fromInt(Shaft.sSettings.doneListLayoutMode))
 
         val empty = view.findViewById<View>(R.id.emptyState)
         view.findViewById<TextView>(R.id.emptyTitle).text = getString(R.string.dlmgr_done_empty_title)
         view.findViewById<TextView>(R.id.emptyHint).text = getString(R.string.dlmgr_done_empty_hint)
 
-        view.findViewById<Button>(R.id.btn1).visibility = View.GONE
+        // btn1 改成"切换布局"按钮 —— 循环 LIST → GRID → COMPACT。
+        // 用户首次发现这个按钮会顺便看到 toast 提示当前模式。
+        val btnLayout = view.findViewById<Button>(R.id.btn1).apply {
+            visibility = View.VISIBLE
+            text = getString(DoneLayoutMode.fromInt(Shaft.sSettings.doneListLayoutMode).labelRes)
+            setOnClickListener {
+                val next = DoneLayoutMode.fromInt(Shaft.sSettings.doneListLayoutMode).next()
+                Shaft.sSettings.doneListLayoutMode = next.ordinal
+                Local.setSettings(Shaft.sSettings)
+                applyLayoutMode(list, next)
+                text = getString(next.labelRes)
+            }
+        }
         view.findViewById<Button>(R.id.btn2).visibility = View.GONE
+        // btn3 改为"导出"：把已完成下载的所有 illustId 拼成 pixiv 链接列表，
+        // 走 ACTION_SEND 让用户分享/保存。4.6.4 之前的 FragmentMultiDownload
+        // 有这个功能，重写后丢了，现在补回来。
         view.findViewById<Button>(R.id.btn3).apply {
-            text = getString(R.string.dlmgr_done_action_refresh)
-            setOnClickListener { refreshTickle.trySend(Unit) }
+            visibility = View.VISIBLE
+            text = getString(R.string.dlmgr_done_action_export)
+            setOnClickListener { exportDoneList() }
         }
         view.findViewById<Button>(R.id.btn4).apply {
             text = getString(R.string.dlmgr_done_action_clear_history)
@@ -153,6 +174,58 @@ class DoneListV3Fragment : Fragment() {
         startActivity(intent)
     }
 
+    /**
+     * 导出已完成下载的链接列表为纯文本，走 [Intent.ACTION_SEND] 让用户选择
+     * 复制 / 保存为文件 / 发送到聊天工具。每行一个 pixiv 作品链接，按下载时间倒序，
+     * 按 illustId 去重（多 p illust 只占一行）。
+     *
+     * 不导出小说（NOVEL_KEY 标记的行）—— 小说没有标准 URL 模板，需要单独处理。
+     */
+    private fun exportDoneList() {
+        val ctx = requireContext()
+        viewLifecycleOwner.lifecycleScope.launch {
+            val (text, illustCount) = withContext(Dispatchers.IO) {
+                val rows = runCatching { dao.getAll(EXPORT_HARD_CAP, 0) }.getOrDefault(emptyList())
+                val groups = groupByIllust(rows)
+                val sb = StringBuilder()
+                var n = 0
+                for (g in groups) {
+                    if (g.isNovel) continue
+                    // 优先用预解析的 illust.id，回退到正则从 illustGson 抽 id
+                    val id = (g.parsedIllust?.id?.toLong()?.takeIf { it > 0 })
+                        ?: extractIllustId(g.latest.illustGson).takeIf { it > 0 }
+                        ?: continue
+                    sb.append("https://www.pixiv.net/artworks/").append(id).append('\n')
+                    n++
+                }
+                sb.toString().trimEnd() to n
+            }
+            if (text.isEmpty()) {
+                Toast.makeText(ctx, getString(R.string.dlmgr_done_export_empty), Toast.LENGTH_SHORT).show()
+                return@launch
+            }
+            val title = getString(R.string.dlmgr_done_export_share_title)
+            val summary = getString(R.string.dlmgr_done_export_summary, illustCount, illustCount)
+            Toast.makeText(ctx, summary, Toast.LENGTH_SHORT).show()
+            val send = Intent(Intent.ACTION_SEND).apply {
+                type = "text/plain"
+                putExtra(Intent.EXTRA_SUBJECT, title)
+                putExtra(Intent.EXTRA_TEXT, text)
+            }
+            startActivity(Intent.createChooser(send, title))
+        }
+    }
+
+    /** 切换布局：换 LayoutManager + 通知 adapter 切 viewType 重 inflate。 */
+    private fun applyLayoutMode(list: RecyclerView, mode: DoneLayoutMode) {
+        list.layoutManager = when (mode) {
+            DoneLayoutMode.LIST    -> LinearLayoutManager(requireContext())
+            DoneLayoutMode.GRID    -> GridLayoutManager(requireContext(), 2)
+            DoneLayoutMode.COMPACT -> GridLayoutManager(requireContext(), 4)
+        }
+        adapter.setMode(mode)
+    }
+
     private fun deleteOne(group: DownloadGroup) {
         viewLifecycleOwner.lifecycleScope.launch {
             withContext(Dispatchers.IO) {
@@ -168,6 +241,8 @@ class DoneListV3Fragment : Fragment() {
     companion object {
         private const val PAGE_SIZE = 600   // 一次取多点；分组后实际卡片数会少
         private const val REFRESH_INTERVAL_MS = 1500L
+        /** 导出时一次拉的硬上限 —— 5w 行 ≈ 2MB 文本，正常用户都装不了这么多 */
+        private const val EXPORT_HARD_CAP = 50000
     }
 }
 
@@ -228,6 +303,24 @@ private fun groupByIllust(rows: List<DownloadEntity>): List<DownloadGroup> {
 
 private enum class DoneAction { OPEN, DELETE }
 
+/**
+ * 已完成 tab 三种布局模式。值与 [Settings.doneListLayoutMode] 同步：
+ *   0 = LIST    横向列表，单列，缩略图在左
+ *   1 = GRID    网格 2 列（旧默认）
+ *   2 = COMPACT 紧凑缩图 4 列，无文字
+ */
+internal enum class DoneLayoutMode(val labelRes: Int) {
+    LIST(R.string.dlmgr_done_layout_list),
+    GRID(R.string.dlmgr_done_layout_grid),
+    COMPACT(R.string.dlmgr_done_layout_compact);
+
+    fun next(): DoneLayoutMode = values()[(ordinal + 1) % values().size]
+
+    companion object {
+        fun fromInt(i: Int): DoneLayoutMode = values().getOrElse(i) { GRID }
+    }
+}
+
 private object DoneDiff : DiffUtil.ItemCallback<DownloadGroup>() {
     override fun areItemsTheSame(a: DownloadGroup, b: DownloadGroup): Boolean = a.key == b.key
     override fun areContentsTheSame(a: DownloadGroup, b: DownloadGroup): Boolean =
@@ -235,13 +328,29 @@ private object DoneDiff : DiffUtil.ItemCallback<DownloadGroup>() {
 }
 
 private class DoneAdapterV3(
+    initialMode: DoneLayoutMode,
     private val onAction: (DownloadGroup, DoneAction) -> Unit,
 ) : ListAdapter<DownloadGroup, DoneAdapterV3.VH>(DoneDiff) {
 
     private val timeFmt = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
+    private var mode: DoneLayoutMode = initialMode
+
+    fun setMode(m: DoneLayoutMode) {
+        if (mode == m) return
+        mode = m
+        // viewType 改了，必须 invalidate 让 RecyclerView 重 inflate 不同 cell
+        notifyDataSetChanged()
+    }
+
+    override fun getItemViewType(position: Int): Int = mode.ordinal
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
-        val v = LayoutInflater.from(parent.context).inflate(R.layout.cell_download_done_v3, parent, false)
+        val layoutRes = when (DoneLayoutMode.fromInt(viewType)) {
+            DoneLayoutMode.LIST    -> R.layout.cell_download_done_v3_list
+            DoneLayoutMode.GRID    -> R.layout.cell_download_done_v3
+            DoneLayoutMode.COMPACT -> R.layout.cell_download_done_v3_compact
+        }
+        val v = LayoutInflater.from(parent.context).inflate(layoutRes, parent, false)
         return VH(v)
     }
 
@@ -250,6 +359,7 @@ private class DoneAdapterV3(
         val entity = group.latest
 
         if (group.isNovel) {
+            h.typeBadge.visibility = View.VISIBLE
             h.typeBadge.text = "NOVEL"
             Glide.with(h.thumb).clear(h.thumb)
             h.thumb.setImageDrawable(null)
@@ -258,11 +368,19 @@ private class DoneAdapterV3(
         } else {
             // 用预解析的 illust（reload 时 IO 线程已 fromJson 完）—— 绑卡 0 解析
             val illust: IllustsBean? = group.parsedIllust
-            // type 徽章：单页 ILLUST，多页 MANGA(N) 体现页数
-            h.typeBadge.text = when {
-                group.pageCount > 1 -> "MANGA · ${group.pageCount}P"
-                (illust?.page_count ?: 1) > 1 -> "MANGA · ${illust?.page_count}P"
-                else -> "ILLUST"
+            // 多页 illust：左上角只显示 "Np"（去掉 "MANGA · " 冗余前缀）。
+            // 单页 illust：徽章直接隐藏 —— 没有页数信息可言。
+            // 之前的渐隐 + 透明背景文字在暗色图上几乎读不出，改为白字 + 70% 黑底。
+            val pageCount = when {
+                group.pageCount > 1 -> group.pageCount
+                (illust?.page_count ?: 1) > 1 -> illust?.page_count ?: 1
+                else -> 1
+            }
+            if (pageCount > 1) {
+                h.typeBadge.visibility = View.VISIBLE
+                h.typeBadge.text = "${pageCount}P"
+            } else {
+                h.typeBadge.visibility = View.GONE
             }
             h.title.text = illust?.title?.takeIf { it.isNotBlank() } ?: entity.fileName.orEmpty()
             h.author.text = illust?.user?.name?.let { "by: $it" } ?: ""

--- a/app/src/main/java/ceui/pixiv/ui/download/DownloadManagerSharedViewModel.kt
+++ b/app/src/main/java/ceui/pixiv/ui/download/DownloadManagerSharedViewModel.kt
@@ -47,9 +47,10 @@ class DownloadManagerSharedViewModel(app: Application) : AndroidViewModel(app) {
                 queueSuccess = runCatching { queueDao.countByStatus(QueueStatus.SUCCESS) }.getOrDefault(0),
                 queueFailed = runCatching { queueDao.countByStatus(QueueStatus.FAILED) }.getOrDefault(0),
                 activeCount = runCatching {
-                    // 只计真正在传输的那一 page —— Manager.loop 串行下载，
-                    // 任意时刻 DOWNLOADING 状态最多 1 个。其它 INIT/PAUSED/FAILED 不算"正在下载"。
-                    // Manager.content 非线程安全；snapshot 失败给 0，下个周期会再试
+                    // 只计真正在传输中的 page。Manager 现支持 1-5 并发，
+                    // 任意时刻 DOWNLOADING 数量上限 = Settings.maxConcurrentDownloads。
+                    // 其它 INIT/PAUSED/FAILED 都不算"正在下载"。
+                    // Manager.content 非线程安全；snapshot 失败给 0，下个周期会再试。
                     ArrayList(Manager.get().content)
                         .count { it.state == DownloadItem.DownloadState.DOWNLOADING }
                 }.getOrDefault(0),

--- a/app/src/main/java/ceui/pixiv/ui/download/QueueListV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/download/QueueListV3Fragment.kt
@@ -18,7 +18,10 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import ceui.lisa.R
 import ceui.lisa.activities.Shaft
+import ceui.lisa.core.Manager
 import ceui.lisa.database.AppDatabase
+import ceui.lisa.http.Retro
+import ceui.lisa.models.IllustsBean
 import ceui.lisa.utils.GlideUtil
 import ceui.loxia.ObjectPool
 import ceui.pixiv.db.queue.DownloadQueueDao
@@ -26,10 +29,18 @@ import ceui.pixiv.db.queue.DownloadQueueEntity
 import ceui.pixiv.db.queue.QueueStatus
 import ceui.pixiv.ui.bulk.QueueDownloadManager
 import com.bumptech.glide.Glide
+import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
  * V3 风格 "批量队列" 列表。
@@ -46,6 +57,11 @@ class QueueListV3Fragment : Fragment() {
         AppDatabase.getAppDatabase(Shaft.getContext()).downloadQueueDao()
     }
     private val adapter = QueueAdapterV3()
+
+    /** 已经成功 prefetch 过的 illustId（避免重复打 API）；fetch 失败会从这里 remove 让下次再试 */
+    private val prefetchedIds = ConcurrentHashMap<Long, Boolean>()
+    /** 限制同时进行的 illust 详情拉取数，避免 1000 项队列把网络打满 */
+    private val prefetchSem = Semaphore(PREFETCH_MAX_CONCURRENCY)
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -67,15 +83,21 @@ class QueueListV3Fragment : Fragment() {
             text = getString(if (QueueDownloadManager.isPaused()) R.string.dlmgr_queue_action_resume else R.string.dlmgr_queue_action_pause)
         }
         val btnRetry = view.findViewById<Button>(R.id.btn2).apply { text = getString(R.string.dlmgr_queue_action_retry_failed) }
-        val btnClearOk = view.findViewById<Button>(R.id.btn3).apply { text = getString(R.string.dlmgr_queue_action_clear_success) }
+        // btn3（原"清成功记录"）已废弃 —— SUCCESS 行会自动从队列消失走到"已完成" tab，
+        // 这个按钮没有实际意义。
+        view.findViewById<Button>(R.id.btn3).visibility = View.GONE
         val btnClearAll = view.findViewById<Button>(R.id.btn4).apply { text = getString(R.string.dlmgr_queue_action_clear_all) }
 
         btnPause.setOnClickListener {
             if (QueueDownloadManager.isPaused()) {
+                // 联动：批量队列恢复时，正在下载 tab 的 Manager 也跟着恢复
                 QueueDownloadManager.resume()
+                Manager.get().startAll()
                 btnPause.text = getString(R.string.dlmgr_queue_action_pause)
             } else {
+                // 联动：批量队列暂停时，连同 Manager 当前正在下的也暂停
                 QueueDownloadManager.pause()
+                Manager.get().stopAll()
                 btnPause.text = getString(R.string.dlmgr_queue_action_resume)
             }
         }
@@ -86,13 +108,11 @@ class QueueListV3Fragment : Fragment() {
                 QueueDownloadManager.resume()
             }
         }
-        btnClearOk.setOnClickListener {
-            viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
-                runCatching { dao.deleteByStatus(QueueStatus.SUCCESS) }
-            }
-        }
         btnClearAll.setOnClickListener {
             viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+                // 联动：清空队列同时把正在下载的也一并停掉清掉，
+                // 否则用户清完队列还看到"正在下载" tab 有残留任务在跑。
+                runCatching { Manager.get().clearAll() }
                 runCatching { dao.deleteAll() }
             }
         }
@@ -107,10 +127,76 @@ class QueueListV3Fragment : Fragment() {
                     }
                     adapter.submitList(rows)
                     empty.visibility = if (rows.isEmpty()) View.VISIBLE else View.GONE
+                    // 空队列时禁用 暂停/继续 + 清空全部 —— 避免用户在没事可做时反复点
+                    val hasWork = rows.isNotEmpty()
+                    btnPause.isEnabled = hasWork
+                    btnPause.alpha = if (hasWork) 1f else 0.4f
+                    btnClearAll.isEnabled = hasWork
+                    btnClearAll.alpha = if (hasWork) 1f else 0.4f
+                    // 让看得见的几条 item 把缩略图/标题加载出来：ObjectPool cache miss 的
+                    // illustId 触发后台拉取，下一轮 polling DiffUtil 会自动重 bind 那些行。
+                    prefetchVisibleIllusts(rows)
                     delay(REFRESH_INTERVAL_MS)
                 }
             }
         }
+    }
+
+    /**
+     * 看得见的几条 item ObjectPool cache miss → 后台拉一发 illust 详情塞回 ObjectPool。
+     * 下一轮 1.5s polling DiffUtil 会因为我们没改 [DownloadQueueEntity]、不会触发 rebind，
+     * 但 [QueueAdapterV3.onBindViewHolder] 内部读 [ObjectPool.getIllust] 此刻已命中，
+     * 因此当 RecyclerView 自然 rebind（滚动 / 状态变化）时缩略图就出来了。
+     *
+     * 上限：[PREFETCH_MAX_VISIBLE] 条 / 每轮 polling，并发 [PREFETCH_MAX_CONCURRENCY]。
+     * 失败的 ID 会从 [prefetchedIds] 移除让下次再试。
+     */
+    private fun prefetchVisibleIllusts(rows: List<DownloadQueueEntity>) {
+        val missing = rows.asSequence()
+            .map { it.illustId }
+            .distinct()
+            .filter { id ->
+                prefetchedIds[id] != true && ObjectPool.getIllust(id).value == null
+            }
+            .take(PREFETCH_MAX_VISIBLE)
+            .toList()
+        if (missing.isEmpty()) return
+        val scope = viewLifecycleOwner.lifecycleScope
+        for (id in missing) {
+            scope.launch(Dispatchers.IO) {
+                prefetchSem.withPermit {
+                    if (prefetchedIds.putIfAbsent(id, true) != null) return@withPermit
+                    if (ObjectPool.getIllust(id).value != null) return@withPermit
+                    runCatching {
+                        val bean = fetchIllustOnce(id) ?: return@runCatching
+                        withContext(Dispatchers.Main.immediate) {
+                            runCatching { ObjectPool.updateIllust(bean) }
+                            // pool 命中后 DiffUtil 不会自动 rebind（DownloadQueueEntity 没变），
+                            // 主动通知该 illustId 的所有可见 row 重 bind 一次。
+                            runCatching { adapter.notifyIllustChanged(id) }
+                        }
+                    }.onFailure {
+                        prefetchedIds.remove(id)
+                        Timber.tag("QueueListV3").w(it, "prefetch illust=$id failed")
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun fetchIllustOnce(id: Long): IllustsBean? = suspendCancellableCoroutine { cont ->
+        val d = Retro.getAppApi().getIllustByID(id)
+            .subscribeOn(Schedulers.io())
+            .firstOrError()
+            .subscribe(
+                { resp ->
+                    if (cont.isActive) cont.resume(resp.illust)
+                },
+                { err ->
+                    if (cont.isActive) cont.resumeWithException(err)
+                }
+            )
+        cont.invokeOnCancellation { d.dispose() }
     }
 
     /**
@@ -144,6 +230,10 @@ class QueueListV3Fragment : Fragment() {
          */
         private const val MAX_DISPLAY_ROWS = 5000
         private const val REFRESH_INTERVAL_MS = 1500L
+        /** 每轮 polling 最多触发的 illust 详情 prefetch 数量 */
+        private const val PREFETCH_MAX_VISIBLE = 30
+        /** prefetch 并发上限 —— 太多会把 pixiv API 打急 */
+        private const val PREFETCH_MAX_CONCURRENCY = 4
     }
 }
 
@@ -154,6 +244,18 @@ private object QueueDiff : DiffUtil.ItemCallback<DownloadQueueEntity>() {
 }
 
 private class QueueAdapterV3 : ListAdapter<DownloadQueueEntity, QueueAdapterV3.VH>(QueueDiff) {
+
+    /**
+     * 用于 prefetch 成功后主动通知特定 illustId 的所有可见 row 重 bind。
+     * DiffUtil 默认按 [DownloadQueueEntity] 内容比较，ObjectPool 填充后实体本身没变，
+     * 不调这个方法的话视图就不会刷新缩略图/标题。
+     */
+    fun notifyIllustChanged(illustId: Long) {
+        val list = currentList
+        list.forEachIndexed { i, e ->
+            if (e.illustId == illustId) notifyItemChanged(i)
+        }
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VH {
         val v = LayoutInflater.from(parent.context).inflate(R.layout.cell_download_queue_v3, parent, false)

--- a/app/src/main/java/ceui/pixiv/ui/download/QueueListV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/download/QueueListV3Fragment.kt
@@ -29,6 +29,9 @@ import ceui.pixiv.db.queue.DownloadQueueEntity
 import ceui.pixiv.db.queue.QueueStatus
 import ceui.pixiv.ui.bulk.QueueDownloadManager
 import com.bumptech.glide.Glide
+import com.qmuiteam.qmui.skin.QMUISkinManager
+import com.qmuiteam.qmui.widget.dialog.QMUIDialog
+import com.qmuiteam.qmui.widget.dialog.QMUIDialogAction
 import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -109,11 +112,14 @@ class QueueListV3Fragment : Fragment() {
             }
         }
         btnClearAll.setOnClickListener {
-            viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
-                // 联动：清空队列同时把正在下载的也一并停掉清掉，
-                // 否则用户清完队列还看到"正在下载" tab 有残留任务在跑。
-                runCatching { Manager.get().clearAll() }
-                runCatching { dao.deleteAll() }
+            // destructive 操作必须确认 —— 误点会让用户失去全部排队
+            showClearConfirmDialog {
+                viewLifecycleOwner.lifecycleScope.launch(Dispatchers.IO) {
+                    // 联动：清空队列同时把正在下载的也一并停掉清掉，
+                    // 否则用户清完队列还看到"正在下载" tab 有残留任务在跑。
+                    runCatching { Manager.get().clearAll() }
+                    runCatching { dao.deleteAll() }
+                }
             }
         }
 
@@ -133,6 +139,12 @@ class QueueListV3Fragment : Fragment() {
                     btnPause.alpha = if (hasWork) 1f else 0.4f
                     btnClearAll.isEnabled = hasWork
                     btnClearAll.alpha = if (hasWork) 1f else 0.4f
+                    // 同步 暂停/继续 文案：用户可能从其它 tab（active）触发了 pause，
+                    // 此时本 tab 的按钮文案要跟着变，否则显示"暂停"但实际已 paused 是误导。
+                    btnPause.text = getString(
+                        if (QueueDownloadManager.isPaused()) R.string.dlmgr_queue_action_resume
+                        else R.string.dlmgr_queue_action_pause
+                    )
                     // 让看得见的几条 item 把缩略图/标题加载出来：ObjectPool cache miss 的
                     // illustId 触发后台拉取，下一轮 polling DiffUtil 会自动重 bind 那些行。
                     prefetchVisibleIllusts(rows)
@@ -182,6 +194,21 @@ class QueueListV3Fragment : Fragment() {
                 }
             }
         }
+    }
+
+    private fun showClearConfirmDialog(onConfirm: () -> Unit) {
+        val act = activity ?: return
+        if (act.isFinishing || act.isDestroyed) return
+        QMUIDialog.MessageDialogBuilder(act)
+            .setTitle(R.string.dlmgr_clear_active_queue_title)
+            .setMessage(R.string.dlmgr_clear_active_queue_message)
+            .setSkinManager(QMUISkinManager.defaultInstance(act))
+            .addAction(R.string.cancel) { d, _ -> d.dismiss() }
+            .addAction(0, R.string.sure, QMUIDialogAction.ACTION_PROP_NEGATIVE) { d, _ ->
+                d.dismiss()
+                onConfirm()
+            }
+            .show()
     }
 
     private suspend fun fetchIllustOnce(id: Long): IllustsBean? = suspendCancellableCoroutine { cont ->

--- a/app/src/main/res/layout/cell_download_done_v3_compact.xml
+++ b/app/src/main/res/layout/cell_download_done_v3_compact.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  已完成 tab 的「紧凑缩图」cell：4 列网格，正方形缩略图 + 角标，无标题文字。
+  IDs 与 cell_download_done_v3.xml 完全一致，让 DoneAdapterV3 同一份代码可同时
+  渲染（title/author/time 在 compact 模式下保持 visibility=gone，binding 调
+  setText 也不会显示，安全）。
+-->
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="2dp"
+    android:foreground="?attr/selectableItemBackground"
+    app:cardBackgroundColor="@color/v3_bg"
+    app:cardCornerRadius="8dp"
+    app:cardElevation="1dp">
+
+    <FrameLayout
+        android:id="@+id/imageWrap"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <ImageView
+            android:id="@+id/thumb"
+            android:layout_width="match_parent"
+            android:layout_height="100dp"
+            android:adjustViewBounds="true"
+            android:background="@color/v3_surface_2"
+            android:contentDescription="@null"
+            android:scaleType="centerCrop" />
+
+        <TextView
+            android:id="@+id/typeBadge"
+            style="@style/V3StatusBadge"
+            android:layout_gravity="top|start"
+            android:layout_margin="3dp"
+            android:background="@drawable/bg_page_count_overlay"
+            android:textColor="#FFFFFF"
+            android:textSize="8sp"
+            android:paddingHorizontal="4dp"
+            android:paddingVertical="1dp"
+            tools:text="3P" />
+
+        <ImageView
+            android:id="@+id/deleteBtn"
+            android:layout_width="22dp"
+            android:layout_height="22dp"
+            android:layout_gravity="bottom|end"
+            android:layout_margin="3dp"
+            android:background="@drawable/v3_nav_btn_bg"
+            android:contentDescription="@null"
+            android:padding="4dp"
+            android:src="@drawable/ic_delete_black_24dp"
+            app:tint="#CCFFFFFF" />
+
+        <!-- 不显示但保留 ID，让 binding 代码不需要分支判断 -->
+        <TextView
+            android:id="@+id/title"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/author"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:visibility="gone" />
+
+        <TextView
+            android:id="@+id/time"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:visibility="gone" />
+    </FrameLayout>
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/cell_download_done_v3_list.xml
+++ b/app/src/main/res/layout/cell_download_done_v3_list.xml
@@ -1,30 +1,37 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+  已完成 tab 的「横向列表」cell：图左 80dp，文字栏靠右铺满。
+  ID 必须与 cell_download_done_v3.xml 一致（thumb/typeBadge/title/author/time/deleteBtn），
+  让 DoneAdapterV3.VH 的同一份代码同时复用两套布局。
+-->
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="5dp"
+    android:layout_marginHorizontal="6dp"
+    android:layout_marginVertical="3dp"
     android:foreground="?attr/selectableItemBackground"
     app:cardBackgroundColor="@color/v3_bg"
-    app:cardCornerRadius="14dp"
-    app:cardElevation="1.5dp">
+    app:cardCornerRadius="12dp"
+    app:cardElevation="1dp">
 
-    <LinearLayout
+    <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
+        android:padding="6dp">
 
         <FrameLayout
             android:id="@+id/imageWrap"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_width="80dp"
+            android:layout_height="80dp"
+            android:layout_alignParentStart="true"
+            android:layout_centerVertical="true">
 
             <ImageView
                 android:id="@+id/thumb"
                 android:layout_width="match_parent"
-                android:layout_height="160dp"
-                android:adjustViewBounds="true"
+                android:layout_height="match_parent"
                 android:background="@color/v3_surface_2"
                 android:contentDescription="@null"
                 android:scaleType="centerCrop" />
@@ -33,31 +40,36 @@
                 android:id="@+id/typeBadge"
                 style="@style/V3StatusBadge"
                 android:layout_gravity="top|start"
-                android:layout_margin="6dp"
+                android:layout_margin="3dp"
                 android:background="@drawable/bg_page_count_overlay"
                 android:textColor="#FFFFFF"
+                android:textSize="9sp"
+                android:paddingHorizontal="5dp"
+                android:paddingVertical="2dp"
                 tools:text="3P" />
-
-            <ImageView
-                android:id="@+id/deleteBtn"
-                android:layout_width="28dp"
-                android:layout_height="28dp"
-                android:layout_gravity="bottom|end"
-                android:layout_margin="6dp"
-                android:background="@drawable/v3_nav_btn_bg"
-                android:contentDescription="@null"
-                android:padding="6dp"
-                android:src="@drawable/ic_delete_black_24dp"
-                app:tint="#CCFFFFFF" />
         </FrameLayout>
+
+        <ImageView
+            android:id="@+id/deleteBtn"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@null"
+            android:padding="6dp"
+            android:src="@drawable/ic_delete_black_24dp"
+            app:tint="@color/v3_text_3" />
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:paddingHorizontal="10dp"
-            android:paddingTop="8dp"
-            android:paddingBottom="10dp">
+            android:layout_centerVertical="true"
+            android:layout_toEndOf="@id/imageWrap"
+            android:layout_toStartOf="@id/deleteBtn"
+            android:layout_marginStart="10dp"
+            android:layout_marginEnd="2dp"
+            android:orientation="vertical">
 
             <TextView
                 android:id="@+id/title"
@@ -67,7 +79,7 @@
                 android:letterSpacing="-0.02"
                 android:maxLines="1"
                 android:textColor="@color/v3_text_1"
-                android:textSize="12sp"
+                android:textSize="13sp"
                 android:textStyle="bold"
                 tools:text="作品标题" />
 
@@ -75,25 +87,25 @@
                 android:id="@+id/author"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="3dp"
+                android:layout_marginTop="2dp"
                 android:ellipsize="end"
                 android:maxLines="1"
                 android:textColor="@color/v3_text_3"
-                android:textSize="10sp"
+                android:textSize="11sp"
                 tools:text="by: 作者" />
 
             <TextView
                 android:id="@+id/time"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
+                android:layout_marginTop="3dp"
                 android:fontFamily="monospace"
-                android:letterSpacing="0.06"
+                android:letterSpacing="0.04"
                 android:textAllCaps="true"
                 android:textColor="@color/v3_text_3"
                 android:textSize="9sp"
                 android:textStyle="bold"
                 tools:text="2 分钟前" />
         </LinearLayout>
-    </LinearLayout>
+    </RelativeLayout>
 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -1062,6 +1062,28 @@
                         <View style="@style/half_divider" />
 
                         <RelativeLayout
+                            android:id="@+id/max_concurrent_downloads_rela"
+                            style="@style/ripple_rela">
+
+                            <TextView
+                                style="@style/setting_text_left_and_center"
+                                android:text="@string/setting_max_concurrent_downloads" />
+
+                            <TextView
+                                android:id="@+id/max_concurrent_downloads"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_alignParentEnd="true"
+                                android:layout_centerVertical="true"
+                                android:layout_marginEnd="@dimen/sixteen_dp"
+                                android:textColor="?attr/colorPrimary"
+                                android:textSize="14sp" />
+
+                        </RelativeLayout>
+
+                        <View style="@style/half_divider" />
+
+                        <RelativeLayout
                             android:id="@+id/download_way_rela"
                             style="@style/ripple_rela">
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1117,9 +1117,9 @@
     <string name="bulk_select_invert">Invert</string>
     <string name="bulk_select_no_items">No selectable works. State may have been lost from a different entry point.</string>
     <string name="bulk_select_loading">Loading…</string>
-    <string name="bulk_select_summary">%1$d total · %2$d selected</string>
-    <string name="bulk_select_summary_with_gif">%1$d total · %2$d selected · %3$d GIFs skipped</string>
-    <string name="bulk_select_confirm">Enqueue (%1$d) →</string>
+    <string name="bulk_select_summary">%1$d total · %2$d selected (%3$d images)</string>
+    <string name="bulk_select_summary_with_gif">%1$d total · %2$d selected (%3$d images) · %4$d GIFs skipped (download from artwork page)</string>
+    <string name="bulk_select_confirm">Enqueue (%1$d works / %2$d images) →</string>
     <string name="bulk_select_confirm_empty">Select at least 1</string>
 
     <!-- Legacy batch enqueue toasts -->
@@ -1183,4 +1183,15 @@
     <string name="dlmgr_done_empty_hint">Completed downloads will appear here</string>
     <string name="dlmgr_done_action_refresh">Refresh</string>
     <string name="dlmgr_done_action_clear_history">Clear records</string>
+    <string name="dlmgr_done_action_export">Export</string>
+    <string name="dlmgr_done_layout_list">Layout: List</string>
+    <string name="dlmgr_done_layout_grid">Layout: Grid</string>
+    <string name="dlmgr_done_layout_compact">Layout: Compact</string>
+    <string name="setting_max_concurrent_downloads">Concurrent downloads</string>
+    <string name="setting_max_concurrent_downloads_one">1 (serial · default)</string>
+    <string name="setting_max_concurrent_downloads_n">%1$d in parallel</string>
+    <string name="setting_max_concurrent_downloads_changed">Concurrent downloads set to %1$d</string>
+    <string name="dlmgr_done_export_empty">No completed works to export</string>
+    <string name="dlmgr_done_export_share_title">Export completed downloads</string>
+    <string name="dlmgr_done_export_summary">%1$d works · %2$d links</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1187,11 +1187,15 @@
     <string name="dlmgr_done_layout_list">Layout: List</string>
     <string name="dlmgr_done_layout_grid">Layout: Grid</string>
     <string name="dlmgr_done_layout_compact">Layout: Compact</string>
+    <string name="dlmgr_clear_active_queue_title">Clear all downloads?</string>
+    <string name="dlmgr_clear_active_queue_message">Downloads in progress and queued items will be stopped and cleared.\n(Partially-downloaded files on disk are kept.)</string>
+    <string name="dlmgr_clear_done_title">Clear completed history?</string>
+    <string name="dlmgr_clear_done_message">Downloaded files stay on disk; only the records here are removed.</string>
     <string name="setting_max_concurrent_downloads">Concurrent downloads</string>
     <string name="setting_max_concurrent_downloads_one">1 (serial · default)</string>
     <string name="setting_max_concurrent_downloads_n">%1$d in parallel</string>
     <string name="setting_max_concurrent_downloads_changed">Concurrent downloads set to %1$d</string>
     <string name="dlmgr_done_export_empty">No completed works to export</string>
     <string name="dlmgr_done_export_share_title">Export completed downloads</string>
-    <string name="dlmgr_done_export_summary">%1$d works · %2$d links</string>
+    <string name="dlmgr_done_export_summary">Exported %1$d work(s)</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1216,11 +1216,15 @@
     <string name="dlmgr_done_layout_list">レイアウト: リスト</string>
     <string name="dlmgr_done_layout_grid">レイアウト: グリッド</string>
     <string name="dlmgr_done_layout_compact">レイアウト: コンパクト</string>
+    <string name="dlmgr_clear_active_queue_title">すべてのダウンロードをクリア？</string>
+    <string name="dlmgr_clear_active_queue_message">ダウンロード中と待機中の項目はすべて停止・削除されます。\n(ディスクに途中までダウンロードされたファイルは残ります。)</string>
+    <string name="dlmgr_clear_done_title">完了履歴をクリア？</string>
+    <string name="dlmgr_clear_done_message">ダウンロード済みファイルはディスクに残ります。ここの記録のみが削除されます。</string>
     <string name="setting_max_concurrent_downloads">同時ダウンロード数</string>
     <string name="setting_max_concurrent_downloads_one">1（直列 · デフォルト）</string>
     <string name="setting_max_concurrent_downloads_n">%1$d 並列</string>
     <string name="setting_max_concurrent_downloads_changed">同時ダウンロード数を %1$d に設定</string>
     <string name="dlmgr_done_export_empty">エクスポート可能な完了作品がありません</string>
     <string name="dlmgr_done_export_share_title">完了したダウンロードをエクスポート</string>
-    <string name="dlmgr_done_export_summary">%1$d 件 · %2$d 個のリンク</string>
+    <string name="dlmgr_done_export_summary">%1$d 件の作品をエクスポート</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1150,9 +1150,9 @@
     <string name="bulk_select_invert">選択反転</string>
     <string name="bulk_select_no_items">選択可能な作品がありません。別の入口から来たため状態が失われた可能性があります。</string>
     <string name="bulk_select_loading">読み込み中…</string>
-    <string name="bulk_select_summary">%1$d 件 · %2$d 件選択中</string>
-    <string name="bulk_select_summary_with_gif">%1$d 件 · %2$d 件選択中 · GIF %3$d 件をスキップ</string>
-    <string name="bulk_select_confirm">ダウンロードキューに追加 (%1$d) →</string>
+    <string name="bulk_select_summary">%1$d 件 · %2$d 件選択中（%3$d 枚）</string>
+    <string name="bulk_select_summary_with_gif">%1$d 件 · %2$d 件選択中（%3$d 枚）· GIF %4$d 件をスキップ（作品ページから個別にダウンロード）</string>
+    <string name="bulk_select_confirm">ダウンロードキューに追加（%1$d 件 / %2$d 枚）→</string>
     <string name="bulk_select_confirm_empty">1件以上選択してください</string>
 
     <string name="bulk_enqueue_empty">キューに追加できる作品がありません</string>
@@ -1212,4 +1212,15 @@
     <string name="dlmgr_done_empty_hint">完了した作品はここに表示されます</string>
     <string name="dlmgr_done_action_refresh">更新</string>
     <string name="dlmgr_done_action_clear_history">記録をクリア</string>
+    <string name="dlmgr_done_action_export">エクスポート</string>
+    <string name="dlmgr_done_layout_list">レイアウト: リスト</string>
+    <string name="dlmgr_done_layout_grid">レイアウト: グリッド</string>
+    <string name="dlmgr_done_layout_compact">レイアウト: コンパクト</string>
+    <string name="setting_max_concurrent_downloads">同時ダウンロード数</string>
+    <string name="setting_max_concurrent_downloads_one">1（直列 · デフォルト）</string>
+    <string name="setting_max_concurrent_downloads_n">%1$d 並列</string>
+    <string name="setting_max_concurrent_downloads_changed">同時ダウンロード数を %1$d に設定</string>
+    <string name="dlmgr_done_export_empty">エクスポート可能な完了作品がありません</string>
+    <string name="dlmgr_done_export_share_title">完了したダウンロードをエクスポート</string>
+    <string name="dlmgr_done_export_summary">%1$d 件 · %2$d 個のリンク</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1123,11 +1123,15 @@
     <string name="dlmgr_done_layout_list">레이아웃: 리스트</string>
     <string name="dlmgr_done_layout_grid">레이아웃: 그리드</string>
     <string name="dlmgr_done_layout_compact">레이아웃: 콤팩트</string>
+    <string name="dlmgr_clear_active_queue_title">모든 다운로드 지우기?</string>
+    <string name="dlmgr_clear_active_queue_message">진행 중이거나 대기 중인 항목이 모두 중지되고 지워집니다.\n(이미 일부 다운로드된 파일은 보존됩니다.)</string>
+    <string name="dlmgr_clear_done_title">완료 기록 지우기?</string>
+    <string name="dlmgr_clear_done_message">다운로드된 파일은 그대로 유지되며, 여기 기록만 사라집니다.</string>
     <string name="setting_max_concurrent_downloads">동시 다운로드 수</string>
     <string name="setting_max_concurrent_downloads_one">1 (직렬 · 기본값)</string>
     <string name="setting_max_concurrent_downloads_n">%1$d개 병렬</string>
     <string name="setting_max_concurrent_downloads_changed">동시 다운로드 수가 %1$d로 설정됨</string>
     <string name="dlmgr_done_export_empty">내보낼 완료된 작품이 없습니다</string>
     <string name="dlmgr_done_export_share_title">완료된 다운로드 내보내기</string>
-    <string name="dlmgr_done_export_summary">%1$d개 작품 · %2$d개 링크</string>
+    <string name="dlmgr_done_export_summary">%1$d개 작품을 내보냈습니다</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1057,9 +1057,9 @@
     <string name="bulk_select_invert">선택 반전</string>
     <string name="bulk_select_no_items">선택 가능한 작품이 없습니다. 다른 진입점에서 와서 상태가 손실되었을 수 있습니다.</string>
     <string name="bulk_select_loading">로딩 중…</string>
-    <string name="bulk_select_summary">%1$d개 · %2$d개 선택됨</string>
-    <string name="bulk_select_summary_with_gif">%1$d개 · %2$d개 선택됨 · GIF %3$d개 건너뜀</string>
-    <string name="bulk_select_confirm">다운로드 큐에 추가 (%1$d) →</string>
+    <string name="bulk_select_summary">%1$d개 · %2$d개 선택됨 (%3$d장)</string>
+    <string name="bulk_select_summary_with_gif">%1$d개 · %2$d개 선택됨 (%3$d장) · GIF %4$d개 건너뜀 (작품 페이지에서 개별 다운로드)</string>
+    <string name="bulk_select_confirm">다운로드 큐에 추가 (%1$d개 / %2$d장) →</string>
     <string name="bulk_select_confirm_empty">최소 1개 이상 선택하세요</string>
 
     <string name="bulk_enqueue_empty">큐에 추가할 작품이 없습니다</string>
@@ -1119,4 +1119,15 @@
     <string name="dlmgr_done_empty_hint">완료된 작품이 여기에 표시됩니다</string>
     <string name="dlmgr_done_action_refresh">새로고침</string>
     <string name="dlmgr_done_action_clear_history">기록 지우기</string>
+    <string name="dlmgr_done_action_export">내보내기</string>
+    <string name="dlmgr_done_layout_list">레이아웃: 리스트</string>
+    <string name="dlmgr_done_layout_grid">레이아웃: 그리드</string>
+    <string name="dlmgr_done_layout_compact">레이아웃: 콤팩트</string>
+    <string name="setting_max_concurrent_downloads">동시 다운로드 수</string>
+    <string name="setting_max_concurrent_downloads_one">1 (직렬 · 기본값)</string>
+    <string name="setting_max_concurrent_downloads_n">%1$d개 병렬</string>
+    <string name="setting_max_concurrent_downloads_changed">동시 다운로드 수가 %1$d로 설정됨</string>
+    <string name="dlmgr_done_export_empty">내보낼 완료된 작품이 없습니다</string>
+    <string name="dlmgr_done_export_share_title">완료된 다운로드 내보내기</string>
+    <string name="dlmgr_done_export_summary">%1$d개 작품 · %2$d개 링크</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1116,11 +1116,15 @@
     <string name="dlmgr_done_layout_list">Вид: Список</string>
     <string name="dlmgr_done_layout_grid">Вид: Сетка</string>
     <string name="dlmgr_done_layout_compact">Вид: Компактный</string>
+    <string name="dlmgr_clear_active_queue_title">Очистить все загрузки?</string>
+    <string name="dlmgr_clear_active_queue_message">Все текущие и ожидающие загрузки будут остановлены и удалены.\n(Частично загруженные файлы на диске сохраняются.)</string>
+    <string name="dlmgr_clear_done_title">Очистить историю завершённых?</string>
+    <string name="dlmgr_clear_done_message">Скачанные файлы останутся на диске; удаляется только запись в этом списке.</string>
     <string name="setting_max_concurrent_downloads">Одновременных загрузок</string>
     <string name="setting_max_concurrent_downloads_one">1 (последовательно · по умолчанию)</string>
     <string name="setting_max_concurrent_downloads_n">%1$d параллельно</string>
     <string name="setting_max_concurrent_downloads_changed">Одновременных загрузок: %1$d</string>
     <string name="dlmgr_done_export_empty">Нет завершённых работ для экспорта</string>
     <string name="dlmgr_done_export_share_title">Экспорт завершённых загрузок</string>
-    <string name="dlmgr_done_export_summary">%1$d работ · %2$d ссылок</string>
+    <string name="dlmgr_done_export_summary">Экспортировано работ: %1$d</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1050,9 +1050,9 @@
     <string name="bulk_select_invert">Инвертировать</string>
     <string name="bulk_select_no_items">Нет доступных работ. Состояние могло быть потеряно при входе с другого экрана.</string>
     <string name="bulk_select_loading">Загрузка…</string>
-    <string name="bulk_select_summary">Всего %1$d · выбрано %2$d</string>
-    <string name="bulk_select_summary_with_gif">Всего %1$d · выбрано %2$d · пропущено %3$d GIF</string>
-    <string name="bulk_select_confirm">Добавить в очередь (%1$d) →</string>
+    <string name="bulk_select_summary">Всего %1$d · выбрано %2$d (%3$d изобр.)</string>
+    <string name="bulk_select_summary_with_gif">Всего %1$d · выбрано %2$d (%3$d изобр.) · пропущено %4$d GIF (скачайте со страницы произведения)</string>
+    <string name="bulk_select_confirm">Добавить в очередь (%1$d работ / %2$d изобр.) →</string>
     <string name="bulk_select_confirm_empty">Выберите хотя бы 1</string>
 
     <string name="bulk_enqueue_empty">Нет работ для очереди</string>
@@ -1112,4 +1112,15 @@
     <string name="dlmgr_done_empty_hint">Завершенные работы появятся здесь</string>
     <string name="dlmgr_done_action_refresh">Обновить</string>
     <string name="dlmgr_done_action_clear_history">Очистить записи</string>
+    <string name="dlmgr_done_action_export">Экспорт</string>
+    <string name="dlmgr_done_layout_list">Вид: Список</string>
+    <string name="dlmgr_done_layout_grid">Вид: Сетка</string>
+    <string name="dlmgr_done_layout_compact">Вид: Компактный</string>
+    <string name="setting_max_concurrent_downloads">Одновременных загрузок</string>
+    <string name="setting_max_concurrent_downloads_one">1 (последовательно · по умолчанию)</string>
+    <string name="setting_max_concurrent_downloads_n">%1$d параллельно</string>
+    <string name="setting_max_concurrent_downloads_changed">Одновременных загрузок: %1$d</string>
+    <string name="dlmgr_done_export_empty">Нет завершённых работ для экспорта</string>
+    <string name="dlmgr_done_export_share_title">Экспорт завершённых загрузок</string>
+    <string name="dlmgr_done_export_summary">%1$d работ · %2$d ссылок</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1114,11 +1114,15 @@
     <string name="dlmgr_done_layout_list">Düzen: Liste</string>
     <string name="dlmgr_done_layout_grid">Düzen: Izgara</string>
     <string name="dlmgr_done_layout_compact">Düzen: Kompakt</string>
+    <string name="dlmgr_clear_active_queue_title">Tüm indirmeleri temizle?</string>
+    <string name="dlmgr_clear_active_queue_message">Süren ve sırada bekleyen tüm indirmeler durdurulup temizlenecek.\n(Disk üzerinde kısmen indirilmiş dosyalar korunur.)</string>
+    <string name="dlmgr_clear_done_title">Tamamlanan kayıtları temizle?</string>
+    <string name="dlmgr_clear_done_message">İndirilen dosyalar diskte kalır; yalnızca buradaki kayıtlar silinir.</string>
     <string name="setting_max_concurrent_downloads">Eş zamanlı indirmeler</string>
     <string name="setting_max_concurrent_downloads_one">1 (sıralı · varsayılan)</string>
     <string name="setting_max_concurrent_downloads_n">%1$d paralel</string>
     <string name="setting_max_concurrent_downloads_changed">Eş zamanlı indirme sayısı %1$d olarak ayarlandı</string>
     <string name="dlmgr_done_export_empty">Dışa aktarılacak tamamlanan eser yok</string>
     <string name="dlmgr_done_export_share_title">Tamamlanan indirmeleri dışa aktar</string>
-    <string name="dlmgr_done_export_summary">%1$d eser · %2$d bağlantı</string>
+    <string name="dlmgr_done_export_summary">%1$d eser dışa aktarıldı</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1048,9 +1048,9 @@
     <string name="bulk_select_invert">Tersine çevir</string>
     <string name="bulk_select_no_items">Seçilebilir eser yok. Farklı bir giriş noktasından gelinmiş olabilir.</string>
     <string name="bulk_select_loading">Yükleniyor…</string>
-    <string name="bulk_select_summary">Toplam %1$d · %2$d seçili</string>
-    <string name="bulk_select_summary_with_gif">Toplam %1$d · %2$d seçili · %3$d GIF atlandı</string>
-    <string name="bulk_select_confirm">Kuyruğa ekle (%1$d) →</string>
+    <string name="bulk_select_summary">Toplam %1$d · %2$d seçili (%3$d resim)</string>
+    <string name="bulk_select_summary_with_gif">Toplam %1$d · %2$d seçili (%3$d resim) · %4$d GIF atlandı (eser sayfasından indirin)</string>
+    <string name="bulk_select_confirm">Kuyruğa ekle (%1$d öğe / %2$d resim) →</string>
     <string name="bulk_select_confirm_empty">En az 1 öğe seçin</string>
 
     <string name="bulk_enqueue_empty">Kuyruğa eklenecek eser yok</string>
@@ -1110,4 +1110,15 @@
     <string name="dlmgr_done_empty_hint">Tamamlanan eserler burada görünecek</string>
     <string name="dlmgr_done_action_refresh">Yenile</string>
     <string name="dlmgr_done_action_clear_history">Kayıtları temizle</string>
+    <string name="dlmgr_done_action_export">Dışa aktar</string>
+    <string name="dlmgr_done_layout_list">Düzen: Liste</string>
+    <string name="dlmgr_done_layout_grid">Düzen: Izgara</string>
+    <string name="dlmgr_done_layout_compact">Düzen: Kompakt</string>
+    <string name="setting_max_concurrent_downloads">Eş zamanlı indirmeler</string>
+    <string name="setting_max_concurrent_downloads_one">1 (sıralı · varsayılan)</string>
+    <string name="setting_max_concurrent_downloads_n">%1$d paralel</string>
+    <string name="setting_max_concurrent_downloads_changed">Eş zamanlı indirme sayısı %1$d olarak ayarlandı</string>
+    <string name="dlmgr_done_export_empty">Dışa aktarılacak tamamlanan eser yok</string>
+    <string name="dlmgr_done_export_share_title">Tamamlanan indirmeleri dışa aktar</string>
+    <string name="dlmgr_done_export_summary">%1$d eser · %2$d bağlantı</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1163,9 +1163,9 @@
     <string name="bulk_select_invert">反選</string>
     <string name="bulk_select_no_items">沒有可選作品，可能從其他入口進來導致狀態遺失。</string>
     <string name="bulk_select_loading">載入中…</string>
-    <string name="bulk_select_summary">共 %1$d 項 · 已選 %2$d 項</string>
-    <string name="bulk_select_summary_with_gif">共 %1$d 項 · 已選 %2$d 項 · GIF 已略過 %3$d 項</string>
-    <string name="bulk_select_confirm">加入下載佇列 (%1$d) →</string>
+    <string name="bulk_select_summary">共 %1$d 項 · 已選 %2$d 項 (%3$d 張圖)</string>
+    <string name="bulk_select_summary_with_gif">共 %1$d 項 · 已選 %2$d 項 (%3$d 張圖) · 跳過 %4$d 個動圖（請到作品頁單獨下載）</string>
+    <string name="bulk_select_confirm">加入下載佇列 (%1$d 項 / %2$d 張圖) →</string>
     <string name="bulk_select_confirm_empty">請至少選擇 1 項</string>
 
     <string name="bulk_enqueue_empty">沒有可入隊的作品</string>
@@ -1225,4 +1225,15 @@
     <string name="dlmgr_done_empty_hint">下載完成的作品會出現在這裡</string>
     <string name="dlmgr_done_action_refresh">重新整理</string>
     <string name="dlmgr_done_action_clear_history">清空記錄</string>
+    <string name="dlmgr_done_action_export">匯出</string>
+    <string name="dlmgr_done_layout_list">版面：列表</string>
+    <string name="dlmgr_done_layout_grid">版面：網格</string>
+    <string name="dlmgr_done_layout_compact">版面：縮圖</string>
+    <string name="setting_max_concurrent_downloads">同時下載數</string>
+    <string name="setting_max_concurrent_downloads_one">1（串列 · 預設）</string>
+    <string name="setting_max_concurrent_downloads_n">%1$d 並發</string>
+    <string name="setting_max_concurrent_downloads_changed">同時下載數已設為 %1$d</string>
+    <string name="dlmgr_done_export_empty">沒有已完成的作品可匯出</string>
+    <string name="dlmgr_done_export_share_title">匯出已完成下載</string>
+    <string name="dlmgr_done_export_summary">共 %1$d 個作品 · %2$d 行連結</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1229,11 +1229,15 @@
     <string name="dlmgr_done_layout_list">版面：列表</string>
     <string name="dlmgr_done_layout_grid">版面：網格</string>
     <string name="dlmgr_done_layout_compact">版面：縮圖</string>
+    <string name="dlmgr_clear_active_queue_title">清空全部下載？</string>
+    <string name="dlmgr_clear_active_queue_message">正在下載和排隊中的任務都會停止並清除。\n（已下載到一半的檔案不會被刪除。）</string>
+    <string name="dlmgr_clear_done_title">清空已完成記錄？</string>
+    <string name="dlmgr_clear_done_message">已下載的檔案不會被刪除，只是從這裡看不到了。</string>
     <string name="setting_max_concurrent_downloads">同時下載數</string>
     <string name="setting_max_concurrent_downloads_one">1（串列 · 預設）</string>
     <string name="setting_max_concurrent_downloads_n">%1$d 並發</string>
     <string name="setting_max_concurrent_downloads_changed">同時下載數已設為 %1$d</string>
     <string name="dlmgr_done_export_empty">沒有已完成的作品可匯出</string>
     <string name="dlmgr_done_export_share_title">匯出已完成下載</string>
-    <string name="dlmgr_done_export_summary">共 %1$d 個作品 · %2$d 行連結</string>
+    <string name="dlmgr_done_export_summary">已匯出 %1$d 個作品的連結</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1530,9 +1530,9 @@
     <string name="bulk_select_invert">反选</string>
     <string name="bulk_select_no_items">没有可选作品，可能从其他入口进来导致状态丢失。</string>
     <string name="bulk_select_loading">加载中…</string>
-    <string name="bulk_select_summary">共 %1$d 项 · 已选 %2$d 项</string>
-    <string name="bulk_select_summary_with_gif">共 %1$d 项 · 已选 %2$d 项 · GIF 已跳过 %3$d 项</string>
-    <string name="bulk_select_confirm">加入下载队列 (%1$d) →</string>
+    <string name="bulk_select_summary">共 %1$d 项 · 已选 %2$d 项 (%3$d 张图)</string>
+    <string name="bulk_select_summary_with_gif">共 %1$d 项 · 已选 %2$d 项 (%3$d 张图) · 跳过 %4$d 个动图（请到作品页单独下载）</string>
+    <string name="bulk_select_confirm">加入下载队列 (%1$d 项 / %2$d 张图) →</string>
     <string name="bulk_select_confirm_empty">请至少选择 1 项</string>
 
     <!-- Legacy batch enqueue 提示 -->
@@ -1596,4 +1596,15 @@
     <string name="dlmgr_done_empty_hint">下载完成的作品会出现在这里</string>
     <string name="dlmgr_done_action_refresh">刷新</string>
     <string name="dlmgr_done_action_clear_history">清空记录</string>
+    <string name="dlmgr_done_action_export">导出</string>
+    <string name="dlmgr_done_layout_list">布局：列表</string>
+    <string name="dlmgr_done_layout_grid">布局：网格</string>
+    <string name="dlmgr_done_layout_compact">布局：缩图</string>
+    <string name="setting_max_concurrent_downloads">同时下载数</string>
+    <string name="setting_max_concurrent_downloads_one">1（串行 · 默认）</string>
+    <string name="setting_max_concurrent_downloads_n">%1$d 个并发</string>
+    <string name="setting_max_concurrent_downloads_changed">同时下载数已设为 %1$d</string>
+    <string name="dlmgr_done_export_empty">没有已完成的作品可导出</string>
+    <string name="dlmgr_done_export_share_title">导出已完成下载</string>
+    <string name="dlmgr_done_export_summary">共 %1$d 个作品 · %2$d 行链接</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1600,11 +1600,15 @@
     <string name="dlmgr_done_layout_list">布局：列表</string>
     <string name="dlmgr_done_layout_grid">布局：网格</string>
     <string name="dlmgr_done_layout_compact">布局：缩图</string>
+    <string name="dlmgr_clear_active_queue_title">清空全部下载？</string>
+    <string name="dlmgr_clear_active_queue_message">正在下载和排队中的任务都会停止并清除。\n（已经下载到一半的文件不会被删除。）</string>
+    <string name="dlmgr_clear_done_title">清空已完成记录？</string>
+    <string name="dlmgr_clear_done_message">已下载的文件不会被删除，只是从这里看不到了。</string>
     <string name="setting_max_concurrent_downloads">同时下载数</string>
     <string name="setting_max_concurrent_downloads_one">1（串行 · 默认）</string>
     <string name="setting_max_concurrent_downloads_n">%1$d 个并发</string>
     <string name="setting_max_concurrent_downloads_changed">同时下载数已设为 %1$d</string>
     <string name="dlmgr_done_export_empty">没有已完成的作品可导出</string>
     <string name="dlmgr_done_export_share_title">导出已完成下载</string>
-    <string name="dlmgr_done_export_summary">共 %1$d 个作品 · %2$d 行链接</string>
+    <string name="dlmgr_done_export_summary">已导出 %1$d 个作品的链接</string>
 </resources>


### PR DESCRIPTION
## Summary

把用户提的 debug_v6 优化清单（22 项）打通，加上自我 review 和真机日志暴露的两个关键 bug 修复。

**4 个 commit、+1042/-188 行、19 个文件改动**：

### `b8529e71` feat: 优化清单全量实现
正在下载 / 批量队列 / 已完成 / 批量下载 4 个 tab 的 9 项 bug 修复 + 5 项功能新增：
- DiffUtil 消除缩略图闪烁 / 暂停后仍闪 / URL 缓存避免重 Glide.load
- 失败重试不再整批 100 张图重新入队（issue #859）
- 批量队列缩略图按需 prefetch（限频 4 并发，pool 命中后局部 rebind）
- 三个 tab 操作按钮联动（暂停/清空 跨 active+queue）+ 删 2 个无功能按钮
- 已完成 typeBadge 暗图可读性修复（白字 + 70% 黑底，单 p 隐藏）
- 多任务并发下载 1-5（Settings 滑块 + Manager pumpAvailableSlots 调度）
- 已完成 tab 三种布局切换（列表 / 网格 / 紧凑缩图，持久化）
- 已完成列表导出（pixiv 链接 ACTION_SEND，恢复 4.6.4 之前丢失的功能）
- 批量下载 dialog 加图片总数 + GIF 引导
- 7 语言翻译同步

### `ae839f1e` ux: self-review 修补 5 处现代软件预期落差
- 暂停/继续按钮即时反馈（点击立刻翻 icon，不等下一轮 polling）
- 批量队列暂停按钮文案与 Manager 真实状态同步（被其他 tab 改了也跟着变）
- 三个 tab 的「清空」按钮加二次确认 dialog（destructive 操作不应一键直行）
- 改并发数走 pumpAvailableSlots 不走 startAll（避免恢复用户手动暂停的项）
- 导出 toast 文案去冗余（"X 个作品 · X 行链接" → "已导出 N 个作品"）

### `3f763f10` fix(media-store): SecurityException 兜底
真机日志暴露：

```
java.lang.SecurityException: ceui.pixiv.cshaft has no access to
  content://media/external_primary/images/media/1694
  at MediaStoreBackend.replace(MediaStoreBackend.kt:71)
```

文件已存在但 MediaStore row owner 不是当前 install（重装 / 外部扫描器创建），
update/delete 直接被 MediaProvider 拒，**整条下载链炸断**。

修：把 in-place update 抽出来包 try/catch SecurityException，命中后 fall through
到 openModern() insert 一条新行，MediaStore Q+ 自动追加 " (1)" 后缀。下载至少能
成功，文件落到 sibling 路径。

### `a69c745e` fix(active): DiffUtil aliasing 进度冻死
review 自己代码时发现的严重 bug：

`ActiveAdapterV3` 用 `ListAdapter<DownloadItem>` 但 Manager 是**原地修改**
DownloadItem 字段。1s 轮询 submit 时新旧列表持有同一对象引用，DiffUtil
`areContentsTheSame(a, b)` 拿到 `a === b`，所有字段比较恒等 → DiffUtil 永远
报告"无变化" → payload-bind 永不触发 → **进度条视觉冻死**。

修：拍 immutable `ActiveSnapshot` data class，把 8 个渲染相关字段冻结到 submit
时刻。新旧 snapshot 是不同对象，data class auto-equals 让 DiffUtil 真实比较。

## Test plan

- [x] `./gradlew :app:assembleGithubDebug` 通过（多次验证，最终 APK ~123MB）
- [x] 7 语言 strings 同步无 lint 错
- [ ] 真机回测：暂停 → 进度条立即显示 PAUSED；恢复 → 进度条继续走（验证 aliasing 修复）
- [ ] 真机回测：下载已存在 row 但非 owner 的文件 → 不再 SecurityException 炸链 (3f763f10)
- [ ] 真机回测：清空按钮二次确认 dialog 出现 + 红色"确定"按钮
- [ ] 真机回测：已完成 tab 切换 列表 / 网格 / 紧凑布局
- [ ] Settings 切并发数 1→5，看正在下载 tab DOWNLOADING 数量上升
- [ ] 批量下载 dialog 显示"共 N 项 · 已选 X 项 (Y 张图)"

## 未做

5 项需要用户进一步澄清场景信息后才能动：跳转按钮夜晚模式输入框、插画详情三个点"批量操作"、预览缩略图 XXP 颜色、(1).png 后缀根因（user 在 classic 分支已有 OEM-rename guard WIP）、下载速度变慢（无指标）。详见 b8529e71 commit 末尾。

🤖 Generated with [Claude Code](https://claude.com/claude-code)