### PR TITLE
feat(events): 上报匿名收藏/关注/下载到 shaft-api-v2 社区榜单

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,15 @@ android {
                 arguments = [:]
             }
         }
+
+        // Shaft community events server (shaft-api-v2). Secret is injected at
+        // build time from ~/.gradle/gradle.properties or env (SHAFT_EVENTS_HMAC) —
+        // never committed. Forks build with empty secret and get 401 from the
+        // server, which is intentional: only official builds may post events.
+        buildConfigField "String", "SHAFT_EVENTS_BASE_URL",
+            '"' + (project.findProperty('SHAFT_EVENTS_BASE_URL') ?: 'http://36.138.103.18:30009') + '"'
+        buildConfigField "String", "SHAFT_EVENTS_HMAC",
+            '"' + (project.findProperty('SHAFT_EVENTS_HMAC') ?: System.getenv('SHAFT_EVENTS_HMAC') ?: '') + '"'
     }
 
     lint {

--- a/app/src/main/java/ceui/lisa/activities/Shaft.java
+++ b/app/src/main/java/ceui/lisa/activities/Shaft.java
@@ -207,6 +207,10 @@ public class Shaft extends Application implements ServicesProvider {
         // 批量下载持久化队列（v33）：冷启动恢复 + 单并发消费循环
         ceui.pixiv.ui.bulk.QueueDownloadManager.INSTANCE.init(this);
 
+        // 社区榜单事件上报（shaft-api-v2）。完全 fire-and-forget，失败静默，
+        // 任何崩溃都被它自己捕获。安全顺序：必须在 MMKV.initialize 之后。
+        ceui.pixiv.events.EventReporter.INSTANCE.init(this);
+
         // 初始化发现池 + 异步构建用户画像
         Timber.d("Discovery/Init >>> initializing DiscoveryPool");
         ceui.pixiv.db.discovery.DiscoveryPool.INSTANCE.initialize();

--- a/app/src/main/java/ceui/lisa/activities/UActivity.kt
+++ b/app/src/main/java/ceui/lisa/activities/UActivity.kt
@@ -46,6 +46,7 @@ import io.reactivex.schedulers.Schedulers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import ceui.pixiv.events.EventReporter
 
 class UActivity : BaseActivity<ActivityNewUserBinding>(), Display<UserDetailResponse> {
     private var userId = 0
@@ -318,6 +319,7 @@ fun FragmentActivity.followUser(sender: ProgressIndicator, userId: Int, followTy
             sender.showProgress()
             Client.appApi.postFollow(userId.toLong(), pendingFollowType)
             RateAppManager.onUserEngaged()
+            EventReporter.report(EventReporter.Type.FOLLOW, EventReporter.Target.USER, userId.toLong())
             delay(500L)
             ObjectPool.followUser(userId.toLong())
             if (pendingFollowType == Params.TYPE_PUBLIC) {
@@ -351,6 +353,7 @@ fun FragmentActivity.unfollowUser(sender: ProgressIndicator, userId: Int) {
         try {
             sender.showProgress()
             Client.appApi.postUnFollow(userId.toLong())
+            EventReporter.report(EventReporter.Type.UNFOLLOW, EventReporter.Target.USER, userId.toLong())
             delay(500L)
             Shaft.appViewModel.updateFollowUserStatus(
                 userId,

--- a/app/src/main/java/ceui/lisa/utils/PixivOperate.java
+++ b/app/src/main/java/ceui/lisa/utils/PixivOperate.java
@@ -76,6 +76,7 @@ import io.reactivex.schedulers.Schedulers;
 import retrofit2.Call;
 import retrofit2.Callback;
 
+import ceui.pixiv.events.EventReporter;
 import ceui.pixiv.session.SessionManager;
 import ceui.pixiv.widgets.RateAppManager;
 
@@ -131,6 +132,11 @@ public class PixivOperate {
                         // 关注行为更新画像
                         Common.showLog("Discovery/Hook followUser userId=" + userID);
                         ceui.pixiv.db.discovery.ProfileManager.INSTANCE.onFollowUser((long) userID);
+
+                        EventReporter.INSTANCE.report(
+                                EventReporter.Type.FOLLOW,
+                                EventReporter.Target.USER,
+                                (long) userID);
                     }
                 });
     }
@@ -154,6 +160,11 @@ public class PixivOperate {
                         // 取消关注更新画像
                         Common.showLog("Discovery/Hook unfollowUser userId=" + userID);
                         ceui.pixiv.db.discovery.ProfileManager.INSTANCE.onUnfollowUser((long) userID);
+
+                        EventReporter.INSTANCE.report(
+                                EventReporter.Type.UNFOLLOW,
+                                EventReporter.Target.USER,
+                                (long) userID);
                     }
                 });
     }
@@ -189,6 +200,13 @@ public class PixivOperate {
                             LocalBroadcastManager.getInstance(Shaft.getContext()).sendBroadcast(intent);
 
                             Common.showToast(getString(R.string.cancel_like_illust));
+
+                            EventReporter.INSTANCE.report(
+                                    EventReporter.Type.UNBOOKMARK,
+                                    "manga".equals(illustsBean.getType())
+                                            ? EventReporter.Target.MANGA
+                                            : EventReporter.Target.ILLUST,
+                                    (long) illustsBean.getId());
                         }
                     });
         } else { //没有收藏
@@ -214,6 +232,13 @@ public class PixivOperate {
                             // 收藏行为更新画像：提升画师和标签偏好，让后续推荐更精准
                             Common.showLog("Discovery/Hook bookmarkIllust id=" + illustsBean.getId());
                             ceui.pixiv.db.discovery.ProfileManager.INSTANCE.onBookmarkIllust(illustsBean);
+
+                            EventReporter.INSTANCE.report(
+                                    EventReporter.Type.BOOKMARK,
+                                    "manga".equals(illustsBean.getType())
+                                            ? EventReporter.Target.MANGA
+                                            : EventReporter.Target.ILLUST,
+                                    (long) illustsBean.getId());
 
                             //收藏后自动关注作者
                             if (Shaft.sSettings.isAutoFollowAfterStar()
@@ -278,6 +303,11 @@ public class PixivOperate {
                                 ((Button) view).setText(getString(R.string.string_180));
                             }
                             Common.showToast(getString(R.string.cancel_like_illust));
+
+                            EventReporter.INSTANCE.report(
+                                    EventReporter.Type.UNBOOKMARK,
+                                    EventReporter.Target.NOVEL,
+                                    (long) novelBean.getId());
                         }
                     });
         } else { //没有收藏
@@ -303,6 +333,11 @@ public class PixivOperate {
                             } else {
                                 Common.showToast(getString(R.string.like_novel_success_private));
                             }
+
+                            EventReporter.INSTANCE.report(
+                                    EventReporter.Type.BOOKMARK,
+                                    EventReporter.Target.NOVEL,
+                                    (long) novelBean.getId());
 
                             //收藏后自动关注作者
                             if (Shaft.sSettings.isAutoFollowAfterStar()

--- a/app/src/main/java/ceui/pixiv/db/queue/DownloadQueueDao.kt
+++ b/app/src/main/java/ceui/pixiv/db/queue/DownloadQueueDao.kt
@@ -113,5 +113,21 @@ interface DownloadQueueDao {
     suspend fun appendBatch(items: List<DownloadQueueEntity>) {
         if (items.isEmpty()) return
         insertAll(items)
+        // Single chokepoint for every download enqueue (single, batch, retry,
+        // legacy, bulk) — fire community-trending events from here so we
+        // don't have to remember to hook every UI path. Reporter is fully
+        // fire-and-forget (see EventReporter.kt) so this can't slow the txn.
+        for (e in items) {
+            val targetType = if (e.type == WorkType.MANGA) {
+                ceui.pixiv.events.EventReporter.Target.MANGA
+            } else {
+                ceui.pixiv.events.EventReporter.Target.ILLUST
+            }
+            ceui.pixiv.events.EventReporter.report(
+                ceui.pixiv.events.EventReporter.Type.DOWNLOAD,
+                targetType,
+                e.illustId,
+            )
+        }
     }
 }

--- a/app/src/main/java/ceui/pixiv/events/EventReporter.kt
+++ b/app/src/main/java/ceui/pixiv/events/EventReporter.kt
@@ -1,0 +1,269 @@
+package ceui.pixiv.events
+
+import android.content.Context
+import ceui.lisa.BuildConfig
+import ceui.lisa.activities.Shaft
+import com.google.gson.Gson
+import com.tencent.mmkv.MMKV
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.RequestBody.Companion.toRequestBody
+import timber.log.Timber
+import java.security.MessageDigest
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Sends bookmark / follow / download events to shaft-api-v2 for community
+ * trending aggregation. Three hard rules drive the design:
+ *
+ *  1) Never block the caller. `report()` is fire-and-forget; everything
+ *     happens on a private SupervisorJob + Dispatchers.IO scope.
+ *  2) Never throw. Every Throwable is caught and logged. A misbehaving
+ *     reporter must not break a bookmark click.
+ *  3) Anonymous identity. We send sha256(random UUID) as client_id — never
+ *     the user's Pixiv UID, never anything that lets the server correlate
+ *     activity to a specific Pixiv account.
+ *
+ * Logs are verbose by design (per project request). All log lines use the
+ * "EventReporter" tag so a single `adb logcat -s EventReporter` shows the
+ * full report → enqueue → flush → POST → response chain.
+ */
+object EventReporter {
+
+    private const val TAG = "EventReporter"
+
+    /** Wire-level event type strings. Must match shaft-api-v2 src/db.js whitelists. */
+    object Type {
+        const val BOOKMARK = "bookmark"
+        const val UNBOOKMARK = "unbookmark"
+        const val DOWNLOAD = "download"
+        const val FOLLOW = "follow"
+        const val UNFOLLOW = "unfollow"
+    }
+
+    /** Wire-level target_type strings. Must match shaft-api-v2 src/db.js whitelists. */
+    object Target {
+        const val ILLUST = "illust"
+        const val MANGA = "manga"
+        const val NOVEL = "novel"
+        const val USER = "user"
+    }
+
+    private const val MMKV_KEY_CLIENT_ID = "shaft_events_client_id"
+    private const val FLUSH_INTERVAL_MS = 30_000L
+    private const val FLUSH_THRESHOLD = 10           // POST when queue reaches this many
+    private const val MAX_BATCH = 50                 // server caps at 100; stay well under
+    private const val MAX_QUEUE = 500                // hard cap, drop oldest above this
+    private const val MAX_RETRIES = 3
+
+    private val initialized = AtomicBoolean(false)
+    private val scope = CoroutineScope(
+        SupervisorJob() + Dispatchers.IO +
+            CoroutineExceptionHandler { _, e -> Timber.tag(TAG).e(e, "uncaught in scope") }
+    )
+    private val mutex = Mutex()
+    private val queue = ArrayDeque<EventEntry>()
+
+    @Volatile private var clientId: String = ""
+    @Volatile private var hmacEnabled: Boolean = false
+
+    private data class EventEntry(
+        val type: String,
+        val targetType: String,
+        val targetId: Long,
+        var attempts: Int = 0,
+    )
+
+    /** Idempotent. Call from Application.onCreate(). */
+    fun init(appCtx: Context) {
+        if (!initialized.compareAndSet(false, true)) {
+            Timber.tag(TAG).d("init() called again, ignoring")
+            return
+        }
+        try {
+            val mmkv = MMKV.defaultMMKV()
+            var id = mmkv?.getString(MMKV_KEY_CLIENT_ID, null)
+            if (id.isNullOrEmpty()) {
+                id = sha256Hex(UUID.randomUUID().toString() + "|" + System.nanoTime())
+                mmkv?.putString(MMKV_KEY_CLIENT_ID, id)
+                Timber.tag(TAG).i("generated new client_id (head=%s..)", id!!.take(8))
+            } else {
+                Timber.tag(TAG).i("loaded existing client_id (head=%s..)", id.take(8))
+            }
+            clientId = id
+            hmacEnabled = BuildConfig.SHAFT_EVENTS_HMAC.isNotEmpty()
+
+            Timber.tag(TAG).i(
+                "init OK: hmac=%s, baseUrl=%s, flushInterval=%dms, threshold=%d, maxBatch=%d",
+                if (hmacEnabled) "enabled" else "disabled (forks/dev)",
+                BuildConfig.SHAFT_EVENTS_BASE_URL,
+                FLUSH_INTERVAL_MS, FLUSH_THRESHOLD, MAX_BATCH,
+            )
+
+            scope.launch {
+                while (isActive) {
+                    delay(FLUSH_INTERVAL_MS)
+                    flushInternal(reason = "tick")
+                }
+            }
+        } catch (t: Throwable) {
+            // Initialization must never crash the app. If MMKV isn't available,
+            // we just stay disabled forever for this process.
+            Timber.tag(TAG).e(t, "init failed, reporter disabled this session")
+            initialized.set(false)
+        }
+    }
+
+    /**
+     * Fire-and-forget. Returns immediately. Drops the event silently when:
+     *  - reporter not initialized, or
+     *  - this build has no HMAC secret (forks / dev builds), or
+     *  - target_id is non-positive.
+     *
+     * Anonymous and on by default — there is no opt-out toggle. Identity is
+     * sha256(random UUID) generated on first launch; Pixiv UID is never sent.
+     */
+    fun report(type: String, targetType: String, targetId: Long) {
+        if (!initialized.get()) {
+            Timber.tag(TAG).v("drop %s/%s/%d (not initialized)", type, targetType, targetId)
+            return
+        }
+        if (!hmacEnabled) {
+            Timber.tag(TAG).v("drop %s/%s/%d (build has no HMAC secret)", type, targetType, targetId)
+            return
+        }
+        if (targetId <= 0) {
+            Timber.tag(TAG).w("drop %s/%s/%d (bad target_id)", type, targetType, targetId)
+            return
+        }
+        scope.launch {
+            val triggerFlush = mutex.withLock {
+                if (queue.size >= MAX_QUEUE) {
+                    queue.removeFirst()
+                    Timber.tag(TAG).w("queue overflow (>=%d), dropped oldest", MAX_QUEUE)
+                }
+                queue.addLast(EventEntry(type, targetType, targetId))
+                Timber.tag(TAG).d("enqueue %s/%s/%d (queue=%d)", type, targetType, targetId, queue.size)
+                queue.size >= FLUSH_THRESHOLD
+            }
+            if (triggerFlush) flushInternal(reason = "threshold")
+        }
+    }
+
+    /** Best-effort flush. Useful from app-lifecycle hooks (e.g. onStop). */
+    fun flushNow() {
+        if (!initialized.get()) return
+        Timber.tag(TAG).d("flushNow() requested")
+        scope.launch { flushInternal(reason = "manual") }
+    }
+
+    private suspend fun flushInternal(reason: String) {
+        val batch = mutex.withLock {
+            if (queue.isEmpty()) {
+                Timber.tag(TAG).v("flush(reason=%s): queue empty", reason)
+                return
+            }
+            val take = minOf(queue.size, MAX_BATCH)
+            val taken = ArrayList<EventEntry>(take)
+            repeat(take) { taken.add(queue.removeFirst()) }
+            taken
+        }
+        Timber.tag(TAG).d("flush(reason=%s) batch=%d", reason, batch.size)
+        try {
+            sendBatch(batch)
+        } catch (t: Throwable) {
+            // Server-side / network failure. Re-queue at the FRONT (preserving
+            // order) and let the next tick try again. Entries that hit
+            // MAX_RETRIES are dropped to keep a flapping server from pinning
+            // unbounded memory.
+            mutex.withLock {
+                var requeued = 0
+                var dropped = 0
+                // Reverse to keep original order when addFirst()-ing.
+                for (e in batch.asReversed()) {
+                    e.attempts++
+                    if (e.attempts > MAX_RETRIES) {
+                        dropped++
+                    } else {
+                        queue.addFirst(e)
+                        requeued++
+                    }
+                }
+                Timber.tag(TAG).w(
+                    t,
+                    "flush failed: requeue=%d drop=%d (queue=%d, maxRetries=%d)",
+                    requeued, dropped, queue.size, MAX_RETRIES,
+                )
+            }
+        }
+    }
+
+    private suspend fun sendBatch(events: List<EventEntry>) {
+        val payload = mapOf(
+            "client_id" to clientId,
+            "platform" to "android",
+            "app_version" to BuildConfig.VERSION_NAME,
+            "events" to events.map {
+                mapOf(
+                    "type" to it.type,
+                    "target_type" to it.targetType,
+                    "target_id" to it.targetId,
+                )
+            },
+        )
+        // Use a local Gson if Shaft.sGson isn't ready yet (tests, very early
+        // boot). Identical configuration is fine for this payload.
+        val json = (Shaft.sGson ?: Gson()).toJson(payload)
+        val sig = hmacSha256Hex(json, BuildConfig.SHAFT_EVENTS_HMAC)
+        Timber.tag(TAG).d(
+            "POST batch=%d bytes=%d sig=%s..%s",
+            events.size, json.length, sig.take(8), sig.takeLast(4),
+        )
+        val resp = ShaftEventsClient.api.batch(
+            sig,
+            json.toRequestBody("application/json".toMediaType()),
+        )
+        Timber.tag(TAG).i(
+            "response accepted=%d deduped=%d total=%d (sent=%d, queueAfter=%d)",
+            resp.accepted, resp.deduped, resp.total, events.size, queue.size,
+        )
+    }
+
+    private fun sha256Hex(s: String): String {
+        val md = MessageDigest.getInstance("SHA-256")
+        return md.digest(s.toByteArray(Charsets.UTF_8)).toHex()
+    }
+
+    /**
+     * Server treats the secret as ASCII bytes (the hex *string* itself),
+     * not as raw bytes decoded from hex — matches Node's
+     * `createHmac('sha256', secret)` default behavior.
+     */
+    private fun hmacSha256Hex(payload: String, secretAscii: String): String {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(secretAscii.toByteArray(Charsets.UTF_8), "HmacSHA256"))
+        return mac.doFinal(payload.toByteArray(Charsets.UTF_8)).toHex()
+    }
+
+    private fun ByteArray.toHex(): String {
+        val out = StringBuilder(size * 2)
+        val hex = "0123456789abcdef"
+        for (b in this) {
+            val v = b.toInt() and 0xFF
+            out.append(hex[v ushr 4])
+            out.append(hex[v and 0x0F])
+        }
+        return out.toString()
+    }
+}

--- a/app/src/main/java/ceui/pixiv/events/ShaftEventsApi.kt
+++ b/app/src/main/java/ceui/pixiv/events/ShaftEventsApi.kt
@@ -1,0 +1,68 @@
+package ceui.pixiv.events
+
+import ceui.lisa.BuildConfig
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.RequestBody
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.Body
+import retrofit2.http.Header
+import retrofit2.http.POST
+import java.util.concurrent.TimeUnit
+
+/**
+ * shaft-api-v2 — community trending events.
+ * Backend lives in https://github.com/SoxiaLiSA/shaft-api-v2
+ *
+ * Deliberately NOT routed through ceui.loxia.Client: pixiv auth headers,
+ * token-refresh logic and Cronet are irrelevant here, and a separate
+ * OkHttp instance keeps short event timeouts from interfering with the
+ * 10s timeouts used for pixiv calls.
+ */
+interface ShaftEventsApi {
+
+    /** Body must be the exact bytes whose HMAC was computed; do NOT use @Body with Gson. */
+    @POST("/api/v1/events/batch")
+    suspend fun batch(
+        @Header("X-Shaft-Sign") sig: String,
+        @Body body: RequestBody
+    ): EventBatchResponse
+}
+
+data class EventBatchResponse(
+    val accepted: Int,
+    val deduped: Int,
+    val total: Int
+)
+
+object ShaftEventsClient {
+
+    val api: ShaftEventsApi by lazy { build() }
+
+    private fun build(): ShaftEventsApi {
+        val builder = OkHttpClient.Builder()
+            .connectTimeout(8, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .writeTimeout(15, TimeUnit.SECONDS)
+            // HTTP/2 is fine over cleartext for this server (no TLS) since the
+            // network_security_config base policy already permits cleartext.
+            .protocols(listOf(Protocol.HTTP_1_1))
+
+        if (BuildConfig.IS_DEBUG_MODE) {
+            builder.addInterceptor(HttpLoggingInterceptor().apply {
+                // BODY would dump every event; HEADERS is enough to confirm the
+                // request was sent and the X-Shaft-Sign / response status.
+                level = HttpLoggingInterceptor.Level.HEADERS
+            })
+        }
+
+        return Retrofit.Builder()
+            .baseUrl(BuildConfig.SHAFT_EVENTS_BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .client(builder.build())
+            .build()
+            .create(ShaftEventsApi::class.java)
+    }
+}

--- a/app/src/main/java/ceui/pixiv/ui/common/PixivFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/PixivFragment.kt
@@ -33,6 +33,7 @@ import ceui.lisa.utils.ShareIllust
 import ceui.lisa.view.LinearItemDecoration
 import ceui.lisa.view.LinearItemDecorationNoLRTB
 import ceui.lisa.view.SpacesItemDecoration
+import ceui.pixiv.events.EventReporter
 import ceui.loxia.Article
 import ceui.loxia.Client
 import ceui.loxia.Illust
@@ -120,6 +121,14 @@ open class PixivFragment(layoutId: Int) : Fragment(layoutId),
             val illust = ObjectPool.get<Illust>(illustId).value
                 ?: Client.appApi.getIllust(illustId).illust?.also { ObjectPool.update(it) }
             if (illust != null) {
+                // Pixiv stores manga as illust with type == "manga"; report
+                // them under their semantic target_type so the server can rank
+                // illust / manga separately.
+                val targetType = if (illust.type == "manga") {
+                    EventReporter.Target.MANGA
+                } else {
+                    EventReporter.Target.ILLUST
+                }
                 if (illust.is_bookmarked == true) {
                     Client.appApi.removeBookmark(illustId)
                     ObjectPool.update(
@@ -129,6 +138,7 @@ open class PixivFragment(layoutId: Int) : Fragment(layoutId),
                         )
                     )
                     Common.showToast(getString(R.string.cancel_like_illust))
+                    EventReporter.report(EventReporter.Type.UNBOOKMARK, targetType, illustId)
                 } else {
                     Client.appApi.postBookmark(illustId)
                     RateAppManager.onUserEngaged()
@@ -139,6 +149,7 @@ open class PixivFragment(layoutId: Int) : Fragment(layoutId),
                         )
                     )
                     Common.showToast(getString(R.string.like_novel_success_public))
+                    EventReporter.report(EventReporter.Type.BOOKMARK, targetType, illustId)
                 }
             }
         }
@@ -158,6 +169,7 @@ open class PixivFragment(layoutId: Int) : Fragment(layoutId),
                         )
                     )
                     Common.showToast(getString(R.string.cancel_like_illust))
+                    EventReporter.report(EventReporter.Type.UNBOOKMARK, EventReporter.Target.NOVEL, novelId)
                 } else {
                     Client.appApi.addNovelBookmark(novelId, Params.TYPE_PUBLIC)
                     RateAppManager.onUserEngaged()
@@ -168,6 +180,7 @@ open class PixivFragment(layoutId: Int) : Fragment(layoutId),
                         )
                     )
                     Common.showToast(getString(R.string.like_novel_success_public))
+                    EventReporter.report(EventReporter.Type.BOOKMARK, EventReporter.Target.NOVEL, novelId)
                 }
             }
         }


### PR DESCRIPTION
## Summary

- 在 4 个埋点位置上报用户匿名行为到自家后端 shaft-api-v2，给"本周最热"等社区榜单功能供数据
- `EventReporter` 单例：完全 fire-and-forget，绝不阻塞 UI，失败静默
- 默认开启，但只有官方 build (设了 `SHAFT_EVENTS_HMAC` 的) 才会发请求；fork build secret 为空 → 自动 disable

## 隐私模型

- 上报字段：`{ client_id, platform, app_version, type, target_type, target_id }`
- `client_id` = `sha256(MMKV 持久化的 UUID)`，**绝不**包含 Pixiv UID / 用户名 / IP / token
- 重装 app = 新身份；服务端按 `(client_id, type, target, day)` 唯一去重，spam-click 不刷分

## 埋点位置（覆盖 lisa Java + loxia Kotlin 两套 HTTP client）

| 入口 | 文件 | 上报 |
|---|---|---|
| 主收藏路径（详情页 V3、老版详情、ComicReader V3）| `PixivOperate.java` | bookmark/unbookmark illust/manga/novel |
| 主关注路径 | `PixivOperate.java` | follow/unfollow user |
| 列表 fab / Kotlin 新路径 | `PixivFragment.kt` | bookmark/unbookmark illust/manga/novel |
| Kotlin follow extension | `UActivity.kt` | follow/unfollow user |
| 下载队列单一 chokepoint | `DownloadQueueDao.kt` | download illust/manga |

## 配置 / Secret

- `app/build.gradle` 加 `SHAFT_EVENTS_BASE_URL` + `SHAFT_EVENTS_HMAC` 两个 buildConfigField
- secret 从 `~/.gradle/gradle.properties`（或 env `SHAFT_EVENTS_HMAC`）读，repo 里**不含 secret**
- fork build 没 secret → BuildConfig 字段空 → reporter 自动 disable，绝不发请求

## Test plan

- [x] `./gradlew :app:assembleGithubDebug` 通过
- [x] 真机 logcat 验证完整链路：`enqueue → flush → POST → response accepted=1`
- [x] 服务端 stats 接口看到数据进库
- [ ] 长跑 24h 看是否有 OOM / 异常重试

🤖 Generated with [Claude Code](https://claude.com/claude-code)