### PR TITLE
feat(events): 上报 illust/novel JSON payload 给 server 元数据缓存

### DIFF
--- a/app/src/main/java/ceui/lisa/utils/PixivOperate.java
+++ b/app/src/main/java/ceui/lisa/utils/PixivOperate.java
@@ -206,7 +206,8 @@ public class PixivOperate {
                                     "manga".equals(illustsBean.getType())
                                             ? EventReporter.Target.MANGA
                                             : EventReporter.Target.ILLUST,
-                                    (long) illustsBean.getId());
+                                    (long) illustsBean.getId(),
+                                    illustsBean);
                         }
                     });
         } else { //没有收藏
@@ -238,7 +239,8 @@ public class PixivOperate {
                                     "manga".equals(illustsBean.getType())
                                             ? EventReporter.Target.MANGA
                                             : EventReporter.Target.ILLUST,
-                                    (long) illustsBean.getId());
+                                    (long) illustsBean.getId(),
+                                    illustsBean);
 
                             //收藏后自动关注作者
                             if (Shaft.sSettings.isAutoFollowAfterStar()
@@ -307,7 +309,8 @@ public class PixivOperate {
                             EventReporter.INSTANCE.report(
                                     EventReporter.Type.UNBOOKMARK,
                                     EventReporter.Target.NOVEL,
-                                    (long) novelBean.getId());
+                                    (long) novelBean.getId(),
+                                    novelBean);
                         }
                     });
         } else { //没有收藏
@@ -337,7 +340,8 @@ public class PixivOperate {
                             EventReporter.INSTANCE.report(
                                     EventReporter.Type.BOOKMARK,
                                     EventReporter.Target.NOVEL,
-                                    (long) novelBean.getId());
+                                    (long) novelBean.getId(),
+                                    novelBean);
 
                             //收藏后自动关注作者
                             if (Shaft.sSettings.isAutoFollowAfterStar()

--- a/app/src/main/java/ceui/pixiv/db/queue/DownloadQueueDao.kt
+++ b/app/src/main/java/ceui/pixiv/db/queue/DownloadQueueDao.kt
@@ -117,16 +117,19 @@ interface DownloadQueueDao {
         // legacy, bulk) — fire community-trending events from here so we
         // don't have to remember to hook every UI path. Reporter is fully
         // fire-and-forget (see EventReporter.kt) so this can't slow the txn.
+        // illustGson is already a serialized IllustsBean — pass it through
+        // raw so the reporter doesn't pay another Gson.toJson roundtrip.
         for (e in items) {
             val targetType = if (e.type == WorkType.MANGA) {
                 ceui.pixiv.events.EventReporter.Target.MANGA
             } else {
                 ceui.pixiv.events.EventReporter.Target.ILLUST
             }
-            ceui.pixiv.events.EventReporter.report(
+            ceui.pixiv.events.EventReporter.reportWithRawJson(
                 ceui.pixiv.events.EventReporter.Type.DOWNLOAD,
                 targetType,
                 e.illustId,
+                e.illustGson,
             )
         }
     }

--- a/app/src/main/java/ceui/pixiv/events/EventReporter.kt
+++ b/app/src/main/java/ceui/pixiv/events/EventReporter.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import ceui.lisa.BuildConfig
 import ceui.lisa.activities.Shaft
 import com.google.gson.Gson
+import com.google.gson.JsonParser
 import com.tencent.mmkv.MMKV
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
@@ -66,6 +67,10 @@ object EventReporter {
     private const val MAX_BATCH = 50                 // server caps at 100; stay well under
     private const val MAX_QUEUE = 500                // hard cap, drop oldest above this
     private const val MAX_RETRIES = 3
+    // Per-event payload cap — must stay <= server's EVENTS_MAX_PAYLOAD_BYTES
+    // (256 KiB). Anything bigger gets the payload stripped (event still
+    // reported without it) so a freak large IllustsBean can't break the batch.
+    private const val MAX_PAYLOAD_BYTES = 200_000
 
     private val initialized = AtomicBoolean(false)
     private val scope = CoroutineScope(
@@ -82,6 +87,11 @@ object EventReporter {
         val type: String,
         val targetType: String,
         val targetId: Long,
+        /** Pre-serialized JSON of the IllustsBean / NovelBean / UserBean.
+         *  Stored as String (not Any) so a re-queue after network failure
+         *  doesn't pay the Gson cost again. null = no payload (server falls
+         *  back to whatever it already has in illust_meta / user_meta). */
+        val payloadJson: String? = null,
         var attempts: Int = 0,
     )
 
@@ -134,7 +144,8 @@ object EventReporter {
      * Anonymous and on by default — there is no opt-out toggle. Identity is
      * sha256(random UUID) generated on first launch; Pixiv UID is never sent.
      */
-    fun report(type: String, targetType: String, targetId: Long) {
+    @JvmOverloads
+    fun report(type: String, targetType: String, targetId: Long, payload: Any? = null) {
         if (!initialized.get()) {
             Timber.tag(TAG).v("drop %s/%s/%d (not initialized)", type, targetType, targetId)
             return
@@ -148,17 +159,59 @@ object EventReporter {
             return
         }
         scope.launch {
-            val triggerFlush = mutex.withLock {
-                if (queue.size >= MAX_QUEUE) {
-                    queue.removeFirst()
-                    Timber.tag(TAG).w("queue overflow (>=%d), dropped oldest", MAX_QUEUE)
-                }
-                queue.addLast(EventEntry(type, targetType, targetId))
-                Timber.tag(TAG).d("enqueue %s/%s/%d (queue=%d)", type, targetType, targetId, queue.size)
-                queue.size >= FLUSH_THRESHOLD
-            }
-            if (triggerFlush) flushInternal(reason = "threshold")
+            val payloadJson = serializePayload(payload, targetType, targetId)
+            enqueue(EventEntry(type, targetType, targetId, payloadJson))
         }
+    }
+
+    /** For callers that already have the JSON in hand (e.g. DownloadQueueDao
+     *  has illustGson cached). Skips the Gson.toJson roundtrip. */
+    fun reportWithRawJson(type: String, targetType: String, targetId: Long, payloadJson: String?) {
+        if (!initialized.get() || !hmacEnabled || targetId <= 0) return
+        scope.launch {
+            val cleaned = clampPayloadJson(payloadJson, targetType, targetId)
+            enqueue(EventEntry(type, targetType, targetId, cleaned))
+        }
+    }
+
+    private suspend fun enqueue(entry: EventEntry) {
+        val triggerFlush = mutex.withLock {
+            if (queue.size >= MAX_QUEUE) {
+                queue.removeFirst()
+                Timber.tag(TAG).w("queue overflow (>=%d), dropped oldest", MAX_QUEUE)
+            }
+            queue.addLast(entry)
+            Timber.tag(TAG).d(
+                "enqueue %s/%s/%d (queue=%d, payload=%s)",
+                entry.type, entry.targetType, entry.targetId, queue.size,
+                entry.payloadJson?.let { "${it.length}B" } ?: "—",
+            )
+            queue.size >= FLUSH_THRESHOLD
+        }
+        if (triggerFlush) flushInternal(reason = "threshold")
+    }
+
+    private fun serializePayload(payload: Any?, targetType: String, targetId: Long): String? {
+        if (payload == null) return null
+        return try {
+            val s = (Shaft.sGson ?: Gson()).toJson(payload)
+            clampPayloadJson(s, targetType, targetId)
+        } catch (t: Throwable) {
+            Timber.tag(TAG).w(t, "payload serialize failed for %s/%d, dropping payload", targetType, targetId)
+            null
+        }
+    }
+
+    private fun clampPayloadJson(json: String?, targetType: String, targetId: Long): String? {
+        if (json == null) return null
+        if (json.length > MAX_PAYLOAD_BYTES) {
+            Timber.tag(TAG).w(
+                "payload too large (%dB > %dB) for %s/%d, dropping payload only",
+                json.length, MAX_PAYLOAD_BYTES, targetType, targetId,
+            )
+            return null
+        }
+        return json
     }
 
     /** Best-effort flush. Useful from app-lifecycle hooks (e.g. onStop). */
@@ -210,33 +263,41 @@ object EventReporter {
     }
 
     private suspend fun sendBatch(events: List<EventEntry>) {
+        val gson = Shaft.sGson ?: Gson()
+        val eventList = events.map { e ->
+            val obj = mutableMapOf<String, Any>(
+                "type" to e.type,
+                "target_type" to e.targetType,
+                "target_id" to e.targetId,
+            )
+            // Re-parse the pre-serialized payload back into a JsonElement so
+            // Gson nests it as an object, not as a quoted JSON string.
+            if (e.payloadJson != null) {
+                obj["payload"] = JsonParser.parseString(e.payloadJson)
+            }
+            obj
+        }
         val payload = mapOf(
             "client_id" to clientId,
             "platform" to "android",
             "app_version" to BuildConfig.VERSION_NAME,
-            "events" to events.map {
-                mapOf(
-                    "type" to it.type,
-                    "target_type" to it.targetType,
-                    "target_id" to it.targetId,
-                )
-            },
+            "events" to eventList,
         )
-        // Use a local Gson if Shaft.sGson isn't ready yet (tests, very early
-        // boot). Identical configuration is fine for this payload.
-        val json = (Shaft.sGson ?: Gson()).toJson(payload)
+        val json = gson.toJson(payload)
         val sig = hmacSha256Hex(json, BuildConfig.SHAFT_EVENTS_HMAC)
+        val withPayload = events.count { it.payloadJson != null }
         Timber.tag(TAG).d(
-            "POST batch=%d bytes=%d sig=%s..%s",
-            events.size, json.length, sig.take(8), sig.takeLast(4),
+            "POST batch=%d (with-payload=%d) bytes=%d sig=%s..%s",
+            events.size, withPayload, json.length, sig.take(8), sig.takeLast(4),
         )
         val resp = ShaftEventsClient.api.batch(
             sig,
             json.toRequestBody("application/json".toMediaType()),
         )
         Timber.tag(TAG).i(
-            "response accepted=%d deduped=%d total=%d (sent=%d, queueAfter=%d)",
-            resp.accepted, resp.deduped, resp.total, events.size, queue.size,
+            "response accepted=%d deduped=%d total=%d meta_inserted=%d meta_skipped=%d (queueAfter=%d)",
+            resp.accepted, resp.deduped, resp.total,
+            resp.meta_inserted ?: 0, resp.meta_skipped ?: 0, queue.size,
         )
     }
 

--- a/app/src/main/java/ceui/pixiv/events/ShaftEventsApi.kt
+++ b/app/src/main/java/ceui/pixiv/events/ShaftEventsApi.kt
@@ -34,7 +34,9 @@ interface ShaftEventsApi {
 data class EventBatchResponse(
     val accepted: Int,
     val deduped: Int,
-    val total: Int
+    val total: Int,
+    val meta_inserted: Int? = null,
+    val meta_skipped: Int? = null,
 )
 
 object ShaftEventsClient {

--- a/app/src/main/java/ceui/pixiv/ui/common/PixivFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/PixivFragment.kt
@@ -138,7 +138,7 @@ open class PixivFragment(layoutId: Int) : Fragment(layoutId),
                         )
                     )
                     Common.showToast(getString(R.string.cancel_like_illust))
-                    EventReporter.report(EventReporter.Type.UNBOOKMARK, targetType, illustId)
+                    EventReporter.report(EventReporter.Type.UNBOOKMARK, targetType, illustId, illust)
                 } else {
                     Client.appApi.postBookmark(illustId)
                     RateAppManager.onUserEngaged()
@@ -149,7 +149,7 @@ open class PixivFragment(layoutId: Int) : Fragment(layoutId),
                         )
                     )
                     Common.showToast(getString(R.string.like_novel_success_public))
-                    EventReporter.report(EventReporter.Type.BOOKMARK, targetType, illustId)
+                    EventReporter.report(EventReporter.Type.BOOKMARK, targetType, illustId, illust)
                 }
             }
         }
@@ -169,7 +169,7 @@ open class PixivFragment(layoutId: Int) : Fragment(layoutId),
                         )
                     )
                     Common.showToast(getString(R.string.cancel_like_illust))
-                    EventReporter.report(EventReporter.Type.UNBOOKMARK, EventReporter.Target.NOVEL, novelId)
+                    EventReporter.report(EventReporter.Type.UNBOOKMARK, EventReporter.Target.NOVEL, novelId, novel)
                 } else {
                     Client.appApi.addNovelBookmark(novelId, Params.TYPE_PUBLIC)
                     RateAppManager.onUserEngaged()
@@ -180,7 +180,7 @@ open class PixivFragment(layoutId: Int) : Fragment(layoutId),
                         )
                     )
                     Common.showToast(getString(R.string.like_novel_success_public))
-                    EventReporter.report(EventReporter.Type.BOOKMARK, EventReporter.Target.NOVEL, novelId)
+                    EventReporter.report(EventReporter.Type.BOOKMARK, EventReporter.Target.NOVEL, novelId, novel)
                 }
             }
         }


### PR DESCRIPTION
## Why

Trending 接口现在只能返回 \`{ target_id, score }\`，前端要展示榜单得 50× \`getIllust()\` 反查详情，慢且容易撞 Pixiv 限流。

让收藏/下载/关注的人**首次接触某个作品时把 IllustsBean 一起上报**，server 用 INSERT OR IGNORE 写入 \`illust_meta\` 表。后续 trending 返回直接带 \`title / user / thumb_url\`，前端一次出图。

## What

- \`EventReporter.report(...)\` 加可选第 4 参数 \`payload: Any?\`；\`@JvmOverloads\` 让 Java 老代码不用改签名
- \`reportWithRawJson(...)\` 给 \`DownloadQueueDao\` 用，直接传 \`illustGson\` 字符串避免 Gson 二次序列化
- payload 在 IO 线程序列化，存进 \`EventEntry.payloadJson\` 字符串；重排队时不重复序列化
- 单 payload 上限 200 KiB（client 端比 server 256 KiB 小一档），超限只丢 payload 不丢 event
- 埋点透传：4 处 PixivOperate (illust + novel × 收藏/取消) + 4 处 PixivFragment + 1 处 DownloadQueueDao

## Server side

配套 server PR (commit \`bd9f23c\` on \`SoxiaLiSA/shaft-api-v2\`)：
- \`illust_meta\` + \`user_meta\` 两张表，PK 唯一约束
- \`POST /api/v1/events/batch\` 接受 \`events[].payload\`
- \`/api/v1/trending/works\` + \`/admin/api/recent\` LEFT JOIN meta，返回 \`{ ..., meta: { title, user_name, thumb_url } }\`
- batch body limit 64 KiB → 2 MiB 装得下 50 个首次 payload

## Test plan

- [x] \`./gradlew :app:assembleGithubDebug\` 通过
- [x] server 本地端到端：第 1 次 POST \`meta_inserted=1\`，第 2 次同 id \`deduped=1, meta_skipped=1\`
- [x] \`/admin/api/recent\` 返回 nested meta
- [x] \`/admin/api/top-works\` 返回 nested meta
- [ ] 装机后真实收藏一张图 → admin 看到 thumb_url

🤖 Generated with [Claude Code](https://claude.com/claude-code)