### PR TITLE
全新的图片双击缩放

### DIFF
--- a/app/src/main/java/ceui/lisa/fragments/FragmentImageDetail.kt
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentImageDetail.kt
@@ -43,7 +43,11 @@ class FragmentImageDetail : BaseFragment<FragmentImageDetailBinding?>() {
     private var saveName: String? = null
     private val viewModel by viewModels<ToggleToolnarViewModel>(ownerProducer = { requireActivity() })
     private val translationViewModel by viewModels<ImageTranslationViewModel>(ownerProducer = { requireActivity() })
-
+    private var isAnimated: Boolean = false
+    private var isScaleMax: Boolean = false
+    private var savedScale: Float? = null
+    private var zoomedToMax: Boolean = false
+    private var pendingGestureCheck: Boolean = false
     // 不再放进 arguments / savedInstanceState，避免每个 Fragment 重复持久化 80KB IllustsBean
     // 导致 TransactionTooLargeException。统一向 ImageDetailActivity 取。
     private val mIllustsBean: IllustsBean?
@@ -55,42 +59,184 @@ class FragmentImageDetail : BaseFragment<FragmentImageDetailBinding?>() {
     private val gestureDetector by lazy {
         GestureDetector(requireContext(), object : GestureDetector.SimpleOnGestureListener() {
             override fun onDoubleTap(e: MotionEvent): Boolean {
+                if (isAnimated) return true
+                isAnimated = true
                 val zoomable = baseBind.image.zoomable
                 val contentPoint = zoomable.touchPointToContentPointF(OffsetCompat(e.x, e.y))
-                if (viewModel.isFullscreenMode.value == false) {
-                    viewModel.toggleFullscreen()
-                }
                 viewLifecycleOwner.lifecycleScope.launch {
-                    zoomable.scaleBy(
-                        addScale = CUSTOM_ZOOM_ADD_SCALE,
-                        centroidContentPointF = contentPoint,
-                        animated = true
-                    )
-                    val afterScale = zoomable.transformState.value.scaleX
-                    val maxScale = zoomable.maxScaleState.value
-                    if (afterScale >= maxScale - MAX_SCALE_EPSILON) {
-                        Toast.makeText(
-                            requireContext(),
-                            R.string.double_tap_zoom_max_reached,
-                            Toast.LENGTH_SHORT
-                        ).show()
+                    //三级智能推测
+                    if (Shaft.sSettings.isUseThreeLevelZoo) {
+                        val currentScale = zoomable.transformState.value.scaleX
+                        val minScale = zoomable.minScaleState.value
+                        val maxScale = zoomable.maxScaleState.value
+                        val targetScale = currentScale * Shaft.sSettings.customZoomAddScale
+
+                        when {
+                            // ① 初始记录
+                            savedScale == null -> {
+                                if (viewModel.isFullscreenMode.value == false) {
+                                    viewModel.toggleFullscreen()
+                                }
+                                zoomable.scale(
+                                    targetScale = targetScale,
+                                    centroidContentPointF = contentPoint,
+                                    animated = true
+                                )
+                                savedScale = targetScale
+                                zoomedToMax = false
+                                pendingGestureCheck = false
+                            }
+
+                            // ② 处于待定期：上次从最大缩回了中间，现在根据手动缩放决定
+                            pendingGestureCheck -> {
+                                val saved = savedScale!!
+                                if (currentScale > saved) {
+                                    if (viewModel.isFullscreenMode.value == false) {
+                                        viewModel.toggleFullscreen()
+                                    }
+                                    // 用户手动放大了 → 放大到最大
+                                    zoomable.scale(
+                                        targetScale = maxScale,
+                                        centroidContentPointF = contentPoint,
+                                        animated = true
+                                    )
+                                    zoomedToMax = true
+                                } else {
+                                    if (viewModel.isFullscreenMode.value == false) {
+                                        viewModel.toggleFullscreen()
+                                    }
+                                    // 用户没放大或缩得更小 → 直接缩到最小并重置
+                                    zoomable.scale(
+                                        targetScale = minScale,
+                                        centroidContentPointF = contentPoint,
+                                        animated = true
+                                    )
+                                    savedScale = null
+                                    zoomedToMax = false
+                                }
+                                pendingGestureCheck = false
+                            }
+
+                            // ③ 还没到最大，且当前缩放 ≥ 记录的中间值 → 放大到最大
+                            !zoomedToMax && currentScale >= savedScale!! -> {
+                                if (viewModel.isFullscreenMode.value == false) {
+                                    viewModel.toggleFullscreen()
+                                }
+                                zoomable.scale(
+                                    targetScale = maxScale,
+                                    centroidContentPointF = contentPoint,
+                                    animated = true
+                                )
+                                zoomedToMax = true
+                            }
+
+                            // ④ 其余情况：缩回逻辑
+                            else -> {
+                                val saved = savedScale!!
+                                when {
+                                    // 等于最大，或介于中间和最大之间 → 缩回中间，并开启待定期
+                                    currentScale == maxScale || (currentScale < maxScale && currentScale > saved) -> {
+                                        if (viewModel.isFullscreenMode.value == false) {
+                                            viewModel.toggleFullscreen()
+                                        }
+                                        zoomable.scale(
+                                            targetScale = saved,
+                                            centroidContentPointF = contentPoint,
+                                            animated = true
+                                        )
+                                        zoomedToMax = false
+                                        pendingGestureCheck = true   // 等待用户手势
+                                        // savedScale 不变
+                                    }
+                                    // 当前缩放 ≤ 中间 → 缩回最小，完全重置
+                                    else -> {
+                                        if (viewModel.isFullscreenMode.value == true) {
+                                            viewModel.toggleFullscreen()
+                                        }
+                                        zoomable.scale(
+                                            targetScale = minScale,
+                                            centroidContentPointF = contentPoint,
+                                            animated = true
+                                        )
+                                        savedScale = null
+                                        zoomedToMax = false
+                                        pendingGestureCheck = false
+                                    }
+                                }
+                            }
+                        }
+
+                        isAnimated = false
+
+
+                    } else {
+                        if (isScaleMax) {
+                            if (viewModel.isFullscreenMode.value == true) {
+                                viewModel.toggleFullscreen()
+                            }
+                            val minScale = zoomable.minScaleState.value
+                            zoomable.scale(
+                                targetScale = minScale,
+                                centroidContentPointF = contentPoint,
+                                animated = true
+                            )
+                            isScaleMax = false
+                            isAnimated = false
+                        } else {
+                            if (viewModel.isFullscreenMode.value == false) {
+                                viewModel.toggleFullscreen()
+                            }
+                            zoomable.scaleBy(
+                                addScale = Shaft.sSettings.customZoomAddScale,
+                                centroidContentPointF = contentPoint,
+                                animated = true
+                            )
+                            val afterScale = zoomable.transformState.value.scaleX
+                            val maxScale = zoomable.maxScaleState.value
+                            if (afterScale >= maxScale - MAX_SCALE_EPSILON) {
+                                if (Shaft.sSettings.isUseCustomLongPressReset) {
+                                    Toast.makeText(
+                                        requireContext(),
+                                        R.string.double_tap_zoom_max_reached,
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                    if (viewModel.isFullscreenMode.value == true) {
+                                        viewModel.toggleFullscreen()
+                                    }
+                                } else {
+                                    isScaleMax = true
+                                    Toast.makeText(
+                                        requireContext(),
+                                        R.string.double_tap_zoom_max_reached2,
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                }
+                            }
+                    }
+                        isAnimated = false
                     }
                 }
                 return true
             }
 
             override fun onLongPress(e: MotionEvent) {
-                val zoomable = baseBind.image.zoomable
-                val contentPoint = zoomable.touchPointToContentPointF(OffsetCompat(e.x, e.y))
-                if (viewModel.isFullscreenMode.value == true) {
-                    viewModel.toggleFullscreen()
-                }
-                viewLifecycleOwner.lifecycleScope.launch {
-                    zoomable.scale(
-                        targetScale = zoomable.minScaleState.value,
-                        centroidContentPointF = contentPoint,
-                        animated = true
-                    )
+                if (!isAnimated && Shaft.sSettings.isUseCustomLongPressReset) {
+                    val zoomable = baseBind.image.zoomable
+                    val contentPoint = zoomable.touchPointToContentPointF(OffsetCompat(e.x, e.y))
+                    if (viewModel.isFullscreenMode.value == true) {
+                        viewModel.toggleFullscreen()
+                    }
+                    viewLifecycleOwner.lifecycleScope.launch {
+                        zoomable.scale(
+                            targetScale = zoomable.minScaleState.value,
+                            centroidContentPointF = contentPoint,
+                            animated = true
+                        )
+                        isScaleMax = false
+                        savedScale = null
+                        zoomedToMax = false
+                        pendingGestureCheck = false
+                    }
                 }
             }
 
@@ -125,6 +271,7 @@ class FragmentImageDetail : BaseFragment<FragmentImageDetailBinding?>() {
             )
             // 单指交给 gestureDetector（双击/长按/单击），多指交回 ZoomImage（拖拽/双指缩放）
             baseBind.image.setOnTouchListener { v, event ->
+                //还是要阻止可能存在误触打断到动画的
                 if (event.pointerCount == 1) {
                     gestureDetector.onTouchEvent(event)
                 } else {
@@ -224,7 +371,7 @@ class FragmentImageDetail : BaseFragment<FragmentImageDetailBinding?>() {
 
     companion object {
         // PR#900 自定义双击放大：每次乘 1.8f；浮点误差判最大倍数容差 0.01f
-        private const val CUSTOM_ZOOM_ADD_SCALE = 1.8f
+        //private const val CUSTOM_ZOOM_ADD_SCALE = 1.8f
         private const val MAX_SCALE_EPSILON = 0.01f
 
         // IllustsBean 由 ImageDetailActivity 持有，Fragment 运行时读取，避免放进 Bundle

--- a/app/src/main/java/ceui/lisa/fragments/FragmentSettings.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSettings.java
@@ -1,18 +1,23 @@
 package ceui.lisa.fragments;
 
 import android.Manifest;
+import android.annotation.SuppressLint;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
 import android.text.TextUtils;
 import android.os.Bundle;
 import android.transition.AutoTransition;
 import android.transition.TransitionManager;
 import android.view.LayoutInflater;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.CompoundButton;
+import android.widget.ImageButton;
 import android.widget.TextView;
 
 import androidx.databinding.DataBindingUtil;
@@ -1390,19 +1395,56 @@ public class FragmentSettings extends SwipeFragment<FragmentSettingsBinding> {
             });
 
             //插画二级详情：自定义双击放大模式（PR#900）
+            baseBind.useCustomLongPressResetGroup.setVisibility(
+                    Shaft.sSettings.isUseCustomDoubleTapZoom() ? View.VISIBLE : View.GONE);
             baseBind.useCustomDoubleTapZoom.setChecked(Shaft.sSettings.isUseCustomDoubleTapZoom());
             baseBind.useCustomDoubleTapZoom.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
                 @Override
                 public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                    boolean changed = isChecked != Shaft.sSettings.isUseCustomDoubleTapZoom();
                     Shaft.sSettings.setUseCustomDoubleTapZoom(isChecked);
                     Common.showToast(getString(R.string.string_428));
                     Local.setSettings(Shaft.sSettings);
+                    ViewGroup CustomLongPressGroup = (ViewGroup) baseBind.useCustomLongPressResetGroup.getParent();
+                    if (CustomLongPressGroup != null) {
+                        TransitionManager.beginDelayedTransition(CustomLongPressGroup, new AutoTransition());
+                    }
+                    baseBind.useCustomLongPressResetGroup.setVisibility(isChecked ? View.VISIBLE : View.GONE);
+                    if (changed) {
+                        Retro.refreshAppApi();
+                        Client.INSTANCE.reset();
+                    }
                 }
             });
+
             baseBind.useCustomDoubleTapZoomRela.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
                     baseBind.useCustomDoubleTapZoom.performClick();
+                }
+            });
+
+            // 初始化缩放增量数值调节
+            setupCustomZoomScaleAdjust();
+
+            //长按复位
+            baseBind.useCustomLongPressReset.setChecked(Shaft.sSettings.isUseCustomLongPressReset());
+            baseBind.useCustomLongPressReset.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                @Override
+                public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                    Shaft.sSettings.setUseCustomLongPressReset(isChecked);
+                    Common.showToast(getString(R.string.string_428));
+                    Local.setSettings(Shaft.sSettings);
+                }
+            });
+
+            baseBind.useCustomThreeLevelZoom.setChecked(Shaft.sSettings.isUseThreeLevelZoo());
+            baseBind.useCustomThreeLevelZoom.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+                @Override
+                public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                    Shaft.sSettings.setUseThreeLevelZoo(isChecked);
+                    Common.showToast(getString(R.string.string_428));
+                    Local.setSettings(Shaft.sSettings);
                 }
             });
 
@@ -1626,6 +1668,126 @@ public class FragmentSettings extends SwipeFragment<FragmentSettingsBinding> {
                         }
                     });
         }
+    }
+
+    private void setupCustomZoomScaleAdjust() {
+        TextView scaleDisplay = baseBind.customZoomScaleDisplay;
+        ImageButton decreaseBtn = baseBind.customZoomScaleDecrease;
+        ImageButton increaseBtn = baseBind.customZoomScaleIncrease;
+
+        // 获取当前保存的缩放增量值
+        float currentScale = Shaft.sSettings.getCustomZoomAddScale();
+        if (currentScale < 1.1f || currentScale > 3.0f) {
+            currentScale = 1.8f; // 默认值
+            Shaft.sSettings.setCustomZoomAddScale(currentScale);
+        }
+
+        // 显示当前值
+        scaleDisplay.setText(String.format(Locale.US, "%.1f", currentScale));
+
+        // 减少按钮
+        decreaseBtn.setOnClickListener(v -> {
+            float scale = Shaft.sSettings.getCustomZoomAddScale();
+            if (scale > 1.1f) {
+                scale = Math.round((scale - 0.1f) * 10f) / 10f;
+                updateZoomScale(scale, scaleDisplay);
+            }
+        });
+
+        // 增加按钮
+        increaseBtn.setOnClickListener(v -> {
+            float scale = Shaft.sSettings.getCustomZoomAddScale();
+            if (scale < 3.0f) {
+                scale = Math.round((scale + 0.1f) * 10f) / 10f;
+                updateZoomScale(scale, scaleDisplay);
+            }
+        });
+
+        // 长按快速调节（可选）
+        setupLongPressAdjust(decreaseBtn, increaseBtn, scaleDisplay);
+    }
+
+    private void updateZoomScale(float newScale, TextView scaleDisplay) {
+        // 保存到 Shaft.sSettings
+        Shaft.sSettings.setCustomZoomAddScale(newScale);
+
+        // 更新显示
+        scaleDisplay.setText(String.format(Locale.US, "%.1f", newScale));
+
+        // 保存设置
+        Local.setSettings(Shaft.sSettings);
+    }
+
+    // 长按快速调节功能（可选）
+    private Handler autoAdjustHandler;
+    private Runnable autoAdjustRunnable;
+
+    @SuppressLint("ClickableViewAccessibility")
+    private void setupLongPressAdjust(ImageButton decreaseBtn,
+                                      ImageButton increaseBtn,
+                                      TextView scaleDisplay) {
+        decreaseBtn.setOnLongClickListener(v -> {
+            startAutoAdjust(scaleDisplay, false);
+            return true;
+        });
+
+        increaseBtn.setOnLongClickListener(v -> {
+            startAutoAdjust(scaleDisplay, true);
+            return true;
+        });
+
+        View.OnTouchListener stopAdjustListener = new View.OnTouchListener() {
+            @Override
+            public boolean onTouch(View v, MotionEvent event) {
+                if (event.getAction() == MotionEvent.ACTION_UP ||
+                        event.getAction() == MotionEvent.ACTION_CANCEL) {
+                    stopAutoAdjust();
+                }
+                return false;
+            }
+        };
+
+        decreaseBtn.setOnTouchListener(stopAdjustListener);
+        increaseBtn.setOnTouchListener(stopAdjustListener);
+    }
+
+    private void startAutoAdjust(TextView scaleDisplay, boolean isIncrease) {
+        stopAutoAdjust();
+
+        if (autoAdjustHandler == null) {
+            autoAdjustHandler = new Handler(Looper.getMainLooper());
+        }
+
+        autoAdjustRunnable = new Runnable() {
+            @Override
+            public void run() {
+                float scale = Shaft.sSettings.getCustomZoomAddScale();
+
+                if (isIncrease && scale < 3.0f) {
+                    scale = Math.round((scale + 0.1f) * 10f) / 10f;
+                    updateZoomScale(scale, scaleDisplay);
+                } else if (!isIncrease && scale > 1.1f) {
+                    scale = Math.round((scale - 0.1f) * 10f) / 10f;
+                    updateZoomScale(scale, scaleDisplay);
+                }
+
+                autoAdjustHandler.postDelayed(this, 100);
+            }
+        };
+
+        autoAdjustHandler.postDelayed(autoAdjustRunnable, 500);
+    }
+
+    private void stopAutoAdjust() {
+        if (autoAdjustHandler != null && autoAdjustRunnable != null) {
+            autoAdjustHandler.removeCallbacks(autoAdjustRunnable);
+        }
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        stopAutoAdjust();
     }
 
     @Override

--- a/app/src/main/java/ceui/lisa/utils/Settings.java
+++ b/app/src/main/java/ceui/lisa/utils/Settings.java
@@ -802,12 +802,34 @@ public class Settings {
     // 插画二级详情：双击放大模式（false=ZoomImage 默认双击缩放，true=自定义增量双击+长按归位 PR#900）
     private boolean useCustomDoubleTapZoom = false;
 
+    private float customZoomAddScale = 1.8f;
+
+    private boolean useCustomLongPressReset = false;
+
+    private boolean useThreeLevelZoo = false;
+
     public boolean isUseCustomDoubleTapZoom() {
         return useCustomDoubleTapZoom;
     }
 
+    public boolean isUseCustomLongPressReset() {
+        return useCustomLongPressReset;
+    }
+
+    public boolean isUseThreeLevelZoo() {
+        return useThreeLevelZoo;
+    }
+
     public void setUseCustomDoubleTapZoom(boolean useCustomDoubleTapZoom) {
         this.useCustomDoubleTapZoom = useCustomDoubleTapZoom;
+    }
+
+    public void setUseCustomLongPressReset(boolean useCustomLongPressReset) {
+        this.useCustomLongPressReset = useCustomLongPressReset;
+    }
+
+    public void setUseThreeLevelZoo(boolean useThreeLevelZoo) {
+        this.useThreeLevelZoo = useThreeLevelZoo;
     }
 
     // 插画V3详情页：下载按钮是否在左（true=左下载右收藏，false=左收藏右下载）
@@ -894,5 +916,13 @@ public class Settings {
 
     public void setShowPlazaEntry(boolean showPlazaEntry) {
         this.showPlazaEntry = showPlazaEntry;
+    }
+
+    public float getCustomZoomAddScale() {
+        return customZoomAddScale;
+    }
+
+    public void setCustomZoomAddScale(float customZoomAddScale) {
+        this.customZoomAddScale = customZoomAddScale;
     }
 }

--- a/app/src/main/res/layout/fragment_settings.xml
+++ b/app/src/main/res/layout/fragment_settings.xml
@@ -1351,6 +1351,140 @@
 
                         <View style="@style/half_divider" />
 
+                        <LinearLayout
+                            android:id="@+id/use_custom_long_press_reset_group"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="vertical"
+                            android:visibility="gone">
+
+                            <!-- 新增：数值调节选项 -->
+                            <RelativeLayout
+                                android:id="@+id/custom_zoom_scale_rela"
+                                style="@style/ripple_rela">
+
+                                <TextView
+                                    android:id="@+id/custom_zoom_scale_title"
+                                    style="@style/setting_text_left"
+                                    android:text="缩放增量值" />
+
+                                <TextView
+                                    android:id="@+id/custom_zoom_scale_title_link"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_below="@+id/custom_zoom_scale_title"
+                                    android:layout_marginStart="@dimen/sixteen_dp"
+                                    android:layout_marginBottom="@dimen/twelve_dp"
+                                    android:ellipsize="start"
+                                    android:singleLine="true"
+                                    android:text="默认1.8，数值不合理（过大或过小）会影响图片缩放体验"
+                                    android:textColor="?attr/colorPrimary"
+                                    android:textSize="12sp" />
+
+                                <LinearLayout
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_alignParentEnd="true"
+                                    android:layout_centerVertical="true"
+                                    android:layout_marginEnd="@dimen/sixteen_dp"
+                                    android:gravity="center_vertical"
+                                    android:orientation="horizontal">
+
+                                    <ImageButton
+                                        android:id="@+id/custom_zoom_scale_decrease"
+                                        android:layout_width="40dp"
+                                        android:layout_height="40dp"
+                                        android:background="?attr/selectableItemBackgroundBorderless"
+                                        android:src="@android:drawable/ic_media_previous"
+                                        android:contentDescription="减少缩放增量" />
+
+                                    <TextView
+                                        android:id="@+id/custom_zoom_scale_display"
+                                        android:layout_width="60dp"
+                                        android:layout_height="wrap_content"
+                                        android:gravity="center"
+                                        android:text="1.8"
+                                        android:textSize="18sp"
+                                        android:textStyle="bold"
+                                        android:textColor="?attr/colorPrimary" />
+
+                                    <ImageButton
+                                        android:id="@+id/custom_zoom_scale_increase"
+                                        android:layout_width="40dp"
+                                        android:layout_height="40dp"
+                                        android:background="?attr/selectableItemBackgroundBorderless"
+                                        android:src="@android:drawable/ic_media_next"
+                                        android:contentDescription="增加缩放增量" />
+
+                                </LinearLayout>
+
+                            </RelativeLayout>
+
+                            <!-- 新增：三级缩放开关 -->
+                            <RelativeLayout
+                                android:id="@+id/use_custom_three_level_zoom_rela"
+                                style="@style/ripple_rela">
+
+                                <TextView
+                                    android:id="@+id/use_custom_three_level_zoom_title"
+                                    style="@style/setting_text_left"
+                                    android:layout_marginBottom="@dimen/six_dp"
+                                    android:text="增量缩放改为三级智能缩放模式" />
+
+                                <TextView
+                                    android:id="@+id/three_level_zoom_link"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_below="@+id/use_custom_three_level_zoom_title"
+                                    android:layout_marginStart="@dimen/sixteen_dp"
+                                    android:layout_marginBottom="@dimen/twelve_dp"
+                                    android:ellipsize="start"
+                                    android:singleLine="true"
+                                    android:text="第二级的缩放大小与上面的缩放增量有联"
+                                    android:textColor="?attr/colorPrimary"
+                                    android:textSize="12sp" />
+
+                                <androidx.appcompat.widget.SwitchCompat
+                                    android:id="@+id/use_custom_three_level_zoom"
+                                    style="@style/setting_right_switch" />
+
+                            </RelativeLayout>
+
+                            <View style="@style/half_divider" />
+                            <!-- 原有的 use_custom_long_press_reset_rela -->
+                            <RelativeLayout
+                                android:id="@+id/use_custom_long_press_reset_rela"
+                                style="@style/ripple_rela">
+
+                                <TextView
+                                    android:id="@+id/use_custom_long_press_reset_title"
+                                    style="@style/setting_text_left"
+                                    android:layout_marginBottom="@dimen/six_dp"
+                                    android:text="@string/use_custom_long_press_reset" />
+
+                                <TextView
+                                    android:id="@+id/use_custom_long_press_reset_link"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_below="@+id/use_custom_long_press_reset_title"
+                                    android:layout_marginStart="@dimen/sixteen_dp"
+                                    android:layout_marginBottom="@dimen/twelve_dp"
+                                    android:ellipsize="start"
+                                    android:singleLine="true"
+                                    android:text="@string/use_custom_long_press_reset_link_text"
+                                    android:textColor="?attr/colorPrimary"
+                                    android:textSize="12sp" />
+
+                                <androidx.appcompat.widget.SwitchCompat
+                                    android:id="@+id/use_custom_long_press_reset"
+                                    style="@style/setting_right_switch" />
+
+                            </RelativeLayout>
+
+                        </LinearLayout>
+
+                        <View style="@style/half_divider" />
+
                         <RelativeLayout
                             android:id="@+id/is_firebase_enable_rela"
                             style="@style/ripple_rela">
@@ -1378,6 +1512,7 @@
                             <TextView
                                 android:id="@+id/default_upscale_model"
                                 style="@style/setting_right_arrow"
+                                android:layout_width="wrap_content"
                                 android:text="@string/string_not_set" />
 
                         </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2086,6 +2086,9 @@
     <string name="tag_popular_export_running">导出中…</string>
     <string name="tag_popular_export_need_tag">请先输入 tag 名称</string>
     <!-- 插画二级详情：自定义双击放大模式（PR#900） -->
-    <string name="use_custom_double_tap_zoom">自定义双击放大（长按复原）</string>
+    <string name="use_custom_double_tap_zoom">（新）插画二级大图使用双击增量/三级放大模式</string>
+    <string name="use_custom_long_press_reset">启用长按复原（推荐启用）</string>
+    <string name="use_custom_long_press_reset_link_text">放至最大后不会循环至最小</string>
     <string name="double_tap_zoom_max_reached">已至最大，长按复原</string>
+    <string name="double_tap_zoom_max_reached2">已至最大，再次双击将缩至最小</string>
 </resources>


### PR DESCRIPTION
### 主要功能

**新增「增量无限挡位缩放」**
**新增「智能三级缩放」**

彻底重构了图片详情页的双击缩放逻辑，从原来的固定倍率/有限挡位，升级为**支持用户自定义增量倍率的无限挡位或三级智能缩放**，大幅提升了浏览高清插画时的双击缩放体验。

### 核心改进

1. **智能三级缩放状态管理**
   - 首次双击：按增量倍率以乘法得出「中间挡位」
   - 继续双击：推断用户意图决策切换「最小挡位」、「中间挡位」和「最大缩放」
   - 结合长按重置，方便图片的快速缩回归「最小挡位」

2. **完全可自定义**
   - 新增设置项：**是否启用三级智能缩放**（`isUseThreeLevelZoom`）
   - 新增设置项：**自定义每次双击的增量倍率**（`customZoomAddScale`，默认 1.8x，可自行设定）
   - 支持 1.1x到3.0x 自由调节倍率

3. **更好的用户反馈**
   - 达到最大缩放时弹出提示（新增两条字符串）
   - 长按可快速重置到原始大小（同时支持设置是否启用自定义长按重置）

### 修改文件

- **`FragmentImageDetail.kt`**（核心修改）
  - 大幅重构双击手势处理逻辑（增加约 140+ 行）
  - 引入 `savedScale`、`zoomedToMax`、`pendingGestureCheck` 等状态变量
  - 智能三级缩放实现复杂的四种状态分支判断决策

- **`FragmentSettings.java` + `fragment_settings.xml`**（后续可将「增量无限挡位缩放」与「智能三级缩放」拆开，两者互斥）
  - 添加两个新的设置开关/输入项

- **`Settings.java`**
  - 新增 `isUseThreeLevelZoom`、`customZoomAddScale`、`isUseCustomLongPressReset` 配置

- **`strings.xml`**
  - 新增缩放相关提示文案（仍需完善）：
    - `double_tap_zoom_max_reached`
    - `double_tap_zoom_max_reached2`

### 比ZoomImage库的三级缩放更好

- ZoomImage 库的三级缩放固定且僵硬，「智能三级缩放」实现双指缩放后的双击可按用户意图放大或缩小
- 没有calculateNextStepScaleWithRatio，也就没有跳档
- 「智能三级缩放」没有maxScale限制，可1:1放大到图片原始最大