### PR TITLE
reader_loading可能被遮挡导致加载动画消失。万字小说，加载动画会提前在分页完成前隐藏，现在分页完成后再隐藏。

### DIFF
--- a/app/src/main/java/ceui/pixiv/ui/novel/reader/NovelReaderV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/reader/NovelReaderV3Fragment.kt
@@ -389,13 +389,17 @@ class NovelReaderV3Fragment : Fragment(R.layout.fragment_novel_reader_v3),
                 loadWatchlistStateForSeries(seriesId)
                 pushStyleAndGeometryIfReady()
                 rebindScrollViewIfActive()
+                // 纵向立即隐藏；分页模式等 pagination 到来
+                if (ReaderSettings.readingDirection == ReadingDirection.Vertical) {
+                    binding.readerLoading.visibility = View.GONE
+                }
             }
         }
 
         // 同时观察 pagination，当它更新时重新评估 loading 状态
         viewModel.pagination.observe(viewLifecycleOwner) { pag ->
-            // 如果当前是 Loaded 状态，且 pagination 不为 null，隐藏 loading
-            if (pag != null && viewModel.loadState.value is NovelReaderV3ViewModel.LoadState.Loaded) {
+            // 只有分页数据真正准备好时才隐藏
+            if (pag != null && pag.pages.isNotEmpty()) {
                 binding.readerLoading.visibility = View.GONE
             }
             // 原有的 paged 模式处理逻辑...
@@ -478,6 +482,9 @@ class NovelReaderV3Fragment : Fragment(R.layout.fragment_novel_reader_v3),
             // mode (page-x/y) and snaps to the current scroll fraction even
             // before the user touches the scroll view.
             sv.pushScrollProgressNow()
+            if (viewModel.loadState.value is NovelReaderV3ViewModel.LoadState.Loaded) {
+                binding.readerLoading.visibility = View.GONE
+            }
         } else {
             scrollReaderView?.let { sv ->
                 viewModel.onScrollPositionChanged(sv.currentCharIndex())
@@ -490,6 +497,10 @@ class NovelReaderV3Fragment : Fragment(R.layout.fragment_novel_reader_v3),
             // be suppressed without this reset.
             lastPushedSnapshot = null
             pushStyleAndGeometryIfReady()
+            // 切换时如果 pagination 为空，显示 loading
+            if (viewModel.pagination.value == null) {
+                binding.readerLoading.visibility = View.VISIBLE
+            }
         }
     }
 
@@ -566,6 +577,7 @@ class NovelReaderV3Fragment : Fragment(R.layout.fragment_novel_reader_v3),
         // currentChar == 0 (fresh entry, no saved progress) — otherwise the
         // scroll-listener wouldn't fire until the user first scrolls.
         sv.pushScrollProgressNow()
+        binding.readerLoading.visibility = View.GONE
     }
 
     private fun togglePixivBookmark() {

--- a/app/src/main/java/ceui/pixiv/ui/novel/reader/NovelReaderV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/reader/NovelReaderV3Fragment.kt
@@ -335,7 +335,7 @@ class NovelReaderV3Fragment : Fragment(R.layout.fragment_novel_reader_v3),
     // 同色 track 以保持与插画详情页进度环一致的配置。
     private fun applyLoadingTint(theme: ReaderTheme) {
         binding.readerLoading.setIndicatorColor(theme.accentColor)
-        binding.readerLoading.trackColor = ColorUtils.setAlphaComponent(theme.accentColor, 0x33)
+        //binding.readerLoading.trackColor = ColorUtils.setAlphaComponent(theme.accentColor, 0x33)
     }
 
     // ---- Observe ------------------------------------------------------------
@@ -369,12 +369,21 @@ class NovelReaderV3Fragment : Fragment(R.layout.fragment_novel_reader_v3),
         }
 
         viewModel.loadState.observe(viewLifecycleOwner) { state ->
-            binding.readerLoading.visibility = if (state is NovelReaderV3ViewModel.LoadState.Loading) View.VISIBLE else View.GONE
+            val isLoading = state is NovelReaderV3ViewModel.LoadState.Loading
+            val paginationReady = viewModel.pagination.value != null
+
+            // 当 Loaded 且 pagination 准备好时才隐藏 loading
+            val shouldShowLoading = isLoading ||
+                    (state is NovelReaderV3ViewModel.LoadState.Loaded && !paginationReady)
+
+            binding.readerLoading.visibility = if (shouldShowLoading) View.VISIBLE else View.GONE
             binding.readerError.visibility = if (state is NovelReaderV3ViewModel.LoadState.Error) View.VISIBLE else View.GONE
-            if (state is NovelReaderV3ViewModel.LoadState.Error) binding.readerError.text = state.message
+
+            if (state is NovelReaderV3ViewModel.LoadState.Error) {
+                binding.readerError.text = state.message
+            }
             if (state is NovelReaderV3ViewModel.LoadState.Loaded) {
                 tb.setTitle(state.novel?.title ?: state.webNovel.title.orEmpty())
-                // 系列按钮按当前小说是否归属系列动态显示。
                 val seriesId = state.novel?.series?.id
                 bb.setSeriesVisible(seriesId != null)
                 loadWatchlistStateForSeries(seriesId)
@@ -383,7 +392,13 @@ class NovelReaderV3Fragment : Fragment(R.layout.fragment_novel_reader_v3),
             }
         }
 
+        // 同时观察 pagination，当它更新时重新评估 loading 状态
         viewModel.pagination.observe(viewLifecycleOwner) { pag ->
+            // 如果当前是 Loaded 状态，且 pagination 不为 null，隐藏 loading
+            if (pag != null && viewModel.loadState.value is NovelReaderV3ViewModel.LoadState.Loaded) {
+                binding.readerLoading.visibility = View.GONE
+            }
+            // 原有的 paged 模式处理逻辑...
             if (pag == null) return@observe
             if (ReaderSettings.readingDirection == ReadingDirection.Vertical) return@observe
             rv.setStyle(pag.style, pag.geometry)

--- a/app/src/main/res/layout/fragment_novel_reader_v3.xml
+++ b/app/src/main/res/layout/fragment_novel_reader_v3.xml
@@ -35,23 +35,6 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom" />
 
-    <!-- 与插画一级/二级详情页的进度环样式统一(30dp/5dp 圆角 Material 环)。
-         阅读器加载章节内容无字节级进度,故用不确定模式;indicatorColor 在
-         applyLoadingTint() 里按当前阅读器主题着色,避免白底主题下不可见。 -->
-    <com.google.android.material.progressindicator.CircularProgressIndicator
-        android:id="@+id/reader_loading"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:indeterminate="true"
-        android:visibility="gone"
-        app:indicatorColor="@color/white"
-        app:indicatorSize="30dp"
-        app:trackColor="@color/voice_record_track_color"
-        app:trackCornerRadius="4dp"
-        app:trackThickness="5dp"
-        tools:visibility="visible" />
-
     <TextView
         android:id="@+id/reader_error"
         android:layout_width="match_parent"
@@ -65,4 +48,20 @@
         tools:text="加载失败"
         tools:visibility="visible" />
 
+    <!-- 与插画一级/二级详情页的进度环样式统一(30dp/5dp 圆角 Material 环)。
+     阅读器加载章节内容无字节级进度,故用不确定模式;indicatorColor 在
+     applyLoadingTint() 里按当前阅读器主题着色,避免白底主题下不可见。 -->
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/reader_loading"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:indeterminate="true"
+        android:visibility="gone"
+        app:indicatorColor="@color/white"
+        app:indicatorSize="30dp"
+        app:trackColor="@color/voice_record_track_color"
+        app:trackCornerRadius="4dp"
+        app:trackThickness="5dp"
+        tools:visibility="visible" />
 </FrameLayout>


### PR DESCRIPTION
依旧在V2361A测试符合预期
把 reader_loading 移到 XML 的最底部（reader_error 之后）
修改 NovelReaderV3Fragment.kt 的 observeReaderState 方法，把 reader_loading 的可见性同时关联到 loadState 和 pagination