### PR TITLE
修复不能有效备份/还原 设置 · 下载 中的下载路径 / 文件名、文件重复时、多图页码起始、下载类型限制

### DIFF
--- a/app/src/main/java/ceui/lisa/file/OutPut.kt
+++ b/app/src/main/java/ceui/lisa/file/OutPut.kt
@@ -58,7 +58,9 @@ object OutPut {
 
     @JvmStatic
     fun outPutBackupFile(context: Context, from: File, fileName: String) {
-        writeRaw(Bucket.Backup, "ShaftBackups/$fileName", "application/zip", from, R.string.save_backup_failed)
+        // 备份文件本身就是 JSON（Shaft-Backup.json），之前写成 application/zip 会让
+        // MediaStore 按 MIME 给文件补一个 .zip 后缀，看起来像压缩包实则不是（#949）。
+        writeRaw(Bucket.Backup, "ShaftBackups/$fileName", "application/json", from, R.string.save_backup_failed)
     }
 
     @JvmStatic

--- a/app/src/main/java/ceui/lisa/utils/BackupUtils.java
+++ b/app/src/main/java/ceui/lisa/utils/BackupUtils.java
@@ -111,6 +111,9 @@ public class BackupUtils {
         try {
             BackupEntity backupEntity = Shaft.sGson.fromJson(backupString, BackupEntity.class);
             // 下载配置自己吞掉所有异常：解析不了就保持本机现状，不影响其余数据还原。
+            // 必须排在 Local.setSettings 之前：本机若还没有 V3 配置，store 会用当前
+            // Settings 的 downloadWay / rootPathUri 兜底，先还原 Settings 就会把备份里
+            // 别的设备的 SAF 目录当成本机的兜底值。
             DownloadConfigBackup.restore(backupEntity.getDownloadConfigV3());
             Settings settings = backupEntity.getSettings();
             if (settings != null) {

--- a/app/src/main/java/ceui/lisa/utils/BackupUtils.java
+++ b/app/src/main/java/ceui/lisa/utils/BackupUtils.java
@@ -14,6 +14,9 @@ import ceui.lisa.database.SearchDao;
 import ceui.lisa.database.SearchEntity;
 import ceui.lisa.database.UserEntity;
 import ceui.lisa.feature.FeatureEntity;
+import ceui.pixiv.download.DownloadsRegistry;
+import ceui.pixiv.download.config.DownloadConfig;
+import ceui.pixiv.download.config.DownloadConfigJson;
 
 public class BackupUtils {
 
@@ -24,7 +27,7 @@ public class BackupUtils {
         private List<SearchEntity> searchEntityList;
         private List<UserEntity> userEntityList;
         private List<IllustHistoryEntity> illustHistoryEntityList;
-
+        private String downloadConfigJson;
         public Settings getSettings() {
             return settings;
         }
@@ -72,11 +75,28 @@ public class BackupUtils {
         public void setIllustHistoryEntityList(List<IllustHistoryEntity> illustHistoryEntityList) {
             this.illustHistoryEntityList = illustHistoryEntityList;
         }
+
+        public String getDownloadConfigJson() {
+            return downloadConfigJson;
+        }
+
+        public void setDownloadConfigJson(String downloadConfigJson) {
+            this.downloadConfigJson = downloadConfigJson;
+        }
     }
 
     public static String getBackupString(Context context, boolean backupViewHistory) {
         BackupEntity backupEntity = new BackupEntity();
         backupEntity.setSettings(Shaft.sSettings);
+        try {
+            ceui.pixiv.download.config.DownloadConfig config =
+                    DownloadsRegistry.getStore().loadOrFallback();
+            String configJson = ceui.pixiv.download.config.DownloadConfigJson.INSTANCE.toJson(config);
+            backupEntity.setDownloadConfigJson(configJson);
+        } catch (Exception e) {
+            e.printStackTrace();
+            // 备份失败不影响其他数据备份
+        }
         AppDatabase appDatabase = AppDatabase.getAppDatabase(context);
         backupEntity.setMuteEntityList(appDatabase.searchDao().getAllMuteEntities());
         backupEntity.setFeatureEntityList(appDatabase.downloadDao().getAllFeatureEntities());
@@ -91,6 +111,23 @@ public class BackupUtils {
     public static boolean restoreBackups(Context context, String backupString) {
         try {
             BackupEntity backupEntity = Shaft.sGson.fromJson(backupString, BackupEntity.class);
+            String configJson = backupEntity.getDownloadConfigJson();
+            if (configJson != null && !configJson.isEmpty()) {
+                try {
+                    DownloadConfig backupConfig = DownloadConfigJson.INSTANCE.fromJson(configJson);
+                    DownloadsRegistry.getStore().update(cfg -> {
+                        // 替换 perBucket、WifiOnly、PageIndexFrom1、从备份中的Defaults提取Overwrite覆盖当前Defaults中的Overwrite
+                        return cfg
+                                .withPerBucket(backupConfig.getPerBucket())
+                                .withWifiOnly(backupConfig.getWifiOnly())
+                                .withPageIndexFrom1(backupConfig.getPageIndexFrom1())
+                                .withDefaultsOverwrite(backupConfig.getDefaults());
+                    });
+                    DownloadsRegistry.invalidateBackends();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
             Settings settings = backupEntity.getSettings();
             if (settings != null) {
                 Local.setSettings(settings);

--- a/app/src/main/java/ceui/lisa/utils/BackupUtils.java
+++ b/app/src/main/java/ceui/lisa/utils/BackupUtils.java
@@ -14,9 +14,7 @@ import ceui.lisa.database.SearchDao;
 import ceui.lisa.database.SearchEntity;
 import ceui.lisa.database.UserEntity;
 import ceui.lisa.feature.FeatureEntity;
-import ceui.pixiv.download.DownloadsRegistry;
-import ceui.pixiv.download.config.DownloadConfig;
-import ceui.pixiv.download.config.DownloadConfigJson;
+import ceui.pixiv.download.config.DownloadConfigBackup;
 
 public class BackupUtils {
 
@@ -27,7 +25,14 @@ public class BackupUtils {
         private List<SearchEntity> searchEntityList;
         private List<UserEntity> userEntityList;
         private List<IllustHistoryEntity> illustHistoryEntityList;
-        private String downloadConfigJson;
+        /**
+         * 整份 V3 下载配置（下载路径 / 文件名 / 文件重复时 / 页码起始 / 仅 WiFi）序列化成的
+         * JSON 字符串。这里存字符串而不是嵌套对象，是因为 {@link Shaft#sGson} 没有注册
+         * StorageChoice 的 sealed 适配器，只有 DownloadConfigJson 那份 Gson 能正确读写；
+         * 字段名与云同步 payload 的 {@code downloadConfigV3} 保持一致，两边可互相导入。
+         */
+        private String downloadConfigV3;
+
         public Settings getSettings() {
             return settings;
         }
@@ -76,27 +81,21 @@ public class BackupUtils {
             this.illustHistoryEntityList = illustHistoryEntityList;
         }
 
-        public String getDownloadConfigJson() {
-            return downloadConfigJson;
+        public String getDownloadConfigV3() {
+            return downloadConfigV3;
         }
 
-        public void setDownloadConfigJson(String downloadConfigJson) {
-            this.downloadConfigJson = downloadConfigJson;
+        public void setDownloadConfigV3(String downloadConfigV3) {
+            this.downloadConfigV3 = downloadConfigV3;
         }
     }
 
     public static String getBackupString(Context context, boolean backupViewHistory) {
         BackupEntity backupEntity = new BackupEntity();
         backupEntity.setSettings(Shaft.sSettings);
-        try {
-            ceui.pixiv.download.config.DownloadConfig config =
-                    DownloadsRegistry.getStore().loadOrFallback();
-            String configJson = ceui.pixiv.download.config.DownloadConfigJson.INSTANCE.toJson(config);
-            backupEntity.setDownloadConfigJson(configJson);
-        } catch (Exception e) {
-            e.printStackTrace();
-            // 备份失败不影响其他数据备份
-        }
+        // 「设置 · 下载」里的下载路径 / 文件名等已经搬到 V3 下载配置，不在 Settings 里，
+        // 得单独打包（#949）。
+        backupEntity.setDownloadConfigV3(DownloadConfigBackup.export());
         AppDatabase appDatabase = AppDatabase.getAppDatabase(context);
         backupEntity.setMuteEntityList(appDatabase.searchDao().getAllMuteEntities());
         backupEntity.setFeatureEntityList(appDatabase.downloadDao().getAllFeatureEntities());
@@ -111,23 +110,8 @@ public class BackupUtils {
     public static boolean restoreBackups(Context context, String backupString) {
         try {
             BackupEntity backupEntity = Shaft.sGson.fromJson(backupString, BackupEntity.class);
-            String configJson = backupEntity.getDownloadConfigJson();
-            if (configJson != null && !configJson.isEmpty()) {
-                try {
-                    DownloadConfig backupConfig = DownloadConfigJson.INSTANCE.fromJson(configJson);
-                    DownloadsRegistry.getStore().update(cfg -> {
-                        // 替换 perBucket、WifiOnly、PageIndexFrom1、从备份中的Defaults提取Overwrite覆盖当前Defaults中的Overwrite
-                        return cfg
-                                .withPerBucket(backupConfig.getPerBucket())
-                                .withWifiOnly(backupConfig.getWifiOnly())
-                                .withPageIndexFrom1(backupConfig.getPageIndexFrom1())
-                                .withDefaultsOverwrite(backupConfig.getDefaults());
-                    });
-                    DownloadsRegistry.invalidateBackends();
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
+            // 下载配置自己吞掉所有异常：解析不了就保持本机现状，不影响其余数据还原。
+            DownloadConfigBackup.restore(backupEntity.getDownloadConfigV3());
             Settings settings = backupEntity.getSettings();
             if (settings != null) {
                 Local.setSettings(settings);

--- a/app/src/main/java/ceui/loxia/MoonSync.kt
+++ b/app/src/main/java/ceui/loxia/MoonSync.kt
@@ -9,9 +9,7 @@ import ceui.lisa.utils.BackupUtils
 import ceui.lisa.utils.Common
 import ceui.lisa.utils.Local
 import ceui.pixiv.download.DownloadsRegistry
-import ceui.pixiv.download.config.BucketConfig
-import ceui.pixiv.download.config.DownloadConfig
-import ceui.pixiv.download.config.DownloadConfigJson
+import ceui.pixiv.download.config.DownloadConfigBackup
 import com.qmuiteam.qmui.skin.QMUISkinManager
 import com.qmuiteam.qmui.widget.dialog.QMUIDialog
 import com.qmuiteam.qmui.widget.dialog.QMUIDialogAction
@@ -173,15 +171,16 @@ object MoonSync {
                     entity.settings = Shaft.sSettings
                     val mutes = AppDatabase.getAppDatabase(activity).searchDao().allMuteEntities
                     entity.muteEntityList = mutes
-                    val obj = Shaft.sGson.toJsonTree(entity).asJsonObject
+                    // downloadConfigV3 现在是 BackupEntity 自己的字段(和设置页导出的
+                    // Shaft-Backup.json 同一份格式),不用再往 envelope 上手动挂。
                     val cfg = DownloadsRegistry.store.loadOrFallback()
-                    val v3Json = DownloadConfigJson.toJson(cfg)
-                    obj.addProperty("downloadConfigV3", v3Json)
+                    entity.downloadConfigV3 = DownloadConfigBackup.export()
+                    val obj = Shaft.sGson.toJsonTree(entity).asJsonObject
 
                     Timber.tag(TAG).d(
                         "[upload] packed: muteCount=%d v3Size=%d perBucket=%d wifiOnly=%b pageFrom1=%b",
                         mutes.size,
-                        v3Json.length,
+                        entity.downloadConfigV3.length,
                         cfg.perBucket.size,
                         cfg.wifiOnly,
                         cfg.pageIndexFrom1,
@@ -319,9 +318,9 @@ object MoonSync {
 
     /**
      * 把云端 payload 应用回本地:
-     * - BackupEntity 部分(settings + muteEntityList)走 [BackupUtils.restoreBackups]
-     * - 如果 envelope 里带了 `downloadConfigV3`,只 merge 模板/策略,storage 保持本地
-     *   (SAF treeUri 是设备绑定的,跨设备无效)
+     * - BackupEntity 部分(settings + muteEntityList + downloadConfigV3)走
+     *   [BackupUtils.restoreBackups];下载配置的 merge 语义见 [DownloadConfigBackup]
+     *   (只 merge 模板/策略,本机用不了的 SAF treeUri 不会被盖上来)
      * - 最后把当前 uid 的 applied version 设为本次 cloud.version
      */
     private suspend fun applyCloudPayload(
@@ -344,70 +343,9 @@ object MoonSync {
         Timber.tag(TAG).i("[apply] BackupUtils.restoreBackups → %b", ok)
         if (!ok) return@withContext false
 
-        // V3 下载配置(可选)
-        val v3Elem = payloadObj.get("downloadConfigV3")
-        if (v3Elem == null || v3Elem.isJsonNull) {
-            Timber.tag(TAG).d("[apply] no downloadConfigV3 in payload (legacy upload)")
-        } else {
-            val v3Raw = v3Elem.asString
-            Timber.tag(TAG).d("[apply] downloadConfigV3 present (%d bytes)", v3Raw.length)
-            val cloudCfg = try {
-                DownloadConfigJson.fromJson(v3Raw)
-            } catch (t: Throwable) {
-                Timber.tag(TAG).w(t, "[apply] downloadConfigV3 parse failed; skipping")
-                null
-            }
-            if (cloudCfg != null) {
-                DownloadsRegistry.store.update { local ->
-                    val merged = mergeDownloadConfig(local, cloudCfg)
-                    Timber.tag(TAG).i(
-                        "[apply] DC3 merged: defaults.template '%s' → '%s', overwrite %s → %s, perBucket %d → %d",
-                        local.defaults.template,
-                        merged.defaults.template,
-                        local.defaults.overwrite,
-                        merged.defaults.overwrite,
-                        local.perBucket.size,
-                        merged.perBucket.size,
-                    )
-                    merged
-                }
-                DownloadsRegistry.invalidateBackends()
-                Timber.tag(TAG).d("[apply] backends invalidated")
-            }
-        }
-
         saveLocalAppliedVersion(uid, cloud.version)
         Timber.tag(TAG).i("[apply] done; applied[uid=%d]=%d", uid, cloud.version)
         true
-    }
-
-    /**
-     * Merge cloud DownloadConfig into local: preserve local storage (SAF
-     * treeUri is device-bound), take cloud's templates / overwrite policy /
-     * wifiOnly / pageIndexFrom1 / padPageNumber.
-     */
-    private fun mergeDownloadConfig(local: DownloadConfig, cloud: DownloadConfig): DownloadConfig {
-        val mergedDefaults = local.defaults.copy(
-            template = cloud.defaults.template,
-            overwrite = cloud.defaults.overwrite,
-            // storage 保持本地不动
-        )
-        val mergedPerBucket = local.perBucket.toMutableMap()
-        for ((bucket, cloudCfg) in cloud.perBucket) {
-            val localCfg = mergedPerBucket[bucket]
-            mergedPerBucket[bucket] = BucketConfig(
-                template = cloudCfg.template ?: localCfg?.template,
-                storage = localCfg?.storage,    // null → fallback 到 defaults.storage
-                overwrite = cloudCfg.overwrite ?: localCfg?.overwrite,
-            )
-        }
-        return local.copy(
-            wifiOnly = cloud.wifiOnly,
-            pageIndexFrom1 = cloud.pageIndexFrom1,
-            padPageNumber = cloud.padPageNumber,
-            defaults = mergedDefaults,
-            perBucket = mergedPerBucket,
-        )
     }
 
     private fun prettyTime(epochMs: Long): String =

--- a/app/src/main/java/ceui/loxia/MoonSync.kt
+++ b/app/src/main/java/ceui/loxia/MoonSync.kt
@@ -174,7 +174,7 @@ object MoonSync {
                     // downloadConfigV3 现在是 BackupEntity 自己的字段(和设置页导出的
                     // Shaft-Backup.json 同一份格式),不用再往 envelope 上手动挂。
                     val cfg = DownloadsRegistry.store.loadOrFallback()
-                    entity.downloadConfigV3 = DownloadConfigBackup.export()
+                    entity.downloadConfigV3 = DownloadConfigBackup.export(cfg)
                     val obj = Shaft.sGson.toJsonTree(entity).asJsonObject
 
                     Timber.tag(TAG).d(

--- a/app/src/main/java/ceui/pixiv/download/config/DownloadConfig.kt
+++ b/app/src/main/java/ceui/pixiv/download/config/DownloadConfig.kt
@@ -1,6 +1,5 @@
 package ceui.pixiv.download.config
 
-import ceui.pixiv.download.DownloadsRegistry.store
 import ceui.pixiv.download.model.Bucket
 import ceui.pixiv.download.template.PageNumbering
 
@@ -29,41 +28,10 @@ data class DownloadConfig(
     /** true = zero-pad `{page}` so multi-page works sort correctly in galleries (#721). */
     val padPageNumber: Boolean = false,
 ) {
-    // 为 Java 提供的便捷方法
-    @JvmOverloads
-    fun withPerBucket(
-        newPerBucket: Map<Bucket, BucketConfig>,
-        wifiOnly: Boolean = this.wifiOnly,
-        pageIndexFrom1: Boolean = this.pageIndexFrom1
-    ): DownloadConfig {
-        return copy(
-            perBucket = newPerBucket,
-            wifiOnly = wifiOnly,
-            pageIndexFrom1 = pageIndexFrom1
-        )
-    }
 
     /** The two page-numbering knobs as the template layer wants them. */
     val pageNumbering: PageNumbering
         get() = PageNumbering(indexFrom1 = pageIndexFrom1, padded = padPageNumber)
-
-    fun withWifiOnly(wifiOnly: Boolean): DownloadConfig = copy(wifiOnly = wifiOnly)
-    fun withPageIndexFrom1(pageIndexFrom1: Boolean): DownloadConfig = copy(
-        pageIndexFrom1 = pageIndexFrom1
-    )
-    /**
-     * 为什么这样做，因为
-     * FragmentSettingsDownload.kt:
-     * OverwritePolicy cur = DownloadsRegistry.getStore().loadOrFallback().getDefaults().getOverwrite();
-     * 这里拿的是defaults.overwrite，而不是perBucket里面的overwrite。
-     * 至于实际文件出现重复时到底时 由defaults.overwrite 还是 perBucket里面的overwrite，需要检查更多的代码来确定
-     * **/
-    fun withDefaultsOverwrite(defaults: BucketDefaults): DownloadConfig {
-        return store.update { cfg ->
-            val newDefaults = cfg.defaults.copy(overwrite = defaults.overwrite)
-            cfg.copy(defaults = newDefaults)
-        }
-    }
 
     fun resolve(bucket: Bucket): ResolvedBucket {
         require(bucket != Bucket.TempCache) {

--- a/app/src/main/java/ceui/pixiv/download/config/DownloadConfig.kt
+++ b/app/src/main/java/ceui/pixiv/download/config/DownloadConfig.kt
@@ -1,5 +1,6 @@
 package ceui.pixiv.download.config
 
+import ceui.pixiv.download.DownloadsRegistry.store
 import ceui.pixiv.download.model.Bucket
 import ceui.pixiv.download.template.PageNumbering
 
@@ -28,10 +29,41 @@ data class DownloadConfig(
     /** true = zero-pad `{page}` so multi-page works sort correctly in galleries (#721). */
     val padPageNumber: Boolean = false,
 ) {
+    // 为 Java 提供的便捷方法
+    @JvmOverloads
+    fun withPerBucket(
+        newPerBucket: Map<Bucket, BucketConfig>,
+        wifiOnly: Boolean = this.wifiOnly,
+        pageIndexFrom1: Boolean = this.pageIndexFrom1
+    ): DownloadConfig {
+        return copy(
+            perBucket = newPerBucket,
+            wifiOnly = wifiOnly,
+            pageIndexFrom1 = pageIndexFrom1
+        )
+    }
 
     /** The two page-numbering knobs as the template layer wants them. */
     val pageNumbering: PageNumbering
         get() = PageNumbering(indexFrom1 = pageIndexFrom1, padded = padPageNumber)
+
+    fun withWifiOnly(wifiOnly: Boolean): DownloadConfig = copy(wifiOnly = wifiOnly)
+    fun withPageIndexFrom1(pageIndexFrom1: Boolean): DownloadConfig = copy(
+        pageIndexFrom1 = pageIndexFrom1
+    )
+    /**
+     * 为什么这样做，因为
+     * FragmentSettingsDownload.kt:
+     * OverwritePolicy cur = DownloadsRegistry.getStore().loadOrFallback().getDefaults().getOverwrite();
+     * 这里拿的是defaults.overwrite，而不是perBucket里面的overwrite。
+     * 至于实际文件出现重复时到底时 由defaults.overwrite 还是 perBucket里面的overwrite，需要检查更多的代码来确定
+     * **/
+    fun withDefaultsOverwrite(defaults: BucketDefaults): DownloadConfig {
+        return store.update { cfg ->
+            val newDefaults = cfg.defaults.copy(overwrite = defaults.overwrite)
+            cfg.copy(defaults = newDefaults)
+        }
+    }
 
     fun resolve(bucket: Bucket): ResolvedBucket {
         require(bucket != Bucket.TempCache) {

--- a/app/src/main/java/ceui/pixiv/download/config/DownloadConfigBackup.kt
+++ b/app/src/main/java/ceui/pixiv/download/config/DownloadConfigBackup.kt
@@ -1,0 +1,119 @@
+package ceui.pixiv.download.config
+
+import ceui.lisa.activities.Shaft
+import ceui.pixiv.download.DownloadsRegistry
+import timber.log.Timber
+
+/**
+ * 备份 / 还原整份 V3 下载配置（「设置 · 下载」里的下载路径、文件名、文件重复时、
+ * 多图页码起始、页码补零、仅 WiFi 下载）。
+ *
+ * 两条链路共用这里，格式也保持一致：
+ *  - 设置页导出 / 导入的 `Shaft-Backup.json`（[ceui.lisa.utils.BackupUtils]）
+ *  - 云同步 payload 里的 `downloadConfigV3`（[ceui.loxia.MoonSync]）
+ *
+ * 还原是 **merge 而不是整份覆盖**：storage（存储位置）跟设备走，备份里的 SAF
+ * treeUri 换台机器或重装后并没有 persistable 权限，照抄回来会让下载全部失败。
+ * 所以只有本机确实还持有写权限的 SAF 才会被还原（同机重装、同机导入导出的
+ * 常见场景仍然生效），否则保留本机当前的存储位置；模板 / 重复策略 / 各开关
+ * 则照单全收。
+ */
+object DownloadConfigBackup {
+
+    /** 当前配置的 JSON 快照，写进备份文件 / 云端 payload。 */
+    @JvmStatic
+    fun export(): String = DownloadConfigJson.toJson(DownloadsRegistry.store.loadOrFallback())
+
+    /**
+     * 把备份里的配置 merge 回本地并落盘。空内容 / 解析失败 / 版本比本地新都直接
+     * 跳过并返回 false —— 备份的其余部分（settings、屏蔽词、搜索历史……）不受影响。
+     *
+     * @return true 表示确实写回了配置
+     */
+    @JvmStatic
+    fun restore(json: String?): Boolean {
+        if (json.isNullOrBlank()) return false
+        val parsed = try {
+            DownloadConfigJson.fromJson(json)
+        } catch (t: Throwable) {
+            Timber.w(t, "DownloadConfigBackup: 下载配置解析失败，跳过")
+            return false
+        }
+        // Gson 走 Unsafe 造对象，字段缺失时即使 Kotlin 声明成非空也会拿到 null，
+        // 所以手改过的备份文件必须在这里挡掉，别等到渲染模板时才 NPE。
+        @Suppress("SENSELESS_COMPARISON", "USELESS_ELVIS")
+        val incoming = parsed.takeIf {
+            it != null && it.defaults != null && it.defaults.storage != null &&
+                    !it.defaults.template.isNullOrBlank()
+        }?.let { it.copy(perBucket = it.perBucket ?: emptyMap()) }
+        if (incoming == null) {
+            Timber.w("DownloadConfigBackup: 备份里的下载配置不完整，跳过")
+            return false
+        }
+        if (incoming.version > DownloadConfig.VERSION) {
+            Timber.w(
+                "DownloadConfigBackup: 备份配置版本 %d 高于本地 %d，跳过",
+                incoming.version, DownloadConfig.VERSION,
+            )
+            return false
+        }
+        return try {
+            DownloadsRegistry.store.update { local -> merge(local, incoming) }
+            // 存储位置可能变了，缓存的 backend 必须丢掉重建。
+            DownloadsRegistry.invalidateBackends()
+            Timber.i(
+                "DownloadConfigBackup: 已还原下载配置（perBucket=%d wifiOnly=%b pageFrom1=%b）",
+                incoming.perBucket.size, incoming.wifiOnly, incoming.pageIndexFrom1,
+            )
+            true
+        } catch (t: Throwable) {
+            Timber.e(t, "DownloadConfigBackup: 写回下载配置失败")
+            false
+        }
+    }
+
+    /**
+     * 备份配置合并进本地配置。[isUsableHere] 决定备份里的存储位置在本机是否可用，
+     * 单测里可以注入假实现。
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun merge(
+        local: DownloadConfig,
+        incoming: DownloadConfig,
+        isUsableHere: (StorageChoice) -> Boolean = ::usableOnThisDevice,
+    ): DownloadConfig {
+        val mergedDefaults = local.defaults.copy(
+            template = incoming.defaults.template,
+            overwrite = incoming.defaults.overwrite,
+            storage = incoming.defaults.storage.takeIf(isUsableHere) ?: local.defaults.storage,
+        )
+        val mergedPerBucket = local.perBucket.toMutableMap()
+        for ((bucket, incomingBucket) in incoming.perBucket) {
+            val localBucket = mergedPerBucket[bucket]
+            mergedPerBucket[bucket] = BucketConfig(
+                template = incomingBucket.template ?: localBucket?.template,
+                // null 表示继承 defaults.storage，本身就是合法状态
+                storage = incomingBucket.storage?.takeIf(isUsableHere) ?: localBucket?.storage,
+                overwrite = incomingBucket.overwrite ?: localBucket?.overwrite,
+            )
+        }
+        return local.copy(
+            defaults = mergedDefaults,
+            perBucket = mergedPerBucket,
+            wifiOnly = incoming.wifiOnly,
+            pageIndexFrom1 = incoming.pageIndexFrom1,
+            padPageNumber = incoming.padPageNumber,
+        )
+    }
+
+    /** SAF 目录只在本机还握着 persistable 写权限时可用；其他存储位置都可以跨设备。 */
+    private fun usableOnThisDevice(choice: StorageChoice): Boolean = when (choice) {
+        is StorageChoice.Saf -> runCatching {
+            Shaft.getContext().contentResolver.persistedUriPermissions
+                .any { it.uri == choice.treeUri && it.isWritePermission }
+        }.getOrDefault(false)
+
+        else -> true
+    }
+}

--- a/app/src/main/java/ceui/pixiv/download/config/DownloadConfigBackup.kt
+++ b/app/src/main/java/ceui/pixiv/download/config/DownloadConfigBackup.kt
@@ -2,6 +2,7 @@ package ceui.pixiv.download.config
 
 import ceui.lisa.activities.Shaft
 import ceui.pixiv.download.DownloadsRegistry
+import ceui.pixiv.download.model.Bucket
 import timber.log.Timber
 
 /**
@@ -20,9 +21,24 @@ import timber.log.Timber
  */
 object DownloadConfigBackup {
 
-    /** 当前配置的 JSON 快照，写进备份文件 / 云端 payload。 */
+    /**
+     * 当前配置的 JSON 快照，写进备份文件 / 云端 payload。
+     *
+     * 绝不抛异常：设置页那个「备份」按钮是主线程 dialog 回调里直接调
+     * [ceui.lisa.utils.BackupUtils.getBackupString]，外面没有 try，这里炸了就是
+     * 整个备份崩掉。真出问题就返回空串——宁可这份备份少一段下载配置。
+     */
     @JvmStatic
-    fun export(): String = DownloadConfigJson.toJson(DownloadsRegistry.store.loadOrFallback())
+    fun export(): String = try {
+        export(DownloadsRegistry.store.loadOrFallback())
+    } catch (t: Throwable) {
+        Timber.e(t, "DownloadConfigBackup: 导出下载配置失败，本次备份不含下载配置")
+        ""
+    }
+
+    /** 已经拿到配置时的重载，省掉一次 MMKV 读。 */
+    @JvmStatic
+    fun export(config: DownloadConfig): String = DownloadConfigJson.toJson(config)
 
     /**
      * 把备份里的配置 merge 回本地并落盘。空内容 / 解析失败 / 版本比本地新都直接
@@ -33,23 +49,12 @@ object DownloadConfigBackup {
     @JvmStatic
     fun restore(json: String?): Boolean {
         if (json.isNullOrBlank()) return false
-        val parsed = try {
-            DownloadConfigJson.fromJson(json)
+        val incoming = try {
+            sanitize(DownloadConfigJson.fromJson(json))
         } catch (t: Throwable) {
             Timber.w(t, "DownloadConfigBackup: 下载配置解析失败，跳过")
-            return false
-        }
-        // Gson 走 Unsafe 造对象，字段缺失时即使 Kotlin 声明成非空也会拿到 null，
-        // 所以手改过的备份文件必须在这里挡掉，别等到渲染模板时才 NPE。
-        @Suppress("SENSELESS_COMPARISON", "USELESS_ELVIS")
-        val incoming = parsed.takeIf {
-            it != null && it.defaults != null && it.defaults.storage != null &&
-                    !it.defaults.template.isNullOrBlank()
-        }?.let { it.copy(perBucket = it.perBucket ?: emptyMap()) }
-        if (incoming == null) {
-            Timber.w("DownloadConfigBackup: 备份里的下载配置不完整，跳过")
-            return false
-        }
+            null
+        } ?: return false
         if (incoming.version > DownloadConfig.VERSION) {
             Timber.w(
                 "DownloadConfigBackup: 备份配置版本 %d 高于本地 %d，跳过",
@@ -73,6 +78,24 @@ object DownloadConfigBackup {
     }
 
     /**
+     * Gson 走 Unsafe 造对象，JSON 里缺字段时即使 Kotlin 声明成非空也会拿到 null，
+     * 而非空 `copy(...)` 参数带着 null 进去会直接抛 IllegalArgumentException。手改过 /
+     * 截断的备份文件就属于这种，统一堵在入口：必填项缺失整份判废，能推导的补默认值。
+     */
+    @Suppress("SENSELESS_COMPARISON", "UNNECESSARY_SAFE_CALL", "USELESS_ELVIS")
+    private fun sanitize(parsed: DownloadConfig): DownloadConfig? {
+        val defaults = parsed?.defaults
+        if (defaults == null || defaults.storage == null || defaults.template.isNullOrBlank()) {
+            Timber.w("DownloadConfigBackup: 备份里的下载配置不完整，跳过")
+            return null
+        }
+        return parsed.copy(
+            defaults = defaults.copy(overwrite = defaults.overwrite ?: OverwritePolicy.Replace),
+            perBucket = parsed.perBucket ?: emptyMap(),
+        )
+    }
+
+    /**
      * 备份配置合并进本地配置。[isUsableHere] 决定备份里的存储位置在本机是否可用，
      * 单测里可以注入假实现。
      */
@@ -83,18 +106,23 @@ object DownloadConfigBackup {
         incoming: DownloadConfig,
         isUsableHere: (StorageChoice) -> Boolean = ::usableOnThisDevice,
     ): DownloadConfig {
+        // 一份配置里同一个 SAF 目录会出现在 defaults 和每个 bucket 上，判定结果只跟
+        // StorageChoice 有关，记一下省掉重复的 persistedUriPermissions 跨进程查询。
+        val verdicts = HashMap<StorageChoice, Boolean>()
+        val usable = { choice: StorageChoice -> verdicts.getOrPut(choice) { isUsableHere(choice) } }
+
         val mergedDefaults = local.defaults.copy(
             template = incoming.defaults.template,
             overwrite = incoming.defaults.overwrite,
-            storage = incoming.defaults.storage.takeIf(isUsableHere) ?: local.defaults.storage,
+            storage = incoming.defaults.storage.takeIf(usable) ?: local.defaults.storage,
         )
-        val mergedPerBucket = local.perBucket.toMutableMap()
-        for ((bucket, incomingBucket) in incoming.perBucket) {
+        val mergedPerBucket = local.perBucket.dropBrokenEntries()
+        for ((bucket, incomingBucket) in incoming.perBucket.dropBrokenEntries()) {
             val localBucket = mergedPerBucket[bucket]
             mergedPerBucket[bucket] = BucketConfig(
                 template = incomingBucket.template ?: localBucket?.template,
                 // null 表示继承 defaults.storage，本身就是合法状态
-                storage = incomingBucket.storage?.takeIf(isUsableHere) ?: localBucket?.storage,
+                storage = incomingBucket.storage?.takeIf(usable) ?: localBucket?.storage,
                 overwrite = incomingBucket.overwrite ?: localBucket?.overwrite,
             )
         }
@@ -106,6 +134,15 @@ object DownloadConfigBackup {
             padPageNumber = incoming.padPageNumber,
         )
     }
+
+    /**
+     * 丢掉 Gson 可能造出的 null key / null value。JSON 里若有本版本已经删掉的 Bucket：
+     * 枚举 key 解析成 null，写回时变成一个 `"null"` 键一直赖在配置里；value 为 null 时
+     * 下面按非空用就是 NPE，整份还原都会被跳过。本地存量配置同样可能有，两边都过一遍。
+     */
+    @Suppress("SENSELESS_COMPARISON")
+    private fun Map<Bucket, BucketConfig>.dropBrokenEntries(): MutableMap<Bucket, BucketConfig> =
+        filterTo(LinkedHashMap()) { (bucket, config) -> bucket != null && config != null }
 
     /** SAF 目录只在本机还握着 persistable 写权限时可用；其他存储位置都可以跨设备。 */
     private fun usableOnThisDevice(choice: StorageChoice): Boolean = when (choice) {

--- a/app/src/test/java/ceui/pixiv/download/DownloadConfigBackupTest.kt
+++ b/app/src/test/java/ceui/pixiv/download/DownloadConfigBackupTest.kt
@@ -1,0 +1,89 @@
+package ceui.pixiv.download
+
+import ceui.pixiv.download.config.BucketConfig
+import ceui.pixiv.download.config.BucketDefaults
+import ceui.pixiv.download.config.DownloadConfig
+import ceui.pixiv.download.config.DownloadConfigBackup
+import ceui.pixiv.download.config.OverwritePolicy
+import ceui.pixiv.download.config.StorageChoice
+import ceui.pixiv.download.model.Bucket
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * 备份还原（#949）的 merge 语义：模板 / 策略 / 开关照抄备份，存储位置只在本机
+ * 确实可用时才跟着走。
+ */
+class DownloadConfigBackupTest {
+
+    private val pictures = StorageChoice.MediaStore(StorageChoice.MediaStore.Collection.Images)
+    private val downloads = StorageChoice.MediaStore(StorageChoice.MediaStore.Collection.Downloads)
+
+    private val local = DownloadConfig(
+        defaults = BucketDefaults(
+            template = "local/{id}.{ext}",
+            storage = pictures,
+            overwrite = OverwritePolicy.Replace,
+        ),
+        perBucket = mapOf(
+            Bucket.Novel to BucketConfig(template = "local-novels/{title}.txt", storage = downloads),
+        ),
+        wifiOnly = false,
+        pageIndexFrom1 = true,
+        padPageNumber = false,
+    )
+
+    private val backup = DownloadConfig(
+        defaults = BucketDefaults(
+            template = "backup/{author}/{id}.{ext}",
+            storage = downloads,
+            overwrite = OverwritePolicy.Skip,
+        ),
+        perBucket = mapOf(
+            Bucket.Novel to BucketConfig(template = "backup-novels/{title}.txt"),
+            Bucket.Illust to BucketConfig(overwrite = OverwritePolicy.Rename),
+        ),
+        wifiOnly = true,
+        pageIndexFrom1 = false,
+        padPageNumber = true,
+    )
+
+    @Test fun `templates, overwrite policy and switches come from the backup`() {
+        val merged = DownloadConfigBackup.merge(local, backup) { true }
+
+        assertEquals("backup/{author}/{id}.{ext}", merged.defaults.template)
+        assertEquals(OverwritePolicy.Skip, merged.defaults.overwrite)
+        assertEquals("backup-novels/{title}.txt", merged.resolve(Bucket.Novel).template)
+        assertEquals(OverwritePolicy.Rename, merged.resolve(Bucket.Illust).overwrite)
+        assertEquals(true, merged.wifiOnly)
+        assertEquals(false, merged.pageIndexFrom1)
+        assertEquals(true, merged.padPageNumber)
+    }
+
+    @Test fun `usable storage from the backup is restored`() {
+        val merged = DownloadConfigBackup.merge(local, backup) { true }
+        assertEquals(downloads, merged.defaults.storage)
+    }
+
+    @Test fun `unusable storage falls back to the local one`() {
+        // 换设备 / 重装后备份里的 SAF treeUri 没有 persistable 权限，照抄会让下载全挂。
+        val merged = DownloadConfigBackup.merge(local, backup) { false }
+
+        assertEquals(pictures, merged.defaults.storage)
+        // 模板照样还原，只有存储位置留在本机
+        assertEquals("backup/{author}/{id}.{ext}", merged.defaults.template)
+        assertEquals(downloads, merged.resolve(Bucket.Novel).storage)
+    }
+
+    @Test fun `per-bucket entries missing from the backup keep their local values`() {
+        val merged = DownloadConfigBackup.merge(local, backup) { true }
+        // 备份里 Illust 只覆盖了 overwrite，模板应该继续继承 defaults
+        assertEquals("backup/{author}/{id}.{ext}", merged.resolve(Bucket.Illust).template)
+    }
+
+    @Test fun `empty backup config leaves local per-bucket overrides alone`() {
+        val empty = backup.copy(perBucket = emptyMap())
+        val merged = DownloadConfigBackup.merge(local, empty) { true }
+        assertEquals("local-novels/{title}.txt", merged.resolve(Bucket.Novel).template)
+    }
+}

--- a/app/src/test/java/ceui/pixiv/download/DownloadConfigBackupTest.kt
+++ b/app/src/test/java/ceui/pixiv/download/DownloadConfigBackupTest.kt
@@ -81,6 +81,17 @@ class DownloadConfigBackupTest {
         assertEquals("backup/{author}/{id}.{ext}", merged.resolve(Bucket.Illust).template)
     }
 
+    @Test fun `unknown bucket key from an old backup is dropped`() {
+        // Gson 遇到本版本已经删掉的 Bucket 会给出 null key，留着它会被原样写回配置。
+        @Suppress("UNCHECKED_CAST")
+        val poisoned = backup.copy(
+            perBucket = mapOf(null to BucketConfig(template = "gone/{id}.{ext}"))
+                    as Map<Bucket, BucketConfig>,
+        )
+        val merged = DownloadConfigBackup.merge(local, poisoned) { true }
+        assertEquals(local.perBucket.keys, merged.perBucket.keys)
+    }
+
     @Test fun `empty backup config leaves local per-bucket overrides alone`() {
         val empty = backup.copy(perBucket = emptyMap())
         val merged = DownloadConfigBackup.merge(local, empty) { true }


### PR DESCRIPTION
备份：复用 DownloadConfigJson 的序列化来将 DownloadConfig 序列化为 JSON 字符串方便再次嵌入json
还原：对于defaults，只单独处理defaults.overwrite，原因见注释，跳过version，剩下都还原
并在DownloadConfig.kt中提供java友好接口

关于备份文件后缀的讨论：实际备份文件以.zip结尾，但其内容实为json文件，可能会误导用户
我想询问是否与后期要做压缩的TOD，如没有应纠正这个错误的后缀