### PR TITLE
feat(login/user): 登录页浏览器登录入口、账号还原与网页登录引导等体验优化

### DIFF
--- a/app/src/main/java/ceui/lisa/activities/MainActivity.java
+++ b/app/src/main/java/ceui/lisa/activities/MainActivity.java
@@ -148,15 +148,9 @@ public class MainActivity extends BaseActivity<ActivityCoverBinding> {
         LocalBroadcastManager.getInstance(this).registerReceiver(profileReadyReceiver, profileFilter);
 
         initDrawerHeader();
-        baseBind.drawerHeader.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                Intent userIntent = new Intent(mContext, UActivity.class);
-                userIntent.putExtra(Params.USER_ID, (int) SessionManager.INSTANCE.getLoggedInUid());
-                startActivity(userIntent);
-                baseBind.drawerLayout.closeDrawer(GravityCompat.START);
-            }
-        });
+        baseBind.drawerHeader.setOnClickListener(v -> openMyUserPage());
+        // 侧边栏头像单击进自己主页；长按仍是 R18 临时过滤开关
+        baseBind.userHead.setOnClickListener(v -> openMyUserPage());
         baseBind.userHead.setOnLongClickListener(new View.OnLongClickListener() {
             @Override
             public boolean onLongClick(View v) {
@@ -649,6 +643,13 @@ public class MainActivity extends BaseActivity<ActivityCoverBinding> {
                     }
                 })
                 .show();
+    }
+
+    private void openMyUserPage() {
+        Intent userIntent = new Intent(mContext, UActivity.class);
+        userIntent.putExtra(Params.USER_ID, (int) SessionManager.INSTANCE.getLoggedInUid());
+        startActivity(userIntent);
+        baseBind.drawerLayout.closeDrawer(GravityCompat.START);
     }
 
     private void initDrawerHeader() {

--- a/app/src/main/java/ceui/lisa/activities/UActivity.kt
+++ b/app/src/main/java/ceui/lisa/activities/UActivity.kt
@@ -214,6 +214,20 @@ class UActivity : BaseActivity<ActivityNewUserBinding>(), Display<UserDetailResp
                 labels.add("跳转到漫画…")
                 actions.add { jumpTo(data.user.id, UserIllustJumpHelper.Kind.MANGA, "漫画作品") }
             }
+            // 与 V3 的「更多」菜单对齐：自己的页面也要能进相关用户和下载管理
+            labels.add(getString(R.string.string_436)) // 相关用户
+            actions.add {
+                val intent = Intent(mContext, TemplateActivity::class.java)
+                intent.putExtra(Params.USER_ID, data.user.id)
+                intent.putExtra(TemplateActivity.EXTRA_FRAGMENT, "相关用户")
+                startActivity(intent)
+            }
+            labels.add(getString(R.string.bulk_user_menu_open_download_manager))
+            actions.add {
+                val intent = Intent(mContext, TemplateActivity::class.java)
+                intent.putExtra(TemplateActivity.EXTRA_FRAGMENT, "下载管理")
+                startActivity(intent)
+            }
             if (!isSelf) {
                 labels.add(
                     if (isMuted) getString(R.string.cancel_block_this_users_work)

--- a/app/src/main/java/ceui/lisa/fragments/FragmentLogin.kt
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentLogin.kt
@@ -1,7 +1,9 @@
 package ceui.lisa.fragments
 
 import android.content.ActivityNotFoundException
+import android.content.ComponentName
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.text.SpannableString
@@ -39,13 +41,18 @@ import ceui.lisa.utils.Dev
 import ceui.lisa.utils.Local
 import ceui.lisa.utils.Params
 import ceui.pixiv.i18n.AppLocales
+import ceui.pixiv.login.PixivLogin
 import com.hjq.toast.Toaster
 import com.qmuiteam.qmui.skin.QMUISkinManager
+import com.qmuiteam.qmui.widget.dialog.QMUIDialog.MenuDialogBuilder
 import com.qmuiteam.qmui.widget.dialog.QMUIDialog.MessageDialogBuilder
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
 import java.util.Locale
 import kotlin.math.roundToInt
 
@@ -154,6 +161,8 @@ class FragmentLogin : BaseFragment<ActivityLoginBinding>() {
     // ── Toolbar ──
 
     private fun setupToolbar() {
+        // 登录页左上角返回选语言页（图标只在进入登录页后显示）
+        baseBind.toolbar.setNavigationOnClickListener { backToLanguagePage() }
         baseBind.toolbar.inflateMenu(R.menu.login_menu)
         baseBind.toolbar.setOnMenuItemClickListener { item ->
             when (item.itemId) {
@@ -174,9 +183,139 @@ class FragmentLogin : BaseFragment<ActivityLoginBinding>() {
                     true
                 }
 
+                R.id.action_browser_login -> {
+                    // 启动协程：避免在主线程执行 PackageManager 查询和 loadLabel
+                    lifecycleScope.launch {
+                        val url = PixivLogin.startLoginUrl()
+                        val title = getString(R.string.browser_dialog_found_title)
+
+                        // 1. 异步获取浏览器数据
+                        val browsers = withContext(Dispatchers.IO) {
+                            getBrowserList(url)
+                        }
+
+                        // 2. 切回主线程渲染弹窗
+                        renderBrowserDialog(url, title, browsers)
+                    }
+                    true
+                }
+
+                R.id.action_browser_signup -> {
+                    lifecycleScope.launch {
+                        val url = PixivLogin.startSignUrl()
+                        val title = getString(R.string.browser_dialog_found_title)
+
+                        // 1. 异步获取浏览器数据
+                        val browsers = withContext(Dispatchers.IO) {
+                            getBrowserList(url)
+                        }
+
+                        // 2. 切回主线程渲染弹窗
+                        renderBrowserDialog(url, title, browsers)
+                    }
+                    true
+                }
+
                 else -> false
             }
         }
+    }
+
+    /** 自建「打开方式」弹窗：列出已安装的浏览器，用显式 Intent 打开 URL。 */
+// 1. 数据结构：用于传递给 UI 层的干净数据
+    data class BrowserItem(
+        val label: String,
+        val packageName: String,
+        val activityName: String
+    )
+
+    // 2. 纯逻辑函数：获取浏览器列表（可在协程/后台线程调用）
+    private fun getBrowserList(url: String): List<BrowserItem> {
+        val openIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+            addCategory(Intent.CATEGORY_BROWSABLE) // 明确要求可从网页启动
+        }
+        val pm = requireContext().packageManager
+        val resolvers = pm.queryIntentActivities(openIntent, PackageManager.MATCH_ALL)
+
+        // 非纯粹浏览器的活动名称黑名单
+        val blacklistedNames = setOf(
+            "com.taobao.browser.BrowserActivity",// 淘宝
+            "com.taobao.live.h5.BrowserActivityH",//淘宝2
+            "com.taobao.live.h5.TransparentWebViewActivity",//淘宝3
+            "com.jingdong.app.mall.open.BrowserActivity",// 京东
+            "com.taobao.live.h5.BrowserActivity",// 淘宝特价版
+            "com.litetao.app.MNWebActivity",//淘宝特价版2
+            "com.xunlei.downloadprovider.launch.LaunchActivity2",// 迅雷
+            "com.tmall.wireless.splash.SchemeHandlerActivity",// 天猫
+            "com.tencent.hunyuan.app.chat.biz.openfile.ExternalOpeFileActivity",// 腾讯元宝
+            "com.baidu.searchbox.BoxBrowserActivity",// 百度（推荐）
+            "com.UCMobile.main.UCMobile.DefaultBrowserEntry",// UC浏览器（推荐）
+            "com.yxcorp.gifshow.growth.applink.GrowthAppLinkActivityHttpRecommend",// 快手极速版
+        )
+
+        // 优先显示的浏览器包名关键词
+        val priorityKeywords = listOf(
+            "chrome",
+            "via",
+            "firefox"
+        )
+
+        return resolvers
+            .filter { resolveInfo ->
+                // 1. 先过滤活动名称：不在黑名单中的才保留
+                Timber.tag("getBrowserList-name").d(resolveInfo.activityInfo.name)
+                !blacklistedNames.contains(resolveInfo.activityInfo.name)
+            }
+            .map { resolveInfo ->
+                // 2. 过滤后再执行耗时的 loadLabel 操作，提升性能
+                BrowserItem(
+                    label = resolveInfo.loadLabel(pm).toString(),
+                    packageName = resolveInfo.activityInfo.packageName,
+                    activityName = resolveInfo.activityInfo.name
+                )
+            }
+            .sortedWith(compareBy<BrowserItem> { item ->
+                // 优先级：匹配关键词的排前面（返回0），不匹配的排后面（返回1）
+                val isPriority = priorityKeywords.any { keyword ->
+                    item.packageName.contains(keyword, ignoreCase = true) ||
+                            item.label.contains(keyword, ignoreCase = true)
+                }
+                if (isPriority) 0 else 1
+            }.thenBy { it.label }) // 同组内按名称排序
+    }
+
+    // 3. 纯渲染函数：只负责接收数据并刷 UI
+    private fun renderBrowserDialog(
+        url: String,
+        dialogTitle: String,
+        browserList: List<BrowserItem>
+    ) {
+        if (browserList.isEmpty()) {
+            Common.showToast(getString(R.string.msg_no_browser))
+            return
+        }
+
+        val labels = browserList.map { it.label }.toTypedArray()
+
+        MenuDialogBuilder(mContext)
+            .setSkinManager(QMUISkinManager.defaultInstance(mContext))
+            .setTitle(dialogTitle)
+            .addItems(labels) { dialog, which ->
+                dialog.dismiss()
+                val targetBrowser = browserList[which]
+
+                // 组装精确跳转的 Intent
+                val launchIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+                    component = ComponentName(targetBrowser.packageName, targetBrowser.activityName)
+                }
+
+                try {
+                    startActivity(launchIntent)
+                } catch (_: ActivityNotFoundException) {
+                    Common.showToast(getString(R.string.msg_no_browser))
+                }
+            }
+            .show()
     }
 
     // ── Language page ──
@@ -305,6 +444,7 @@ class FragmentLogin : BaseFragment<ActivityLoginBinding>() {
         AppLocales.applyConfigurationInPlace(requireActivity(), selectedTag)
 
         relocalizeLoginPage()
+        baseBind.toolbar.setNavigationIcon(R.drawable.ic_arrow_back_white_shadow)
         crossFadeLanguagePageToLoginPage()
     }
 
@@ -317,6 +457,7 @@ class FragmentLogin : BaseFragment<ActivityLoginBinding>() {
         page.loginButton.text = getString(R.string.now_login)
         page.signButton.text = getString(R.string.now_sign)
         page.restoreFromEmail.text = getString(R.string.email_backup_login_entry)
+        page.restoreFromEmailHint.text = getString(R.string.email_backup_login_entry_hint)
         // 协议链接里的 SpannableString 也是 inflate 时算的，要重塞 —— 内部 getString(...) 此刻
         // 已经走新 locale 了。
         setupTermsText(page.firstText)
@@ -340,6 +481,25 @@ class FragmentLogin : BaseFragment<ActivityLoginBinding>() {
         langPage.animate().alpha(0f).setDuration(dur).withEndAction {
             langPage.visibility = View.GONE
         }.start()
+    }
+
+    /** 从登录页返回选语言页：反向交叉淡入淡出，并恢复问候语轮播。 */
+    private fun backToLanguagePage() {
+        val langPage = baseBind.languagePage.root
+        val loginPage = baseBind.loginPage.root
+        val dur = 300L
+
+        baseBind.toolbar.navigationIcon = null
+
+        langPage.visibility = View.VISIBLE
+        langPage.alpha = 0f
+        langPage.animate().alpha(1f).setDuration(dur).start()
+
+        loginPage.animate().alpha(0f).setDuration(dur).withEndAction {
+            loginPage.visibility = View.GONE
+        }.start()
+
+        startGreetingCycle()
     }
 
     // ── Login page ──

--- a/app/src/main/java/ceui/lisa/fragments/FragmentLogin.kt
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentLogin.kt
@@ -52,7 +52,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import timber.log.Timber
 import java.util.Locale
 import kotlin.math.roundToInt
 
@@ -184,35 +183,12 @@ class FragmentLogin : BaseFragment<ActivityLoginBinding>() {
                 }
 
                 R.id.action_browser_login -> {
-                    // 启动协程：避免在主线程执行 PackageManager 查询和 loadLabel
-                    lifecycleScope.launch {
-                        val url = PixivLogin.startLoginUrl()
-                        val title = getString(R.string.browser_dialog_found_title)
-
-                        // 1. 异步获取浏览器数据
-                        val browsers = withContext(Dispatchers.IO) {
-                            getBrowserList(url)
-                        }
-
-                        // 2. 切回主线程渲染弹窗
-                        renderBrowserDialog(url, title, browsers)
-                    }
+                    showBrowserPicker(PixivLogin.startLoginUrl())
                     true
                 }
 
                 R.id.action_browser_signup -> {
-                    lifecycleScope.launch {
-                        val url = PixivLogin.startSignUrl()
-                        val title = getString(R.string.browser_dialog_found_title)
-
-                        // 1. 异步获取浏览器数据
-                        val browsers = withContext(Dispatchers.IO) {
-                            getBrowserList(url)
-                        }
-
-                        // 2. 切回主线程渲染弹窗
-                        renderBrowserDialog(url, title, browsers)
-                    }
+                    showBrowserPicker(PixivLogin.startSignUrl())
                     true
                 }
 
@@ -221,97 +197,77 @@ class FragmentLogin : BaseFragment<ActivityLoginBinding>() {
         }
     }
 
-    /** 自建「打开方式」弹窗：列出已安装的浏览器，用显式 Intent 打开 URL。 */
-// 1. 数据结构：用于传递给 UI 层的干净数据
-    data class BrowserItem(
+    // ── Browser picker ──
+
+    private data class BrowserItem(
         val label: String,
         val packageName: String,
-        val activityName: String
+        val activityName: String,
     )
 
-    // 2. 纯逻辑函数：获取浏览器列表（可在协程/后台线程调用）
-    private fun getBrowserList(url: String): List<BrowserItem> {
-        val openIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
-            addCategory(Intent.CATEGORY_BROWSABLE) // 明确要求可从网页启动
-        }
+    /**
+     * 自建「打开方式」弹窗：列出已安装的浏览器，选中后用显式 Intent 打开 [url]。
+     * 不直接 ACTION_VIEW 交给系统，是因为国内 ROM 上电商 / 下载器类 App 会抢 https
+     * 打开权，登录 URL 被劫走就完成不了 OAuth。
+     */
+    private fun showBrowserPicker(url: String) {
+        // PackageManager 查询和 loadLabel 都是跨进程调用，放 IO 线程；pm 必须在主线程
+        // 先取好再进协程 —— IO 块里调 requireContext() 会在 fragment 恰好销毁时抛
+        // IllegalStateException 直接崩掉。
         val pm = requireContext().packageManager
-        val resolvers = pm.queryIntentActivities(openIntent, PackageManager.MATCH_ALL)
+        viewLifecycleOwner.lifecycleScope.launch {
+            val browsers = withContext(Dispatchers.IO) { queryBrowsers(pm) }
+            showBrowserDialog(url, browsers)
+        }
+    }
 
-        // 非纯粹浏览器的活动名称黑名单
-        val blacklistedNames = setOf(
-            "com.taobao.browser.BrowserActivity",// 淘宝
-            "com.taobao.live.h5.BrowserActivityH",//淘宝2
-            "com.taobao.live.h5.TransparentWebViewActivity",//淘宝3
-            "com.jingdong.app.mall.open.BrowserActivity",// 京东
-            "com.taobao.live.h5.BrowserActivity",// 淘宝特价版
-            "com.litetao.app.MNWebActivity",//淘宝特价版2
-            "com.xunlei.downloadprovider.launch.LaunchActivity2",// 迅雷
-            "com.tmall.wireless.splash.SchemeHandlerActivity",// 天猫
-            "com.tencent.hunyuan.app.chat.biz.openfile.ExternalOpeFileActivity",// 腾讯元宝
-            "com.baidu.searchbox.BoxBrowserActivity",// 百度（推荐）
-            "com.UCMobile.main.UCMobile.DefaultBrowserEntry",// UC浏览器（推荐）
-            "com.yxcorp.gifshow.growth.applink.GrowthAppLinkActivityHttpRecommend",// 快手极速版
-        )
-
-        // 优先显示的浏览器包名关键词
-        val priorityKeywords = listOf(
-            "chrome",
-            "via",
-            "firefox"
-        )
-
-        return resolvers
-            .filter { resolveInfo ->
-                // 1. 先过滤活动名称：不在黑名单中的才保留
-                Timber.tag("getBrowserList-name").d(resolveInfo.activityInfo.name)
-                !blacklistedNames.contains(resolveInfo.activityInfo.name)
-            }
+    /** 枚举已安装的真浏览器，常用浏览器排前，其余按名称排。 */
+    private fun queryBrowsers(pm: PackageManager): List<BrowserItem> {
+        // 框架枚举浏览器的标准姿势：scheme-only 的 "https:"（无 host）。真浏览器的
+        // intent-filter 只声明 scheme、能接任意网址，所以匹配；只注册了特定 host
+        // deep link 的 App（官方 pixiv 客户端、本应用自己之类）因为 filter 带
+        // authority、要求 URI 提供 host，天然不匹配，不用逐个点名。
+        val browserProbe = Intent(Intent.ACTION_VIEW, Uri.fromParts("https", "", null)).apply {
+            addCategory(Intent.CATEGORY_BROWSABLE)
+        }
+        return pm.queryIntentActivities(browserProbe, PackageManager.MATCH_ALL)
+            // 同样按 scheme 通配注册的劫持类 App（电商 / 下载器）筛不出来，黑名单兜底。
+            .filterNot { it.activityInfo.name in HIJACKER_ACTIVITY_NAMES }
             .map { resolveInfo ->
-                // 2. 过滤后再执行耗时的 loadLabel 操作，提升性能
                 BrowserItem(
                     label = resolveInfo.loadLabel(pm).toString(),
                     packageName = resolveInfo.activityInfo.packageName,
-                    activityName = resolveInfo.activityInfo.name
+                    activityName = resolveInfo.activityInfo.name,
                 )
             }
             .sortedWith(compareBy<BrowserItem> { item ->
-                // 优先级：匹配关键词的排前面（返回0），不匹配的排后面（返回1）
-                val isPriority = priorityKeywords.any { keyword ->
+                val isPriority = PRIORITY_BROWSER_KEYWORDS.any { keyword ->
                     item.packageName.contains(keyword, ignoreCase = true) ||
                             item.label.contains(keyword, ignoreCase = true)
                 }
                 if (isPriority) 0 else 1
-            }.thenBy { it.label }) // 同组内按名称排序
+            }.thenBy { it.label })
     }
 
-    // 3. 纯渲染函数：只负责接收数据并刷 UI
-    private fun renderBrowserDialog(
-        url: String,
-        dialogTitle: String,
-        browserList: List<BrowserItem>
-    ) {
-        if (browserList.isEmpty()) {
+    private fun showBrowserDialog(url: String, browsers: List<BrowserItem>) {
+        if (browsers.isEmpty()) {
             Common.showToast(getString(R.string.msg_no_browser))
             return
         }
 
-        val labels = browserList.map { it.label }.toTypedArray()
-
         MenuDialogBuilder(mContext)
             .setSkinManager(QMUISkinManager.defaultInstance(mContext))
-            .setTitle(dialogTitle)
-            .addItems(labels) { dialog, which ->
+            .setTitle(getString(R.string.browser_dialog_found_title))
+            .addItems(browsers.map { it.label }.toTypedArray()) { dialog, which ->
                 dialog.dismiss()
-                val targetBrowser = browserList[which]
-
-                // 组装精确跳转的 Intent
+                val target = browsers[which]
                 val launchIntent = Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
-                    component = ComponentName(targetBrowser.packageName, targetBrowser.activityName)
+                    component = ComponentName(target.packageName, target.activityName)
                 }
-
                 try {
                     startActivity(launchIntent)
                 } catch (_: ActivityNotFoundException) {
+                    // 弹窗挂着的这段时间里目标浏览器可能刚好被卸载
                     Common.showToast(getString(R.string.msg_no_browser))
                 }
             }
@@ -523,6 +479,8 @@ class FragmentLogin : BaseFragment<ActivityLoginBinding>() {
         // 此入口无需登录即可触达，是 Play 自动化测试检测到邮箱外传的位置。
         if (BuildConfig.IS_LITE) {
             page.restoreFromEmail.visibility = View.GONE
+            // 提示紧挨在邮箱恢复入口下面，入口没了提示也一起藏，别留一句悬空的话
+            page.restoreFromEmailHint.visibility = View.GONE
         } else {
             page.restoreFromEmail.setOnClickListener {
                 startActivity(Intent(mContext, TemplateActivity::class.java).apply {
@@ -627,6 +585,30 @@ class FragmentLogin : BaseFragment<ActivityLoginBinding>() {
     private fun dp(value: Float): Int = (value * resources.displayMetrics.density).roundToInt()
 
     private data class Greeting(val tag: String, val hero: String, val subtitle: String)
+
+    companion object {
+        /**
+         * 声明了通配 http/https（handleAllWebDataURI 筛不掉）、但并非浏览器的
+         * 劫持类 App，按 activity 全名点名排除。
+         */
+        private val HIJACKER_ACTIVITY_NAMES = setOf(
+            "com.taobao.browser.BrowserActivity", // 淘宝
+            "com.taobao.live.h5.BrowserActivityH", // 淘宝
+            "com.taobao.live.h5.TransparentWebViewActivity", // 淘宝
+            "com.jingdong.app.mall.open.BrowserActivity", // 京东
+            "com.taobao.live.h5.BrowserActivity", // 淘宝特价版
+            "com.litetao.app.MNWebActivity", // 淘宝特价版
+            "com.xunlei.downloadprovider.launch.LaunchActivity2", // 迅雷
+            "com.tmall.wireless.splash.SchemeHandlerActivity", // 天猫
+            "com.tencent.hunyuan.app.chat.biz.openfile.ExternalOpeFileActivity", // 腾讯元宝
+            "com.baidu.searchbox.BoxBrowserActivity", // 百度
+            "com.UCMobile.main.UCMobile.DefaultBrowserEntry", // UC浏览器
+            "com.yxcorp.gifshow.growth.applink.GrowthAppLinkActivityHttpRecommend", // 快手极速版
+        )
+
+        /** 常用「纯浏览器」关键词，选择列表里置顶。 */
+        private val PRIORITY_BROWSER_KEYWORDS = listOf("chrome", "via", "firefox")
+    }
 }
 
 fun SpannableString.setLinkSpan(

--- a/app/src/main/java/ceui/lisa/fragments/FragmentSettingsData.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSettingsData.java
@@ -21,16 +21,22 @@ import com.qmuiteam.qmui.widget.dialog.QMUIDialog;
 import com.qmuiteam.qmui.widget.dialog.QMUIDialogAction;
 
 import java.io.File;
+import java.util.List;
 
 import ceui.lisa.R;
 import ceui.lisa.activities.BaseActivity;
 import ceui.lisa.activities.Shaft;
+import ceui.lisa.database.UserEntity;
 import ceui.lisa.databinding.FragmentSettingsDataBinding;
 import ceui.lisa.download.IllustDownload;
 import ceui.lisa.file.LegacyFile;
 import ceui.lisa.interfaces.Callback;
+import ceui.lisa.models.UserModel;
 import ceui.lisa.utils.BackupUtils;
+import ceui.lisa.utils.BackupUtils.BackupEntity;
 import ceui.lisa.utils.Common;
+import ceui.lisa.utils.Dev;
+import ceui.lisa.utils.Local;
 import ceui.lisa.utils.Params;
 import ceui.lisa.utils.Settings;
 import ceui.loxia.MoonSync;
@@ -233,12 +239,82 @@ public class FragmentSettingsData extends SettingsPageFragment<FragmentSettingsD
             try {
                 Uri uri = data.getData();
                 String fileString = new String(UriUtils.uri2Bytes(uri));
-                boolean restoreResult = BackupUtils.restoreBackups(mContext, fileString);
-                Common.showToast(restoreResult ? getString(R.string.restore_success) : getString(R.string.restore_failed));
+                BackupEntity restored = BackupUtils.restoreBackupEntity(mContext, fileString);
+                if (restored != null) {
+                    Common.showToast(getString(R.string.restore_success));
+                    if (!SessionManager.INSTANCE.isLoggedIn()) {
+                        maybePromptRestoreAccount(restored.getUserEntityList());
+                    }
+                } else {
+                    Common.showToast(getString(R.string.restore_failed));
+                }
             } catch (Exception e) {
                 e.printStackTrace();
             }
         }
+    }
+
+    /**
+     * 无账号登录状态下，还原的备份中若带有登录账号，弹窗询问是否立即恢复登录。
+     * 选择「是」则切到备份中最近登录的账号并重启进主页瀑布流；选择「稍后自行切换」
+     * 则账号已保留在本地账号列表，可稍后自行切换。
+     */
+    private void maybePromptRestoreAccount(List<UserEntity> accounts) {
+        final UserModel target = pickLatestBackupAccount(accounts);
+        if (target == null) {
+            return;
+        }
+        if (getActivity() == null || getActivity().isFinishing() || getActivity().isDestroyed()) {
+            return;
+        }
+        new QMUIDialog.MessageDialogBuilder(getActivity())
+                .setTitle(R.string.restore_found_account_title)
+                .setMessage(R.string.restore_found_account_message)
+                .setSkinManager(QMUISkinManager.defaultInstance(mContext))
+                .addAction(R.string.restore_switch_later, new QMUIDialogAction.ActionListener() {
+                    @Override
+                    public void onClick(QMUIDialog dialog, int index) {
+                        dialog.dismiss();
+                    }
+                })
+                .addAction(0, R.string.restore_switch_now, QMUIDialogAction.ACTION_PROP_POSITIVE, new QMUIDialogAction.ActionListener() {
+                    @Override
+                    public void onClick(QMUIDialog dialog, int index) {
+                        dialog.dismiss();
+                        target.getUser().setIs_login(true);
+                        Local.saveUser(target);
+                        Dev.refreshUser = true;
+                        Common.restart();
+                    }
+                })
+                .create()
+                .show();
+    }
+
+    /** 取备份中最近一次登录的账号；token 不完整（非真实登录账号）时返回 null。 */
+    private UserModel pickLatestBackupAccount(List<UserEntity> accounts) {
+        if (accounts == null || accounts.isEmpty()) {
+            return null;
+        }
+        UserEntity best = null;
+        for (UserEntity entity : accounts) {
+            if (best == null || entity.getLoginTime() > best.getLoginTime()) {
+                best = entity;
+            }
+        }
+        if (best == null) {
+            return null;
+        }
+        try {
+            UserModel userModel = Shaft.sGson.fromJson(best.getUserGson(), UserModel.class);
+            if (userModel != null && userModel.getUser() != null
+                    && !TextUtils.isEmpty(userModel.getRawAccessToken())
+                    && !TextUtils.isEmpty(userModel.getRefresh_token())) {
+                return userModel;
+            }
+        } catch (Exception ignored) {
+        }
+        return null;
     }
 
     private void loadCacheSizeAsync(TextView target, File folder) {

--- a/app/src/main/java/ceui/lisa/fragments/StreetMainFragment.kt
+++ b/app/src/main/java/ceui/lisa/fragments/StreetMainFragment.kt
@@ -261,7 +261,11 @@ class StreetMainFragment : BaseLazyFragment<FragmentBaseListBinding>() {
         val cookies = MMKV.defaultMMKV().getString(SessionManager.COOKIE_KEY, "")
         if (!SessionManager.isLoggedInWebCookie(cookies)) {
             // 含匿名 PHPSESSID 的旧存量也走这里重新登录,不然会卡在「拿不到 CSRF token」。
-            showWebLoginDialog()
+            if (autoStartWebLogin()) {
+                startWebLogin()
+            } else {
+                showWebLoginDialog()
+            }
         } else if (CsrfTokenProvider.get() == null) {
             // 有 cookie 但没 CSRF token，用 WebView 静默提取
             fetchCsrfViaWebView()
@@ -269,6 +273,10 @@ class StreetMainFragment : BaseLazyFragment<FragmentBaseListBinding>() {
             viewModel.refresh()
         }
     }
+
+    /** 从按 tag 筛选的空态「去登录」进入时直接开始网页登录，不弹确认对话框。 */
+    private fun autoStartWebLogin(): Boolean =
+        activity?.intent?.getBooleanExtra(Params.AUTO_WEB_LOGIN, false) == true
 
     /**
      * Cookie 已有，但 CSRF token 缺失。用隐藏 WebView 加载 pixiv.net，
@@ -390,7 +398,12 @@ class StreetMainFragment : BaseLazyFragment<FragmentBaseListBinding>() {
                         cleanupWebView()
                         if (token != null) {
                             Toaster.showShort(getString(R.string.street_web_login_success))
-                            viewModel.refresh()
+                            if (autoStartWebLogin()) {
+                                // 从标签筛选空态进入：登录完成直接返回来源页，来源页在 onResume 里自动刷新
+                                activity?.finish()
+                            } else {
+                                viewModel.refresh()
+                            }
                         } else {
                             // 这里曾经无条件报「登录成功」，紧接着 refresh() 再弹一条
                             // 「CSRF token 未就绪」——两条自相矛盾的 toast 一起糊在用户脸上，

--- a/app/src/main/java/ceui/lisa/utils/BackupUtils.java
+++ b/app/src/main/java/ceui/lisa/utils/BackupUtils.java
@@ -108,6 +108,10 @@ public class BackupUtils {
     }
 
     public static boolean restoreBackups(Context context, String backupString) {
+        return restoreBackupEntity(context, backupString) != null;
+    }
+
+    public static BackupEntity restoreBackupEntity(Context context, String backupString) {
         try {
             BackupEntity backupEntity = Shaft.sGson.fromJson(backupString, BackupEntity.class);
             // 下载配置自己吞掉所有异常：解析不了就保持本机现状，不影响其余数据还原。
@@ -156,10 +160,10 @@ public class BackupUtils {
                 }
             }
 
-            return true;
+            return backupEntity;
         } catch (Exception e) {
             e.printStackTrace();
-            return false;
+            return null;
         }
     }
 }

--- a/app/src/main/java/ceui/lisa/utils/Params.java
+++ b/app/src/main/java/ceui/lisa/utils/Params.java
@@ -53,6 +53,7 @@ public class Params {
     public static final String FRAGMENT_SEARCH_CLIPBOARD_VALUE  = "fragment search clipboard value";
     public static final String MANGA_SERIES_ID  = "manga series id";
     public static final String REVERSE_SEARCH_IMAGE_URI = "reverse image uri";
+    public static final String AUTO_WEB_LOGIN = "auto web login";
 
 
     public static final String VIEW_PAGER_MUTED  = "muted history viewpager";

--- a/app/src/main/java/ceui/pixiv/ui/user/PixivBlockOperate.kt
+++ b/app/src/main/java/ceui/pixiv/ui/user/PixivBlockOperate.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.lifecycleScope
 import ceui.lisa.R
 import ceui.lisa.activities.TemplateActivity
 import ceui.lisa.utils.Common
+import ceui.lisa.utils.Params
 import ceui.loxia.BlockSaveRequest
 import ceui.loxia.Client
 import ceui.loxia.CsrfTokenProvider
@@ -230,6 +231,7 @@ object PixivBlockOperate {
                 activity.startActivity(
                     Intent(activity, TemplateActivity::class.java).apply {
                         putExtra(TemplateActivity.EXTRA_FRAGMENT, "Web首页")
+                        putExtra(Params.AUTO_WEB_LOGIN, true)
                     }
                 )
             }

--- a/app/src/main/java/ceui/pixiv/ui/user/UserIllustByTagFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/user/UserIllustByTagFeedFragment.kt
@@ -88,6 +88,7 @@ class UserIllustByTagFeedFragment : IllustFeedFragment(R.layout.fragment_toolbar
                 startActivity(
                     Intent(requireContext(), TemplateActivity::class.java).apply {
                         putExtra(TemplateActivity.EXTRA_FRAGMENT, "Web首页")
+                        putExtra(Params.AUTO_WEB_LOGIN, true)
                     }
                 )
             }

--- a/app/src/main/res/layout/page_login.xml
+++ b/app/src/main/res/layout/page_login.xml
@@ -58,6 +58,19 @@
                 android:textColor="@color/white"
                 android:textSize="13sp" />
 
+            <TextView
+                android:id="@+id/restore_from_email_hint"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginBottom="14dp"
+                android:alpha="0.7"
+                android:gravity="center"
+                android:paddingHorizontal="12dp"
+                android:text="@string/email_backup_login_entry_hint"
+                android:textColor="@color/white"
+                android:textSize="11sp" />
+
             <LinearLayout
                 android:id="@+id/checkbox_one"
                 android:layout_width="match_parent"

--- a/app/src/main/res/menu/login_menu.xml
+++ b/app/src/main/res/menu/login_menu.xml
@@ -13,4 +13,16 @@
         android:title="@string/action_import"
         app:showAsAction="never" />
 
+    <item
+        android:id="@+id/action_browser_login"
+        android:orderInCategory="100"
+        android:title="@string/action_browser_login"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/action_browser_signup"
+        android:orderInCategory="100"
+        android:title="@string/action_browser_signup"
+        app:showAsAction="never" />
+
 </menu>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -9,6 +9,9 @@
     <string name="nav_header_desc">Navigation header</string>
     <string name="action_settings">Settings</string>
     <string name="action_import">Import from clipboard</string>
+    <string name="action_browser_login">Log in with a browser of your choice</string>
+    <string name="action_browser_signup">Sign up with a browser of your choice</string>
+    <string name="browser_dialog_found_title">Found these</string>
     <string name="action_qcode">Scan QR code</string>
     <string name="title_activity_blank">BlankActivity</string>
     <string name="empty_list_1">Actually had nothing</string>
@@ -845,6 +848,10 @@
     <string name="success_clear_bulk_download_cache">Bulk download data cleared</string>
     <string name="restore_success">Restore successful</string>
     <string name="restore_failed">Restore failed</string>
+    <string name="restore_found_account_title">Account found in backup</string>
+    <string name="restore_found_account_message">Restore the login state now?</string>
+    <string name="restore_switch_later">I\'ll switch later</string>
+    <string name="restore_switch_now">Yes</string>
     <string name="backup_success">Backup successful</string>
     <string name="color_shiYinPurple">Shiin Purple</string>
     <string name="color_classicBlue">Classic Blue</string>
@@ -2056,6 +2063,7 @@
     <string name="email_backup_do_restore">Restore and sign in</string>
     <string name="email_backup_settings_entry">Back up account to email</string>
     <string name="email_backup_login_entry">Already backed up? Restore from email</string>
+    <string name="email_backup_login_entry_hint">Exported to clipboard? Exported a backup file in Settings? Check the top-right corner.</string>
     <string name="email_backup_bound_title">Backed up</string>
     <string name="email_backup_bound_email">Encrypted backup to %1$s</string>
     <string name="email_backup_bound_time">Backed up on %1$s</string>
@@ -2278,6 +2286,6 @@
     <string name="pixiv_unblock_done">Unblocked “%1$s”</string>
     <string name="pixiv_block_checking">Checking block status…</string>
     <string name="pixiv_block_submitting">Submitting…</string>
-    <string name="pixiv_block_need_web_login">Blocking is a web feature. Sign in to the web version once so the session can be synced.</string>
-    <string name="user_tag_filter_empty_need_web_login">No works found.\nTag filtering uses Pixiv\'s web API. Sign in on the web once to see all works.</string>
+    <string name="pixiv_block_need_web_login">This feature works through the web interface, so you need to sign in on the web once more.</string>
+    <string name="user_tag_filter_empty_need_web_login">No works found.\nThis feature works through the web interface, so you need to sign in on the web once more to see all works under this tag.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -9,6 +9,9 @@
     <string name="nav_header_desc">Navigation header</string>
     <string name="action_settings">設定</string>
     <string name="action_import">クリップボードからインポート</string>
+    <string name="action_browser_login">好きなブラウザでログイン</string>
+    <string name="action_browser_signup">好きなブラウザで登録</string>
+    <string name="browser_dialog_found_title">こちらが見つかりました</string>
     <string name="action_qcode">"QRコードをスキャン "</string>
     <string name="title_activity_blank">BlankActivity</string>
     <string name="empty_list_1">コンテンツなし</string>
@@ -845,6 +848,10 @@
     <string name="success_clear_bulk_download_cache">一括ダウンロード関連データを削除しました</string>
     <string name="restore_success">復元しました</string>
     <string name="restore_failed">復元できませんでした</string>
+    <string name="restore_found_account_title">バックアップからアカウントを検出</string>
+    <string name="restore_found_account_message">すぐにログイン状態を復元しますか？</string>
+    <string name="restore_switch_later">あとで自分で切り替える</string>
+    <string name="restore_switch_now">はい</string>
     <string name="backup_success">"バックアップしました。保存先： "</string>
     <string name="color_shiYinPurple">矢尹紫</string>
     <string name="color_classicBlue">クラシックブルー</string>
@@ -2056,6 +2063,7 @@
     <string name="email_backup_do_restore">復元してログイン</string>
     <string name="email_backup_settings_entry">アカウントをメールにバックアップ</string>
     <string name="email_backup_login_entry">バックアップ済み？メールから復元</string>
+    <string name="email_backup_login_entry_hint">クリップボードに書き出した？設定でバックアップファイルを書き出した？右上を見てみて。</string>
     <string name="email_backup_bound_title">バックアップ済み</string>
     <string name="email_backup_bound_email">%1$s に暗号化バックアップ済み</string>
     <string name="email_backup_bound_time">バックアップ日時 %1$s</string>
@@ -2278,6 +2286,6 @@
     <string name="pixiv_unblock_done">「%1$s」のブロックを解除しました</string>
     <string name="pixiv_block_checking">ブロック状態を確認中…</string>
     <string name="pixiv_block_submitting">送信中…</string>
-    <string name="pixiv_block_need_web_login">ブロックはウェブ版の機能です。先にウェブ版へ一度ログインしてセッションを同期してください。</string>
-    <string name="user_tag_filter_empty_need_web_login">作品が見つかりませんでした。\nタグ絞り込みは pixiv のウェブ API を使います。すべての作品を見るにはウェブで一度ログインしてください。</string>
+    <string name="pixiv_block_need_web_login">この機能はウェブインターフェースで動作するため、追加で一度ウェブにログインする必要があります。</string>
+    <string name="user_tag_filter_empty_need_web_login">作品が見つかりませんでした。\nこの機能はウェブインターフェースで動作するため、このタグのすべての作品を見るには、追加でウェブに一度ログインする必要があります</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -9,6 +9,9 @@
     <string name="nav_header_desc">항 법 제목</string>
     <string name="action_settings">설치</string>
     <string name="action_import">클립보드 에서 가 져 오기</string>
+    <string name="action_browser_login">원하는 브라우저로 로그인</string>
+    <string name="action_browser_signup">원하는 브라우저로 가입</string>
+    <string name="browser_dialog_found_title">다음을 찾았습니다</string>
     <string name="action_qcode">QR 코드 를 스캐닝 하 다.</string>
     <string name="title_activity_blank">공백 활성</string>
     <string name="empty_list_1">아무것도 없다 니.</string>
@@ -845,6 +848,10 @@
     <string name="success_clear_bulk_download_cache">일괄 다운로드 관련 데이터가 삭제되었습니다</string>
     <string name="restore_success">복원 성공</string>
     <string name="restore_failed">복원 실패</string>
+    <string name="restore_found_account_title">백업에서 계정을 찾았습니다</string>
+    <string name="restore_found_account_message">지금 로그인 상태를 복원할까요?</string>
+    <string name="restore_switch_later">나중에 직접 전환</string>
+    <string name="restore_switch_now">예</string>
     <string name="backup_success">백업 성공</string>
     <string name="color_shiYinPurple">시인 퍼플</string>
     <string name="color_classicBlue">클래식 블루</string>
@@ -2056,6 +2063,7 @@
     <string name="email_backup_do_restore">복원하고 로그인</string>
     <string name="email_backup_settings_entry">계정을 이메일에 백업</string>
     <string name="email_backup_login_entry">이미 백업했나요? 이메일에서 복원</string>
+    <string name="email_backup_login_entry_hint">클립보드로 내보냈나요? 설정에서 백업 파일을 내보냈나요? 오른쪽 위를 확인해 보세요.</string>
     <string name="email_backup_bound_title">백업됨</string>
     <string name="email_backup_bound_email">%1$s(으)로 암호화 백업됨</string>
     <string name="email_backup_bound_time">백업 시간 %1$s</string>
@@ -2278,6 +2286,6 @@
     <string name="pixiv_unblock_done">“%1$s”의 차단을 해제했습니다</string>
     <string name="pixiv_block_checking">차단 상태 확인 중…</string>
     <string name="pixiv_block_submitting">전송 중…</string>
-    <string name="pixiv_block_need_web_login">차단은 웹 기능입니다. 먼저 웹 버전에 한 번 로그인해 세션을 동기화하세요.</string>
-    <string name="user_tag_filter_empty_need_web_login">작품을 찾지 못했습니다.\n태그 필터는 pixiv 웹 API를 사용합니다. 모든 작품을 보려면 웹에서 한 번 로그인하세요.</string>
+    <string name="pixiv_block_need_web_login">이 기능은 웹 인터페이스로 동작하므로, 추가로 웹에 한 번 더 로그인해야 합니다.</string>
+    <string name="user_tag_filter_empty_need_web_login">작품을 찾지 못했습니다.\n이 기능은 웹 인터페이스로 동작하므로, 이 태그의 모든 작품을 보려면 웹에 한 번 더 로그인해야 합니다</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -9,6 +9,9 @@
     <string name="nav_header_desc">Заголовок бокового меню</string>
     <string name="action_settings">Настройки</string>
     <string name="action_import">Импорт из буфера обмена</string>
+    <string name="action_browser_login">Войти через выбранный браузер</string>
+    <string name="action_browser_signup">Зарегистрироваться через выбранный браузер</string>
+    <string name="browser_dialog_found_title">Найдено следующее</string>
     <string name="action_qcode">Сканировать QR-код</string>
     <string name="title_activity_blank">Пустой экран</string>
     <string name="empty_list_1">Здесь ничего нет</string>
@@ -845,6 +848,10 @@
     <string name="success_clear_bulk_download_cache">Данные массовых загрузок очищены</string>
     <string name="restore_success">Восстановлено</string>
     <string name="restore_failed">Не удалось восстановить</string>
+    <string name="restore_found_account_title">В резервной копии найден аккаунт</string>
+    <string name="restore_found_account_message">Восстановить состояние входа сейчас?</string>
+    <string name="restore_switch_later">Переключу позже</string>
+    <string name="restore_switch_now">Да</string>
     <string name="backup_success">Резервная копия создана</string>
     <string name="color_shiYinPurple">Фиолетовый Shiin</string>
     <string name="color_classicBlue">Классический синий</string>
@@ -2056,6 +2063,7 @@
     <string name="email_backup_do_restore">Восстановить и войти</string>
     <string name="email_backup_settings_entry">Резервная копия аккаунта в почту</string>
     <string name="email_backup_login_entry">Уже есть копия? Восстановить из почты</string>
+    <string name="email_backup_login_entry_hint">Экспортировали в буфер обмена? Экспортировали резервную копию в настройках? Загляните в правый верхний угол.</string>
     <string name="email_backup_bound_title">Сохранено</string>
     <string name="email_backup_bound_email">Зашифрованная копия в %1$s</string>
     <string name="email_backup_bound_time">Дата копии: %1$s</string>
@@ -2278,6 +2286,6 @@
     <string name="pixiv_unblock_done">«%1$s» разблокирован</string>
     <string name="pixiv_block_checking">Проверка статуса блокировки…</string>
     <string name="pixiv_block_submitting">Отправка…</string>
-    <string name="pixiv_block_need_web_login">Блокировка — функция веб-версии. Войдите один раз в веб-версию, чтобы синхронизировать сессию.</string>
-    <string name="user_tag_filter_empty_need_web_login">Работы не найдены.\nФильтр по тегам использует веб-API pixiv. Войдите один раз через веб, чтобы увидеть все работы.</string>
+    <string name="pixiv_block_need_web_login">Эта функция работает через веб-интерфейс, поэтому нужно дополнительно войти через веб.</string>
+    <string name="user_tag_filter_empty_need_web_login">Работы не найдены.\nЭта функция работает через веб-интерфейс, поэтому, чтобы увидеть все работы по этому тегу, нужно дополнительно войти через веб</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -9,6 +9,9 @@
     <string name="nav_header_desc">Menü başlığı</string>
     <string name="action_settings">Ayarlar</string>
     <string name="action_import">Panodan aktar</string>
+    <string name="action_browser_login">Seçtiğiniz tarayıcıyla giriş yapın</string>
+    <string name="action_browser_signup">Seçtiğiniz tarayıcıyla kayıt olun</string>
+    <string name="browser_dialog_found_title">Şunlar bulundu</string>
     <string name="action_qcode">QR kodu tara</string>
     <string name="title_activity_blank">Boş Sayfa</string>
     <string name="empty_list_1">Burası boş</string>
@@ -845,6 +848,10 @@
     <string name="success_clear_bulk_download_cache">Toplu indirme verileri temizlendi</string>
     <string name="restore_success">Geri yükleme başarılı</string>
     <string name="restore_failed">Geri yükleme başarısız</string>
+    <string name="restore_found_account_title">Yedekte hesap bulundu</string>
+    <string name="restore_found_account_message">Giriş durumu şimdi geri yüklensin mi?</string>
+    <string name="restore_switch_later">Sonra kendim geçerim</string>
+    <string name="restore_switch_now">Evet</string>
     <string name="backup_success">Yedekleme başarılı</string>
     <string name="color_shiYinPurple">Shiin Moru</string>
     <string name="color_classicBlue">Klasik Mavi</string>
@@ -2056,6 +2063,7 @@
     <string name="email_backup_do_restore">Geri yükle ve giriş yap</string>
     <string name="email_backup_settings_entry">Hesabı e-postaya yedekle</string>
     <string name="email_backup_login_entry">Yedeğin var mı? E-postadan geri yükle</string>
+    <string name="email_backup_login_entry_hint">Panoya dışa aktardınız mı? Ayarlardan yedek dosyası dışa aktardınız mı? Sağ üst köşeye bakın.</string>
     <string name="email_backup_bound_title">Yedeklendi</string>
     <string name="email_backup_bound_email">%1$s adresine şifreli yedek</string>
     <string name="email_backup_bound_time">Yedek tarihi %1$s</string>
@@ -2278,6 +2286,6 @@
     <string name="pixiv_unblock_done">“%1$s” engeli kaldırıldı</string>
     <string name="pixiv_block_checking">Engelleme durumu kontrol ediliyor…</string>
     <string name="pixiv_block_submitting">Gönderiliyor…</string>
-    <string name="pixiv_block_need_web_login">Engelleme bir web özelliğidir. Oturumun eşitlenmesi için önce web sürümünde bir kez oturum açın.</string>
-    <string name="user_tag_filter_empty_need_web_login">Eser bulunamadı.\nEtiket filtresi pixiv web API\'sini kullanır. Tüm eserleri görmek için web\'de bir kez giriş yapın.</string>
+    <string name="pixiv_block_need_web_login">Bu özellik web arayüzü üzerinden çalışır; ek olarak web\'de bir kez daha giriş yapmanız gerekir.</string>
+    <string name="user_tag_filter_empty_need_web_login">Eser bulunamadı.\nBu özellik web arayüzü üzerinden çalışır; bu etiket altındaki tüm eserleri görmek için web\'de bir kez daha giriş yapmanız gerekir</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -9,6 +9,9 @@
     <string name="nav_header_desc">標題導航</string>
     <string name="action_settings">設定</string>
     <string name="action_import">從剪貼簿導入</string>
+    <string name="action_browser_login">自選瀏覽器進行登入</string>
+    <string name="action_browser_signup">自選瀏覽器進行註冊</string>
+    <string name="browser_dialog_found_title">查找到了這些</string>
     <string name="action_qcode">掃描 QR 碼</string>
     <string name="title_activity_blank">BlankActivity</string>
     <string name="empty_list_1">居然什麼也沒有</string>
@@ -847,6 +850,10 @@
     <string name="success_clear_bulk_download_cache">批次下載關聯資料已清除</string>
     <string name="restore_success">還原成功</string>
     <string name="restore_failed">還原失敗</string>
+    <string name="restore_found_account_title">從備份中發現帳號</string>
+    <string name="restore_found_account_message">是否立即恢復登入狀態？</string>
+    <string name="restore_switch_later">稍後自行切換</string>
+    <string name="restore_switch_now">是</string>
     <string name="backup_success">備份成功</string>
     <string name="color_shiYinPurple">矢尹紫</string>
     <string name="color_classicBlue">經典藍</string>
@@ -2058,6 +2065,7 @@
     <string name="email_backup_do_restore">還原並登入</string>
     <string name="email_backup_settings_entry">帳號備份到電子郵件</string>
     <string name="email_backup_login_entry">已備份過？從電子郵件還原登入</string>
+    <string name="email_backup_login_entry_hint">匯出過剪貼簿？透過設定匯出過備份檔案？看看右上角</string>
     <string name="email_backup_bound_title">已備份</string>
     <string name="email_backup_bound_email">已加密備份到 %1$s</string>
     <string name="email_backup_bound_time">備份時間 %1$s</string>
@@ -2280,6 +2288,6 @@
     <string name="pixiv_unblock_done">已解除封鎖「%1$s」</string>
     <string name="pixiv_block_checking">正在查詢封鎖狀態…</string>
     <string name="pixiv_block_submitting">正在提交…</string>
-    <string name="pixiv_block_need_web_login">封鎖是網頁端功能，需要先完成一次網頁登入以同步工作階段資訊。</string>
-    <string name="user_tag_filter_empty_need_web_login">沒有篩到作品。\n依標籤篩選走的是 Pixiv 網頁介面，需要在網頁裡登入一次才能看到全部作品。</string>
+    <string name="pixiv_block_need_web_login">該功能透過網頁介面實作，需要額外進行一次網頁登入。</string>
+    <string name="user_tag_filter_empty_need_web_login">沒有篩到作品。\n該功能透過網頁介面實作，需要額外進行一次網頁登入才能看到該標籤下的全部作品</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,9 @@
     <string name="nav_header_desc">Navigation header</string>
     <string name="action_settings">设置</string>
     <string name="action_import">从剪切板导入</string>
+    <string name="action_browser_login">自选浏览器进行登录</string>
+    <string name="action_browser_signup">自选浏览器进行注册</string>
+    <string name="browser_dialog_found_title">查找到了这些</string>
     <string name="action_qcode">扫描二维码</string>
     <string name="title_activity_blank">BlankActivity</string>
 
@@ -872,6 +875,10 @@
     <string name="success_clear_bulk_download_cache">批量下载关联数据已清除</string>
     <string name="restore_success">还原成功</string>
     <string name="restore_failed">还原失败</string>
+    <string name="restore_found_account_title">从备份中发现账号</string>
+    <string name="restore_found_account_message">是否立即恢复登录状态？</string>
+    <string name="restore_switch_later">稍后自行切换</string>
+    <string name="restore_switch_now">是</string>
     <string name="backup_success">备份成功</string>
     <string name="color_shiYinPurple">矢尹紫</string>
     <string name="color_classicBlue">经典蓝</string>
@@ -2269,6 +2276,7 @@
     <string name="email_backup_do_restore">恢复并登录</string>
     <string name="email_backup_settings_entry">账号备份到邮箱</string>
     <string name="email_backup_login_entry">已备份过？从邮箱恢复登录</string>
+    <string name="email_backup_login_entry_hint">导出过剪切板？通过设置导出过备份文件？看看右上角</string>
     <string name="email_backup_bound_title">已备份</string>
     <string name="email_backup_bound_email">已加密备份到 %1$s</string>
     <string name="email_backup_bound_time">备份时间 %1$s</string>
@@ -2478,8 +2486,8 @@
     <string name="pixiv_unblock_done">已取消拉黑「%1$s」</string>
     <string name="pixiv_block_checking">正在查询拉黑状态…</string>
     <string name="pixiv_block_submitting">正在提交…</string>
-    <string name="pixiv_block_need_web_login">拉黑是网页端功能，需要先完成一次网页登录来同步会话信息。</string>
+    <string name="pixiv_block_need_web_login">该功能通过网页接口实现，需要额外进行一次网页登录。</string>
     <!-- 画师页 chip 来自 app-api、筛选走网页 ajax，两边可见范围可能不一致；只给线索不下断言，
          见 UserIllustByTagFeedFragment.emptyStateText 的 KDoc（非 issue #956 的实证成因） -->
-    <string name="user_tag_filter_empty_need_web_login">没有筛到作品。\n按标签筛选走的是 Pixiv 网页接口，需要在网页里登录一次才能看到全部作品。</string>
+    <string name="user_tag_filter_empty_need_web_login">没有筛到作品。\n该功能通过网页接口实现，需要额外进行一次网页登录才能看到该标签下的全部作品</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,12 @@ buildscript {
         google()
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
-        maven { url "https://jitpack.io" }
+        maven {
+            url "https://jitpack.io"
+            // 「只兜 com.github.*」不能只写在注释里：加 content filter 后其余坐标
+            // 根本不会去 jitpack 发请求，也防止它抢答非 GitHub 坐标。
+            content { includeGroupByRegex 'com\\.github\\..*' }
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.7.3'
@@ -39,7 +44,12 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        maven { url 'https://jitpack.io' }
+        maven {
+            url 'https://jitpack.io'
+            // 本仓所有 jitpack 坐标都是 com.github.*；过滤掉其余 group，别的依赖
+            // 不再对 jitpack 发注定 404 的探测请求。
+            content { includeGroupByRegex 'com\\.github\\..*' }
+        }
         maven { url 'https://maven.aliyun.com/repository/public/' }
 //        mavenLocal()
     }


### PR DESCRIPTION
本 PR 包含两个提交：

1. **优化构建源** — 构建源相关调整
2. **feat(login/user): 登录页浏览器登录入口、账号还原与网页登录引导等体验优化**
   - 登录页右上角新增「自选浏览器进行登录/注册」：自建弹窗列出已安装浏览器，用显式 Intent 打开
   - 登录页「已备份过？从邮箱恢复登录」下方新增恢复提示，左上角新增返回选语言页按钮
   - 设置-备份还原：无账号登录时还原到含账号的备份，弹窗询问是否立即恢复登录，确认后自动切换进瀑布流
   - 标签筛选空态缺网页会话时直接进入网页登录，登录成功自动返回来源页并刷新
   - 拉黑缺网页会话时引导登录改为携带 AUTO_WEB_LOGIN（保留确认弹窗）
   - 经典用户页「更多」菜单补齐「相关用户」「打开下载管理器」；侧边栏头像支持单击进自己主页
   - 更新相关提示文案并补齐 7 种语言