### PR TITLE
feat(detail): 多 P 空白容器改由 IllustsBean 宽高预置,非单P插画首图不再垫高

### DIFF
--- a/app/src/main/java/ceui/lisa/adapters/IllustAdapter.java
+++ b/app/src/main/java/ceui/lisa/adapters/IllustAdapter.java
@@ -115,6 +115,8 @@ public class IllustAdapter extends AbstractIllustAdapter<ViewHolder<RecyIllustDe
      *   <li>兜底(无 cookie / 精简 bean 无尺寸):图片解码后由 {@link #rememberDecodedRatio}
      *       用位图宽高定下。</li>
      * </ul>
+     * 真 ratio 尚未确定时,先用 {@link IllustsBean#getWidth()}/{@code getHeight()}
+     * 当「最开始的空白容器」(见 {@link #applyRatioOrPlaceholder}),图片解码后仍校正进本表。
      * 缓存进此表 → 滑走再回、回收重绑时首帧直接套用,消除抖动;{@link #release()} 时清空。
      */
     private final Map<Integer, Float> pageRatio = new ConcurrentHashMap<>();
@@ -329,8 +331,10 @@ public class IllustAdapter extends AbstractIllustAdapter<ViewHolder<RecyIllustDe
     }
 
     /**
-     * ratio 已知就套用(首帧即终值),未知就退回占位高({@code maxHeight} 或布局默认)并返回
-     * {@code changeSize=true} —— 让 {@link #loadIllust} 走「解码后定 ratio」的兜底路径。
+     * ratio 已知就套用(首帧即终值);未知时先用 {@link IllustsBean#getWidth()}/{@code getHeight()}
+     * (第 0 页真比)当「最开始的空白容器」,仍返回 {@code changeSize=true}——让 {@link #loadIllust}
+     * 走「解码后定 ratio」的兜底路径,用位图真尺寸覆盖占位;bean 也没有尺寸才退回固定占位高
+     * ({@code maxHeight} 或布局默认)。
      * @return changeSize:true 表示 ratio 未知、需解码后定。
      */
     private boolean applyRatioOrPlaceholder(ViewHolder<RecyIllustDetailBinding> holder, int position) {
@@ -339,8 +343,14 @@ public class IllustAdapter extends AbstractIllustAdapter<ViewHolder<RecyIllustDe
             holder.baseBind.illust.setHeightRatio(ratio);
             return false;
         }
-        int placeholder = maxHeight > 0 ? maxHeight : holder.baseBind.illust.getLayoutParams().height;
-        setFixedHeight(holder, placeholder);
+        int w = allIllust.getWidth();
+        int h = allIllust.getHeight();
+        if (w > 0 && h > 0) {
+            holder.baseBind.illust.setHeightRatio((float) h / w);
+            return true;
+        }
+        int placeholderHeight = maxHeight > 0 ? maxHeight : holder.baseBind.illust.getLayoutParams().height;
+        setFixedHeight(holder, placeholderHeight);
         return true;
     }
 
@@ -550,7 +560,9 @@ public class IllustAdapter extends AbstractIllustAdapter<ViewHolder<RecyIllustDe
      * 兜底路径:该页 ratio 事先未知(无网页 ajax 尺寸、精简 bean 无有效 meta 宽高)时,图片解码完成后
      * 用位图宽高定下并缓存该页展示 ratio,并即时套到 {@link ceui.lisa.view.DynamicHeightImageView}。
      * 缓存进 {@link #pageRatio} → 回收重绑首帧直接套用,不再「占位高→自然高」跳。仅 {@code changeSize}
-     * (ratio 未知)页生效;ratio 已知的页高度绑定时就摆正,不进此路径。
+     * (ratio 未知)页生效——绑定时即使已用 {@link IllustsBean#getWidth()}/{@code getHeight()} 垫了
+     * 空白容器(见 {@link #applyRatioOrPlaceholder}),也仍走这里校正为真 ratio;ratio 已知的页高度
+     * 绑定时就摆正,不进此路径。
      */
     private void rememberDecodedRatio(ViewHolder<RecyIllustDetailBinding> holder, int position,
                                       boolean changeSize, Bitmap resource) {
@@ -571,9 +583,10 @@ public class IllustAdapter extends AbstractIllustAdapter<ViewHolder<RecyIllustDe
      * 后续页首次绑定时,{@link ceui.lisa.view.DynamicHeightImageView} 用真实宽 × ratio 算高,首帧就量
      * 在终值上,消除那一跳。ratio 与解码兜底同一套口径,不会二次跳。
      * <p>{@code dims} 按页序:{@code dims.get(i) = {width, height}} 对应第 i 页。cookie 缺失 / 接口
-     * 失败时上层根本不会调用它 → 保持解码后定 ratio 的兜底行为。<b>静默写表、不 notify</b>:已在屏的页
-     * 保留各自的解码兜底(强行 rebind 会闪),尚未绑定的页(折叠 3P+ 展开、上滑新上屏)自然读表命中——
-     * 正是首帧跳最明显的场景。
+     * 失败时上层根本不会调用它 → 页仍先用 {@link IllustsBean#getWidth()}/{@code getHeight()} 当
+     * 空白容器、图片解码后再校正(见 {@link #applyRatioOrPlaceholder})。<b>静默写表、不 notify</b>:
+     * 已在屏的页保留各自当前的占位/解码比(强行 rebind 会闪),尚未绑定的页(折叠 3P+ 展开、上滑新上屏)
+     * 自然读表命中——正是首帧跳最明显的场景。
      */
     public void seedPageDimensions(@Nullable List<int[]> dims) {
         if (released || dims == null || dims.isEmpty()) {

--- a/app/src/main/java/ceui/lisa/fragments/FragmentIllustViewModel.kt
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentIllustViewModel.kt
@@ -35,7 +35,8 @@ class FragmentIllustViewModel(private val illustId: Long) : ViewModel() {
     val hasDownload: LiveData<Boolean> = _hasDownload
 
     // ── 每页真实宽高(网页 ajax /ajax/illust/{id}/pages)──
-    // 与 ArtworkV3ViewModel 同一套:多 P 时提前拿到每页宽高,让顶部大图下载前就按真 ratio 摆准高度。
+    // 与 ArtworkV3ViewModel 同一套:详情页先用 IllustsBean 的 width/height 当空白容器;
+    // 多 P 时提前拿到每页真实宽高,让顶部大图下载前就按真 ratio 摆准高度。
     // Fragment 观察 [pageDimensions] 喂给 IllustAdapter.seedPageDimensions;缺 cookie/失败静默降级。
     private val _pageDimensions = MutableLiveData<List<IntArray>>()
 

--- a/app/src/main/java/ceui/loxia/IllustDetailSupport.kt
+++ b/app/src/main/java/ceui/loxia/IllustDetailSupport.kt
@@ -232,8 +232,9 @@ private fun WebIllustBody.toIllustsBean(illustId: Long, webPages: List<WebIllust
 
 /**
  * 网页 ajax `/ajax/illust/{id}/pages` 拉每一 P 的真实原图宽高（`[width, height]`,按页序）。
- * app-api 的 meta_pages 只有 image_urls、不带宽高;详情页多 P 靠它在下载前预置每页展示 ratio,
- * 消除「兜底高→自然高」的首帧跳(见 IllustAdapter.seedPageDimensions)。
+ * 注:详情页多 P 在真实宽高到来前,先用 {@code IllustsBean} 的 width/height当
+ * 「最开始的空白容器」(见 IllustAdapter.applyRatioOrPlaceholder);这里的网页 ajax 再补每 P 真实
+ * 原图宽高做精修,把后续页展示高度摆准,消除「占位比→自然比」的首帧跳(见 IllustAdapter.seedPageDimensions)。
  *
  * SFW 作品无 cookie 也能拿;R18 / 受限 / 删除作品或缺 cookie 时接口返回 error/空 → 返回 null,
  * 调用方沿用「图片解码后异步定高」的兜底,**不影响使用**。协程取消照常向上抛,不吞。

--- a/app/src/main/java/ceui/loxia/Models.kt
+++ b/app/src/main/java/ceui/loxia/Models.kt
@@ -670,6 +670,8 @@ data class BlockSaveRequest(
 
 // 网页 ajax /ajax/illust/{id}/pages 的 body 元素:每一 P 的真实原图宽高与图片地址。
 // 宽高供详情页多 P 下载前预置展示高度(见 IllustAdapter.seedPageDimensions);
+// 详情页多 P 先用 IllustsBean 的 width/height 当「最开始的空白容器」,
+// 这里的 width/height 是每 P 真实原图宽高,供 ajax 精修。
 // urls 供 #592 受限作品 web 兜底时拼 meta_pages。
 data class WebIllustPage(
     val width: Int = 0,

--- a/app/src/main/java/ceui/loxia/PixivWebApi.kt
+++ b/app/src/main/java/ceui/loxia/PixivWebApi.kt
@@ -25,9 +25,10 @@ interface PixivWebApi {
     ): WebResponse<WebIllustBody>
 
     /**
-     * 每一 P 的真实原图宽高(app-api 的 meta_pages 只给 image_urls、不带宽高)。详情页多 P 用它在
-     * 下载前就把后续页展示高度摆准,消除首帧「兜底高→自然高」的跳。需要网页 cookie;缺失时接口
-     * 会 error/403,调用方静默降级到图片就绪后的异步定高。见 IllustAdapter.seedPageDimensions。
+     * 每一 P 的真实原图宽高。详情页多 P 先用 {@code IllustsBean} 的 width/height 当「最开始的
+     * 空白容器」,这里再补每 P 真实原图宽高做精修,把后续页展示高度摆准,消除首帧
+     * 「占位比→自然比」的跳。需要网页 cookie;缺失时接口会 error/403,调用方静默降级到图片就绪后的
+     * 异步定高。见 IllustAdapter.seedPageDimensions。
      */
     @GET("/ajax/illust/{illust_id}/pages?lang=zh")
     suspend fun getIllustPages(

--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3ViewModel.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3ViewModel.kt
@@ -56,8 +56,9 @@ class ArtworkV3ViewModel(
     }
 
     // ── 每页真实宽高(网页 ajax /ajax/illust/{id}/pages)──
-    // app-api 的 meta_pages 不带每 P 宽高;这里补上,供顶部大图在下载前按真 ratio 预置各页高度,
-    // 消除多 P 首帧「兜底高→自然高」的跳。Fragment 观察 [pageDimensions] 喂给 IllustAdapter。
+    // 详情页先用 IllustsBean 的 width/height 当空白容器;这里再补每 P 真实原图宽高,供顶部大图
+    // 在下载前按真 ratio 预置各页高度,消除多 P 首帧「占位比→自然比」的跳。
+    // Fragment 观察 [pageDimensions] 喂给 IllustAdapter。
     private val _pageDimensions = MutableLiveData<List<IntArray>>()
 
     /** 每一 P 的 [width, height],按页序;缺 cookie / 接口失败则不发射(沿用解码后异步定高)。 */

--- a/app/src/main/java/ceui/pixiv/ui/detail/CollapsibleIllustAdapter.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/CollapsibleIllustAdapter.kt
@@ -99,6 +99,10 @@ class CollapsibleIllustAdapter(
      * 原样不动、依旧无黑边贴顶。
      */
     private fun floorCoverHeight(holder: ViewHolder<RecyIllustDetailBinding>) {
+        // 只对漫画宽封面和单 P 插画兜高:多 P 插画首图保持真比例,不做 maxHeight 垫高
+        // 否则宽幅插画（P > 3）的首图在 V3 沉浸式里会错误的出现上下空白边
+        // 漫画保留兜高,是为了托住「展开剩余 X 张」胶囊不顶进 toolbar(见 8c8665711)。
+        if ("manga" != illust.type || illust.page_count != 1) return
         val image = holder.baseBind.illust
         val w = illust.width
         val h = illust.height


### PR DESCRIPTION
- IllustAdapter.applyRatioOrPlaceholder:该页真 ratio 未知时先用 IllustsBean 的 width/height(第 0 页真比)当「最开始的空白容器」,仍 changeSize=true 走解码后定 ratio 兜底;网页 ajax(seedPageDimensions)与解码位图(rememberDecodedRatio)照旧覆盖,多 P 后续页首帧即有确定展示盒
- CollapsibleIllustAdapter.floorCoverHeight 仅对漫画宽封面和单P插画兜高:多 P 插画首图保持真比例,不再被 maxHeight 垫出上下空白边;漫画保留兜高托住「展开剩余 X 张」胶囊不顶进 toolbar
- 同步订正 IllustDetailSupport/PixivWebApi/Models/两套 VM 注释,统一「IllustsBean 宽高当空白容器、ajax 精修（ajax失败等图解出高宽）」的口径