### PR TITLE
feat(ugoira): 动图自动播放开关与预览图呈现/播放交互优化

### DIFF
--- a/app/src/main/java/ceui/lisa/fragments/FragmentSettingsViewing.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSettingsViewing.java
@@ -143,6 +143,18 @@ public class FragmentSettingsViewing extends SettingsPageFragment<FragmentSettin
         });
         baseBind.ugoiraRifeEnableRela.setOnClickListener(v -> baseBind.ugoiraRifeEnable.performClick());
 
+        //动画(ugoira) 自动播放，默认开启。关闭后详情页不自动下载/播放，在图片中间显示「开始播放（下载）」按钮。
+        baseBind.ugoiraAutoPlay.setChecked(Shaft.sSettings.isAutoPlayUgoira());
+        baseBind.ugoiraAutoPlay.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                Shaft.sSettings.setAutoPlayUgoira(isChecked);
+                Common.showToast(getString(R.string.string_428));
+                Local.setSettings(Shaft.sSettings);
+            }
+        });
+        baseBind.ugoiraAutoPlayRela.setOnClickListener(v -> baseBind.ugoiraAutoPlay.performClick());
+
         // 看图时保留状态栏(刘海/挖孔)区域（issue #724），默认关闭。
         baseBind.keepStatusBarWhenViewImage.setChecked(Shaft.sSettings.isKeepStatusBarWhenViewImage());
         baseBind.keepStatusBarWhenViewImage.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {

--- a/app/src/main/java/ceui/lisa/fragments/SettingsCatalog.kt
+++ b/app/src/main/java/ceui/lisa/fragments/SettingsCatalog.kt
@@ -119,6 +119,7 @@ object SettingsCatalog {
         add(Entry(VIEWING, "novel_direct_reader_rela", R.string.novel_direct_reader, R.string.novel_direct_reader_desc, keywords = "小说 正文 阅读器 略过详情 跳过详情 直接阅读 novel reader skip detail"))
         add(Entry(VIEWING, "transform_type_rela", R.string.string_393, keywords = "翻页 动画 切页 过渡 特效 transformer"))
         add(Entry(VIEWING, "ugoira_rife_enable_rela", R.string.ugoira_rife_enable, R.string.ugoira_rife_enable_desc, keywords = "动图 补帧 插帧 rife 帧率 60fps 顺滑 丝滑 ugoira interpolation"))
+        add(Entry(VIEWING, "ugoira_auto_play_rela", R.string.ugoira_auto_play, keywords = "动图 自动播放 自动下载 播放 gif ugoira auto play download"))
         add(Entry(VIEWING, "keep_status_bar_when_view_image_rela", R.string.keep_status_bar_when_view_image, keywords = "状态栏 刘海 挖孔 全屏 沉浸 notch"))
         add(Entry(VIEWING, "illust_detail_keep_screen_on_rela", R.string.string_451, keywords = "常亮 息屏 熄屏 屏幕 keep screen on"))
         add(Entry(VIEWING, "use_custom_double_tap_zoom_rela", R.string.use_custom_double_tap_zoom, keywords = "双击 放大 缩放 zoom"))

--- a/app/src/main/java/ceui/lisa/utils/Settings.java
+++ b/app/src/main/java/ceui/lisa/utils/Settings.java
@@ -312,6 +312,11 @@ public class Settings {
     // 对帧序列做 2x 插帧,帧率翻倍;模型未下载则静默回落原始帧率
     private boolean ugoiraRifeEnable = false;
 
+    // auto play ugoira on detail page; default true. When disabled, show a center
+    // "start playback (download)" button instead of auto download/play, and never
+    // auto-play on swipe-back even if frames are already cached.
+    private boolean autoPlayUgoira = true;
+
     // 冷启动时是否自动刷新首页推荐插画（issue #955），默认开启（保持本地优先的原语义）。
     // 关掉后冷启命中磁盘快照就停在快照上，由用户下拉刷新才拉新内容
     private boolean autoRefreshHomeFeed = true;
@@ -1024,6 +1029,14 @@ public class Settings {
 
     public void setUgoiraRifeEnable(boolean ugoiraRifeEnable) {
         this.ugoiraRifeEnable = ugoiraRifeEnable;
+    }
+
+    public boolean isAutoPlayUgoira() {
+        return autoPlayUgoira;
+    }
+
+    public void setAutoPlayUgoira(boolean autoPlayUgoira) {
+        this.autoPlayUgoira = autoPlayUgoira;
     }
 
     public boolean isAutoRefreshHomeFeed() {

--- a/app/src/main/java/ceui/lisa/utils/Settings.java
+++ b/app/src/main/java/ceui/lisa/utils/Settings.java
@@ -312,9 +312,8 @@ public class Settings {
     // 对帧序列做 2x 插帧,帧率翻倍;模型未下载则静默回落原始帧率
     private boolean ugoiraRifeEnable = false;
 
-    // auto play ugoira on detail page; default true. When disabled, show a center
-    // "start playback (download)" button instead of auto download/play, and never
-    // auto-play on swipe-back even if frames are already cached.
+    // 详情页动图(ugoira)自动播放,默认开启(行为不变)。关闭后进详情不自动下载/播放,
+    // 图片中间显示「开始播放(下载)」按钮;已缓存或左右切回也不自动播,点按钮才开始。
     private boolean autoPlayUgoira = true;
 
     // 冷启动时是否自动刷新首页推荐插画（issue #955），默认开启（保持本地优先的原语义）。

--- a/app/src/main/java/ceui/pixiv/ui/detail/UgoiraPlayerView.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/UgoiraPlayerView.kt
@@ -221,18 +221,13 @@ class UgoiraPlayerView @JvmOverloads constructor(
         }
     }
 
-    /** 关闭自动播放时按钮直接显示，不做淡入——左右切入不会出现动画闪烁。 */
+    /** 关闭自动播放时按钮直接显隐，不做淡入——左右切入不会出现动画闪烁。 */
     private fun showPlayButton() {
-        if (playButton.isVisible && playButton.alpha == 1f) return
-        playButton.animate().cancel()
         playButton.isVisible = true
-        playButton.alpha = 1f
     }
 
     private fun hidePlayButton() {
-        playButton.animate().cancel()
         playButton.isVisible = false
-        playButton.alpha = 1f
     }
 
     private var job: Job? = null
@@ -308,7 +303,7 @@ class UgoiraPlayerView @JvmOverloads constructor(
         if (!playbackActive) loadPreview(illust)
         // 关闭自动播放时，按钮在预加载（view 创建）阶段就显示，不依赖页面激活；
         // 左右切入时按钮跟着页面一起进来，不会中途闪现；无论是否点过播放都显示。
-        if (!playbackActive && !Shaft.sSettings.isAutoPlayUgoira()) {
+        if (!playbackActive && !Shaft.sSettings.isAutoPlayUgoira) {
             showPlayButton()
         }
 
@@ -342,9 +337,7 @@ class UgoiraPlayerView @JvmOverloads constructor(
         retryButton.setOnClickListener(null)
         retryButton.isVisible = false
         playButton.setOnClickListener(null)
-        playButton.animate().cancel()
         playButton.isVisible = false
-        playButton.alpha = 1f
         downloadInFlight = false
         hideOverlay()
         previewIllustId = null

--- a/app/src/main/java/ceui/pixiv/ui/detail/UgoiraPlayerView.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/UgoiraPlayerView.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.StaggeredGridLayoutManager
+import ceui.lisa.activities.Shaft
 import ceui.lisa.R
 import ceui.lisa.models.IllustsBean
 import ceui.lisa.utils.GlideUtil
@@ -142,6 +143,39 @@ class UgoiraPlayerView @JvmOverloads constructor(
         )
     }
 
+    // 「开始播放（下载）」按钮：关闭「动图自动播放」时显示在图片中间，点击才拉数据 →
+    // 下载 → 解压 → 编码 → 播放。样式与「重试」按钮同一套视觉语言。
+    private val playButton = LinearLayout(context).apply {
+        orientation = LinearLayout.HORIZONTAL
+        gravity = Gravity.CENTER_VERTICAL
+        setPadding(18.ppppx, 9.ppppx, 20.ppppx, 9.ppppx)
+        isClickable = true
+        isFocusable = true
+        isVisible = false
+        background = buildRetryPill()
+        addView(
+            ImageView(context).apply {
+                setImageResource(R.drawable.ic_baseline_play_arrow_24)
+                scaleType = ImageView.ScaleType.FIT_CENTER
+                imageTintList = ColorStateList.valueOf(0xFFFFFFFF.toInt())
+            },
+            LinearLayout.LayoutParams(18.ppppx, 16.ppppx).apply { marginEnd = 7.ppppx },
+        )
+        addView(
+            TextView(context).apply {
+                setText(R.string.ugoira_start_play_button)
+                setTextColor(0xFFFFFFFF.toInt())
+                textSize = 14f
+                typeface = Typeface.DEFAULT_BOLD
+                letterSpacing = 0.02f
+            },
+            LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT,
+            ),
+        )
+    }
+
     /** 主题实心圆角胶囊 + 白色按压波纹(裁到胶囊形状)。 */
     private fun buildRetryPill(): Drawable {
         val radius = 999f
@@ -194,6 +228,10 @@ class UgoiraPlayerView @JvmOverloads constructor(
             retryButton,
             LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT, Gravity.CENTER),
         )
+        addView(
+            playButton,
+            LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT, Gravity.CENTER),
+        )
     }
 
     /** 绑定一条 ugoira。进入即自动拉数据 → 下载 → 解压 → 编码 → 播放。 */
@@ -226,6 +264,10 @@ class UgoiraPlayerView @JvmOverloads constructor(
             pausePlayback()
             startLoad(owner, illust)
         }
+        playButton.setOnClickListener {
+            pausePlayback()
+            startLoad(owner, illust)
+        }
         resumePlayback()
     }
 
@@ -246,6 +288,8 @@ class UgoiraPlayerView @JvmOverloads constructor(
         autoHealedDir = null
         retryButton.setOnClickListener(null)
         retryButton.isVisible = false
+        playButton.setOnClickListener(null)
+        playButton.isVisible = false
         glide.clear(imageView)
         imageView.setImageDrawable(null)
     }
@@ -261,6 +305,7 @@ class UgoiraPlayerView @JvmOverloads constructor(
         // 离屏 holder 还压着一张全尺寸 Bitmap。
         glide.clear(imageView)
         imageView.setImageDrawable(null)
+        playButton.isVisible = false
         hideOverlay()
     }
 
@@ -272,12 +317,19 @@ class UgoiraPlayerView @JvmOverloads constructor(
             !owner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
         ) return
         glide.load(GlideUtil.getLargeImage(illust)).into(imageView)
+        // 关闭「动图自动播放」时：只打底预览图并显示中间按钮，任何路径（进页/左右切回/
+        // 滚回屏幕/已缓存秒开）都不自动拉数据或播放，只有点按钮才 startLoad。
+        if (!Shaft.sSettings.isAutoPlayUgoira()) {
+            playButton.isVisible = true
+            return
+        }
         startLoad(owner, illust)
     }
 
     private fun startLoad(owner: LifecycleOwner, illust: IllustsBean) {
         playbackActive = true
         job?.cancel()
+        playButton.isVisible = false
         retryButton.isVisible = false
         // 秒开:内存已有帧序列就立刻播,不等协程、不显示浮层(主线程零 IO,不碰文件系统)。
         val ready = UgoiraEngine.peekReadyInMemory(illust.id)

--- a/app/src/main/java/ceui/pixiv/ui/detail/UgoiraPlayerView.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/UgoiraPlayerView.kt
@@ -27,6 +27,7 @@ import ceui.lisa.activities.Shaft
 import ceui.lisa.R
 import ceui.lisa.models.IllustsBean
 import ceui.lisa.utils.GlideUtil
+import ceui.lisa.utils.GlideUrlChild
 import ceui.pixiv.ui.bulk.UGOIRA_LOG_TAG
 import ceui.pixiv.ui.bulk.UgoiraEngine
 import ceui.pixiv.ui.bulk.UgoiraPhase
@@ -34,6 +35,7 @@ import ceui.pixiv.ui.bulk.UgoiraProgress
 import ceui.pixiv.utils.ppppx
 import ceui.pixiv.ui.bulk.UgoiraFrames
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -195,15 +197,57 @@ class UgoiraPlayerView @JvmOverloads constructor(
         overlay.isVisible = false
     }
 
+    /**
+     * 打底预览图：先用列表页大概率已缓存的 medium 秒出，再让 large 异步覆盖，
+     * 避免进详情页时 large 首次网络下载导致的长时间空白。
+     */
+    private fun loadPreview(illust: IllustsBean) {
+        if (previewIllustId == illust.id && imageView.drawable != null) return
+        previewIllustId = illust.id
+        val large = GlideUtil.getLargeImage(illust) ?: return
+        val mediumUrl = illust.image_urls?.medium?.takeIf { it.isNotBlank() }
+        glide.clear(imageView)
+
+        var builder = glide.load(large)
+        if (mediumUrl != null) {
+            // 有 medium：它大概率已在列表缓存，秒出打底；large 到位后直接替换，不做淡入。
+            builder = builder.thumbnail(glide.load(GlideUrlChild(mediumUrl)))
+            builder.into(imageView)
+        } else {
+            // 没有 medium：等 large 从网络/硬盘到达后淡入。
+            builder
+                .transition(DrawableTransitionOptions.withCrossFade(300))
+                .into(imageView)
+        }
+    }
+
+    /** 关闭自动播放时按钮直接显示，不做淡入——左右切入不会出现动画闪烁。 */
+    private fun showPlayButton() {
+        if (playButton.isVisible && playButton.alpha == 1f) return
+        playButton.animate().cancel()
+        playButton.isVisible = true
+        playButton.alpha = 1f
+    }
+
+    private fun hidePlayButton() {
+        playButton.animate().cancel()
+        playButton.isVisible = false
+        playButton.alpha = 1f
+    }
+
     private var job: Job? = null
     private var player: FrameSequencePlayer? = null
     private var playingDir: String? = null
     private var playbackActive = false
+    /** 点过播放且帧序列还没就绪（下载/解压/压制中）。切走再切回时继续显示进度、不弹按钮。 */
+    private var downloadInFlight = false
 
     /** 已为哪版帧序列自动自愈过(dir path)。同一版自愈一次仍坏就转手动重试,不无限循环重下。 */
     private var autoHealedDir: String? = null
     private var boundOwner: LifecycleOwner? = null
     private var boundIllust: IllustsBean? = null
+    /** 当前已加载/在加载的预览图对应的作品 id，用于重进去重。 */
+    private var previewIllustId: Int? = null
     private val lifecycleObserver = object : DefaultLifecycleObserver {
         override fun onResume(owner: LifecycleOwner) {
             resumePlayback()
@@ -238,6 +282,12 @@ class UgoiraPlayerView @JvmOverloads constructor(
     fun bind(owner: LifecycleOwner, illust: IllustsBean, maxHeight: Int) {
         if (boundIllust?.id != illust.id) {
             pausePlayback()
+            // 换了一条作品：旧的预览/帧画面不能残留，等新预览就位。
+            downloadInFlight = false
+            hideOverlay()
+            previewIllustId = null
+            glide.clear(imageView)
+            imageView.setImageDrawable(null)
         }
         if (boundOwner !== owner) {
             boundOwner?.lifecycle?.removeObserver(lifecycleObserver)
@@ -255,8 +305,11 @@ class UgoiraPlayerView @JvmOverloads constructor(
 
         // 预览图打底(拿到 gif 前先显示首帧/大图)。同一 holder 的无关重绑不能把正在播的 GIF
         // 又替换回预览图。
-        if (!playbackActive) {
-            glide.load(GlideUtil.getLargeImage(illust)).into(imageView)
+        if (!playbackActive) loadPreview(illust)
+        // 关闭自动播放时，按钮在预加载（view 创建）阶段就显示，不依赖页面激活；
+        // 左右切入时按钮跟着页面一起进来，不会中途闪现；无论是否点过播放都显示。
+        if (!playbackActive && !Shaft.sSettings.isAutoPlayUgoira()) {
+            showPlayButton()
         }
 
         Timber.tag(UGOIRA_LOG_TAG).i("[player] illust=%d bind %dx%d", illust.id, illust.width, illust.height)
@@ -289,7 +342,12 @@ class UgoiraPlayerView @JvmOverloads constructor(
         retryButton.setOnClickListener(null)
         retryButton.isVisible = false
         playButton.setOnClickListener(null)
+        playButton.animate().cancel()
         playButton.isVisible = false
+        playButton.alpha = 1f
+        downloadInFlight = false
+        hideOverlay()
+        previewIllustId = null
         glide.clear(imageView)
         imageView.setImageDrawable(null)
     }
@@ -301,12 +359,18 @@ class UgoiraPlayerView @JvmOverloads constructor(
         player?.stop()
         player = null
         playingDir = null
-        // 帧播放器的 Bitmap 由它自己回收;这里把 ImageView 上最后一张也摘掉,免得
-        // 离屏 holder 还压着一张全尺寸 Bitmap。
-        glide.clear(imageView)
-        imageView.setImageDrawable(null)
-        playButton.isVisible = false
-        hideOverlay()
+        // 不在这里清 ImageView；开关关闭时：下载/压制中保留进度浮层，否则把按钮放回来，
+        // 左右切回秒显、无弹跳；真正释放放在 recycle()（holder 进回收池）再做。
+        if (!Shaft.sSettings.isAutoPlayUgoira) {
+            if (downloadInFlight) {
+                // 保持进度浮层可见，切回继续显示进度，不弹按钮。
+            } else {
+                showPlayButton()
+                hideOverlay()
+            }
+        } else {
+            hideOverlay()
+        }
     }
 
     private fun resumePlayback() {
@@ -316,11 +380,16 @@ class UgoiraPlayerView @JvmOverloads constructor(
         if (!isAttachedToWindow ||
             !owner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
         ) return
-        glide.load(GlideUtil.getLargeImage(illust)).into(imageView)
+        loadPreview(illust)
         // 关闭「动图自动播放」时：只打底预览图并显示中间按钮，任何路径（进页/左右切回/
         // 滚回屏幕/已缓存秒开）都不自动拉数据或播放，只有点按钮才 startLoad。
-        if (!Shaft.sSettings.isAutoPlayUgoira()) {
-            playButton.isVisible = true
+        if (!Shaft.sSettings.isAutoPlayUgoira) {
+            if (downloadInFlight) {
+                // 之前点过播放、下载还在进行：切回继续走下载→播放，显示进度。
+                startLoad(owner, illust)
+            } else {
+                showPlayButton()
+            }
             return
         }
         startLoad(owner, illust)
@@ -328,8 +397,9 @@ class UgoiraPlayerView @JvmOverloads constructor(
 
     private fun startLoad(owner: LifecycleOwner, illust: IllustsBean) {
         playbackActive = true
+        downloadInFlight = true
         job?.cancel()
-        playButton.isVisible = false
+        hidePlayButton()
         retryButton.isVisible = false
         // 秒开:内存已有帧序列就立刻播,不等协程、不显示浮层(主线程零 IO,不碰文件系统)。
         val ready = UgoiraEngine.peekReadyInMemory(illust.id)
@@ -378,6 +448,7 @@ class UgoiraPlayerView @JvmOverloads constructor(
                 // 已经播上原速版了就别退回「重试」——补帧失败不该毁掉能看的画面
                 if (player == null) {
                     playbackActive = false
+                    downloadInFlight = false
                     hideOverlay()
                     retryButton.isVisible = true
                 }
@@ -393,6 +464,7 @@ class UgoiraPlayerView @JvmOverloads constructor(
     private fun playFrames(illust: IllustsBean, frames: UgoiraFrames) {
         if (playingDir == frames.dir.path) return
         if (frames.files.isEmpty()) return
+        downloadInFlight = false
         player?.stop()
         playingDir = frames.dir.path
         retryButton.isVisible = false
@@ -422,6 +494,8 @@ class UgoiraPlayerView @JvmOverloads constructor(
         pausePlayback()
         if (healedBefore) {
             Timber.tag(UGOIRA_LOG_TAG).w("[player] illust=%d 自愈后仍解码失败,转手动重试", illust.id)
+            // pausePlayback 会按开关把播放按钮放回来，这里只留「重试」，避免两个按钮叠一起。
+            hidePlayButton()
             retryButton.isVisible = true
         } else {
             autoHealedDir = frames.dir.path

--- a/app/src/main/res/layout/fragment_settings_viewing.xml
+++ b/app/src/main/res/layout/fragment_settings_viewing.xml
@@ -183,6 +183,24 @@
                 </RelativeLayout>
 
                 <RelativeLayout
+                    android:id="@+id/ugoira_auto_play_rela"
+                    style="@style/M3SetRow"
+                    android:background="@drawable/bg_m3_row_mid">
+
+                    <LinearLayout style="@style/M3SetTexts">
+
+                        <TextView
+                            style="@style/M3SetTitle"
+                            android:text="@string/ugoira_auto_play" />
+                    </LinearLayout>
+
+                    <androidx.appcompat.widget.SwitchCompat
+                        android:id="@+id/ugoira_auto_play"
+                        style="@style/M3SetSwitch" />
+
+                </RelativeLayout>
+
+                <RelativeLayout
                     android:id="@+id/keep_status_bar_when_view_image_rela"
                     style="@style/M3SetRow"
                     android:background="@drawable/bg_m3_row_mid">

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -2294,6 +2294,8 @@
     <string name="ugoira_rife_enable">Ugoira AI frame interpolation (RIFE)</string>
     <string name="ugoira_rife_enable_desc">Insert AI-generated in-between frames, boosting frame rate up to 4x (near the 50fps GIF ceiling). Requires downloading the interpolation model; encoding takes longer</string>
     <string name="ugoira_interpolating">Interpolating</string>
+    <string name="ugoira_auto_play">Auto-play ugoira</string>
+    <string name="ugoira_start_play_button">Start playback (download)</string>
     <string name="string_rife_model">Frame interpolation model</string>
     <string name="string_rife_download_title">Download RIFE model</string>
     <string name="string_rife_download_subtitle">%1$s needs to be downloaded to enable ugoira frame interpolation</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -2294,6 +2294,8 @@
     <string name="ugoira_rife_enable">うごイラ AI フレーム補間 (RIFE)</string>
     <string name="ugoira_rife_enable_desc">AI が中間フレームを生成し最大4倍のフレームレートに(GIF の 50fps 上限まで)。初回は補間モデルのダウンロードが必要で、エンコードに時間がかかります</string>
     <string name="ugoira_interpolating">フレーム補間中</string>
+    <string name="ugoira_auto_play">うごイラを自動再生</string>
+    <string name="ugoira_start_play_button">再生を開始（ダウンロード）</string>
     <string name="string_rife_model">フレーム補間モデル</string>
     <string name="string_rife_download_title">RIFE モデルをダウンロード</string>
     <string name="string_rife_download_subtitle">うごイラのフレーム補間には %1$s のダウンロードが必要です</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2294,6 +2294,8 @@
     <string name="ugoira_rife_enable">움직이는 일러스트 AI 프레임 보간 (RIFE)</string>
     <string name="ugoira_rife_enable_desc">AI 중간 프레임을 삽입해 최대 4배 프레임률로(GIF 50fps 상한까지). 보간 모델 다운로드가 필요하며 인코딩 시간이 길어집니다</string>
     <string name="ugoira_interpolating">프레임 보간 중</string>
+    <string name="ugoira_auto_play">움직이는 일러스트 자동 재생</string>
+    <string name="ugoira_start_play_button">재생 시작(다운로드)</string>
     <string name="string_rife_model">프레임 보간 모델</string>
     <string name="string_rife_download_title">RIFE 모델 다운로드</string>
     <string name="string_rife_download_subtitle">프레임 보간을 사용하려면 %1$s 다운로드가 필요합니다</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2294,6 +2294,8 @@
     <string name="ugoira_rife_enable">ИИ-интерполяция кадров угоира (RIFE)</string>
     <string name="ugoira_rife_enable_desc">Вставляет ИИ-кадры, повышая частоту до 4x (до потолка GIF 50fps). Требуется загрузка модели; кодирование занимает больше времени</string>
     <string name="ugoira_interpolating">Интерполяция</string>
+    <string name="ugoira_auto_play">Автовоспроизведение угоира</string>
+    <string name="ugoira_start_play_button">Начать воспроизведение (загрузка)</string>
     <string name="string_rife_model">Модель интерполяции кадров</string>
     <string name="string_rife_download_title">Загрузить модель RIFE</string>
     <string name="string_rife_download_subtitle">Для интерполяции кадров необходимо загрузить %1$s</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -2294,6 +2294,8 @@
     <string name="ugoira_rife_enable">Ugoira yapay zeka kare arası doldurma (RIFE)</string>
     <string name="ugoira_rife_enable_desc">Yapay zeka ara kareler ekleyerek kare hızını 4 kata kadar artırır (GIF 50fps sınırına yakın). Model indirmek gerekir; kodlama daha uzun sürer</string>
     <string name="ugoira_interpolating">Kare doldurma</string>
+    <string name="ugoira_auto_play">Ugoira otomatik oynatma</string>
+    <string name="ugoira_start_play_button">Oynatmayı başlat (indir)</string>
     <string name="string_rife_model">Kare doldurma modeli</string>
     <string name="string_rife_download_title">RIFE modelini indir</string>
     <string name="string_rife_download_subtitle">Kare doldurma için %1$s indirilmelidir</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -2296,6 +2296,8 @@
     <string name="ugoira_rife_enable">動圖 AI 補幀 (RIFE)</string>
     <string name="ugoira_rife_enable_desc">在相鄰幀之間插入 AI 生成的中間幀,自動補至最高 4 倍幀率(貼近 GIF 50fps 上限);首次使用需下載補幀模型,壓製耗時會變長</string>
     <string name="ugoira_interpolating">補幀中</string>
+    <string name="ugoira_auto_play">動圖自動播放</string>
+    <string name="ugoira_start_play_button">開始播放（下載）</string>
     <string name="string_rife_model">補幀模型</string>
     <string name="string_rife_download_title">下載 RIFE 補幀模型</string>
     <string name="string_rife_download_subtitle">%1$s 需要額外下載以啟用動圖 AI 補幀</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2496,6 +2496,8 @@
     <string name="ugoira_rife_enable">动图 AI 补帧 (RIFE)</string>
     <string name="ugoira_rife_enable_desc">在相邻帧之间插入 AI 生成的中间帧,自动补至最高 4 倍帧率(贴近 GIF 50fps 上限);首次使用需下载补帧模型,压制耗时会变长</string>
     <string name="ugoira_interpolating">补帧中</string>
+    <string name="ugoira_auto_play">动图自动播放</string>
+    <string name="ugoira_start_play_button">开始播放（下载）</string>
     <string name="string_rife_model">补帧模型</string>
     <string name="string_rife_download_title">下载 RIFE 补帧模型</string>
     <string name="string_rife_download_subtitle">%1$s 需要额外下载以启用动图 AI 补帧</string>


### PR DESCRIPTION
## 改动内容

### 1. 动图（ugoira）自动播放开关
- 新增设置项「动图自动播放」（默认开启，行为不变），位于 设置 → 看图与详情。
- 关闭后：进入动图详情页不再自动下载/播放，图片中间显示「开始播放（下载）」按钮；即使已缓存或左右切回也不会自动播放。
- 点击按钮才开始 下载 → 解压 → 编码 → 播放。

### 2. 预览图呈现优化
- 渐进式呈现：优先用列表页大概率已缓存的 medium 秒出打底，避免 large 首次网络下载时的长时间空白；large 到位后平滑覆盖。
- 无 medium 兜底时，large 从网络/硬盘到达后以 300ms 淡入呈现，不突兀闪现。
- 播放按钮、进度浮层与预览图分层协调：按钮在预加载阶段就位，左右切入切出即时显隐，无动画闪烁；点过播放且正在下载/压制中时，切走再切回继续显示进度并自动续播，不弹按钮。

## 涉及文件
- app/src/main/java/ceui/lisa/utils/Settings.java
- app/src/main/java/ceui/lisa/fragments/FragmentSettingsViewing.java
- app/src/main/java/ceui/lisa/fragments/SettingsCatalog.kt
- app/src/main/java/ceui/pixiv/ui/detail/UgoiraPlayerView.kt
- app/src/main/res/layout/fragment_settings_viewing.xml
- app/src/main/res/values*/strings.xml（7 语言）