### PR TITLE
feat(settings): 小说列表标签可完全不折叠，新增开关默认开启 (#978)

### DIFF
--- a/app/src/main/java/ceui/lisa/fragments/FragmentSettingsAppearance.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSettingsAppearance.java
@@ -181,6 +181,19 @@ public class FragmentSettingsAppearance extends SettingsPageFragment<FragmentSet
         baseBind.showNovelCardTagsRela.setOnClickListener(v ->
                 baseBind.showNovelCardTags.performClick());
 
+        // 小说列表卡片标签折叠
+        baseBind.collapseNovelCardTags.setChecked(Shaft.sSettings.isCollapseNovelCardTags());
+        baseBind.collapseNovelCardTags.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                Shaft.sSettings.setCollapseNovelCardTags(isChecked);
+                Common.showToast(getString(R.string.string_428));
+                Local.setSettings(Shaft.sSettings);
+            }
+        });
+        baseBind.collapseNovelCardTagsRela.setOnClickListener(v ->
+                baseBind.collapseNovelCardTags.performClick());
+
         // 首页导航栏初始化位置
         String navigationInitPositionSettingValue = Shaft.sSettings.getNavigationInitPosition();
         final String navigationInitPosition = !TextUtils.isEmpty(navigationInitPositionSettingValue)

--- a/app/src/main/java/ceui/lisa/utils/Settings.java
+++ b/app/src/main/java/ceui/lisa/utils/Settings.java
@@ -151,6 +151,9 @@ public class Settings {
     //小说卡片是否显示标签
     private boolean showNovelCardTags = true;
 
+    //小说列表卡片标签是否折叠（超过 6 个换成「+N」），默认折叠
+    private boolean collapseNovelCardTags = true;
+
     //直接下载单个作品所有P
     private boolean directDownloadAllImage = true;
 
@@ -984,6 +987,14 @@ public class Settings {
 
     public void setShowNovelCardTags(boolean showNovelCardTags) {
         this.showNovelCardTags = showNovelCardTags;
+    }
+
+    public boolean isCollapseNovelCardTags() {
+        return collapseNovelCardTags;
+    }
+
+    public void setCollapseNovelCardTags(boolean collapseNovelCardTags) {
+        this.collapseNovelCardTags = collapseNovelCardTags;
     }
 
     public boolean isIllustDetailKeepScreenOn() {

--- a/app/src/main/java/ceui/pixiv/ui/common/NovelFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/NovelFeedFragment.kt
@@ -204,13 +204,14 @@ abstract class NovelFeedFragment(
         // AI 生成角标（novel_ai_type == 2，与 card/v3/history/detail 同口径）
         b.badgeAi.isVisible = novel.novel_ai_type == 2
 
-        // 标签流：尊重「显示标签」设置，关时喂空列表折叠。compact + 去 # 前缀 + 超 6 折叠成「+N」，
+        // 标签流：尊重「显示标签」设置，关时喂空列表折叠。compact + 去 # 前缀，
+        // 「标签折叠」开关开启时超 6 个折叠成「+N」，关闭时 maxTags=-1 全量展示；
         // searchIndex=1 让点击跳搜索页「小说」tab。
         val tags = if (Shaft.sSettings.isShowNovelCardTags()) novel.tags.orEmpty() else emptyList()
         b.novelTag.compact = true
         b.novelTag.searchIndex = 1
         b.novelTag.showHashPrefix = false
-        b.novelTag.maxTags = 6
+        b.novelTag.maxTags = if (Shaft.sSettings.isCollapseNovelCardTags) 6 else -1
         b.novelTag.setTags(tags)
         b.novelTag.isVisible = tags.isNotEmpty()
 

--- a/app/src/main/res/layout/fragment_settings_appearance.xml
+++ b/app/src/main/res/layout/fragment_settings_appearance.xml
@@ -216,7 +216,7 @@
                 <RelativeLayout
                     android:id="@+id/show_novel_card_tags_rela"
                     style="@style/M3SetRow"
-                    android:background="@drawable/bg_m3_row_bottom">
+                    android:background="@drawable/bg_m3_row_mid">
 
                     <LinearLayout style="@style/M3SetTexts">
 
@@ -227,6 +227,24 @@
 
                     <androidx.appcompat.widget.SwitchCompat
                         android:id="@+id/show_novel_card_tags"
+                        style="@style/M3SetSwitch" />
+
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:id="@+id/collapse_novel_card_tags_rela"
+                    style="@style/M3SetRow"
+                    android:background="@drawable/bg_m3_row_bottom">
+
+                    <LinearLayout style="@style/M3SetTexts">
+
+                        <TextView
+                            style="@style/M3SetTitle"
+                            android:text="@string/collapse_novel_card_tags_setting" />
+                    </LinearLayout>
+
+                    <androidx.appcompat.widget.SwitchCompat
+                        android:id="@+id/collapse_novel_card_tags"
                         style="@style/M3SetSwitch" />
 
                 </RelativeLayout>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1009,6 +1009,7 @@
     <string name="rate_dialog_maybe_later">Maybe Later</string>
     <string name="rate_dialog_never">Don\'t ask again</string>
     <string name="show_novel_card_tags_setting">Show tags on novel cards</string>
+    <string name="collapse_novel_card_tags_setting">Collapse tags on novel cards</string>
     <string name="string_discovery">Discover</string>
     <string name="download_records_export">Export download records</string>
     <string name="download_records_import">Import download records</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1009,6 +1009,7 @@
     <string name="rate_dialog_maybe_later">あとで</string>
     <string name="rate_dialog_never">今後表示しない</string>
     <string name="show_novel_card_tags_setting">小説カードにタグを表示</string>
+    <string name="collapse_novel_card_tags_setting">小説リストのタグを折りたたむ</string>
     <string name="string_discovery">発見</string>
     <string name="download_records_export">ダウンロード履歴をエクスポート</string>
     <string name="download_records_import">ダウンロード履歴をインポート</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1009,6 +1009,7 @@
     <string name="rate_dialog_maybe_later">나중에</string>
     <string name="rate_dialog_never">다시 묻지 않기</string>
     <string name="show_novel_card_tags_setting">소설 카드에 태그 표시</string>
+    <string name="collapse_novel_card_tags_setting">소설 목록 태그 접기</string>
     <string name="string_discovery">탐색</string>
     <string name="download_records_export">다운로드 기록 내보내기</string>
     <string name="download_records_import">다운로드 기록 가져오기</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1009,6 +1009,7 @@
     <string name="rate_dialog_maybe_later">Позже</string>
     <string name="rate_dialog_never">Больше не спрашивать</string>
     <string name="show_novel_card_tags_setting">Показывать теги на карточках новелл</string>
+    <string name="collapse_novel_card_tags_setting">Сворачивать теги на карточках новелл</string>
     <string name="string_discovery">Обзор</string>
     <string name="download_records_export">Экспорт истории загрузок</string>
     <string name="download_records_import">Импорт истории загрузок</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1009,6 +1009,7 @@
     <string name="rate_dialog_maybe_later">Sonra</string>
     <string name="rate_dialog_never">Bir daha sorma</string>
     <string name="show_novel_card_tags_setting">Roman kartlarında etiketleri göster</string>
+    <string name="collapse_novel_card_tags_setting">Roman kartlarında etiketleri daralt</string>
     <string name="string_discovery">Keşfet</string>
     <string name="download_records_export">İndirme kayıtlarını dışa aktar</string>
     <string name="download_records_import">İndirme kayıtlarını içe aktar</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1011,6 +1011,7 @@
     <string name="rate_dialog_maybe_later">以後再說</string>
     <string name="rate_dialog_never">不再提醒</string>
     <string name="show_novel_card_tags_setting">小說列表顯示標籤</string>
+    <string name="collapse_novel_card_tags_setting">小說列表標籤摺疊</string>
     <string name="string_discovery">發現</string>
     <string name="download_records_export">匯出下載記錄</string>
     <string name="download_records_import">匯入下載記錄</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1073,6 +1073,7 @@
     <string name="rate_dialog_never">不再提醒</string>
 
     <string name="show_novel_card_tags_setting">小说列表显示标签</string>
+    <string name="collapse_novel_card_tags_setting">小说列表标签折叠</string>
 
     <string name="string_discovery">发现</string>
 


### PR DESCRIPTION
实现 #978 中的第 3 点：小说列表标签可完全不折叠。

- 设置 > 界面 新增「小说列表标签折叠」开关，默认开启，与原行为一致（超过 6 个标签折叠为 +N）；
- 关闭开关后，小说卡片标签全量展示，不再折叠；
- 开关位置紧邻「小说列表显示标签」，便于一起调整。

同步修改：Settings 字段与存取、设置页布局与绑定、小说卡片渲染（maxTags）、7 个语言资源。