### PR TITLE
fix(drawer): 侧边栏头像跟随站外修改自动更新，关联 #978

### DIFF
--- a/app/src/main/java/ceui/lisa/activities/MainActivity.java
+++ b/app/src/main/java/ceui/lisa/activities/MainActivity.java
@@ -148,6 +148,8 @@ public class MainActivity extends BaseActivity<ActivityCoverBinding> {
         LocalBroadcastManager.getInstance(this).registerReceiver(profileReadyReceiver, profileFilter);
 
         initDrawerHeader();
+        // 账号数据变化（登录/切号/编辑资料/前台静默同步）时自动重绑侧边栏账号区
+        SessionManager.INSTANCE.getLoggedInAccount().observe(this, account -> initDrawerHeader());
         baseBind.drawerHeader.setOnClickListener(v -> openMyUserPage());
         // 侧边栏头像单击进自己主页；长按仍是 R18 临时过滤开关
         baseBind.userHead.setOnClickListener(v -> openMyUserPage());
@@ -707,10 +709,9 @@ public class MainActivity extends BaseActivity<ActivityCoverBinding> {
     @Override
     protected void onResume() {
         super.onResume();
-        if (Dev.refreshUser) {
-            initDrawerHeader();
-            Dev.refreshUser = false;
-        }
+        // 回到前台时静默拉一次自己的资料（去抖 + 失败静默），在站外换头像后也能自动更新；
+        // 侧边栏账号区由 loggedInAccount 观察者负责重绑，Dev.refreshUser 开关已不再需要。
+        SessionManager.INSTANCE.syncLoggedInProfileIfNeeded();
         // 发现入口(画像)/ 聊天室 / 广场开关可能在别的页面变化,回来时重建抽屉
         buildDrawerMenu();
     }

--- a/app/src/main/java/ceui/lisa/activities/MainActivity.java
+++ b/app/src/main/java/ceui/lisa/activities/MainActivity.java
@@ -147,8 +147,9 @@ public class MainActivity extends BaseActivity<ActivityCoverBinding> {
                 ceui.pixiv.db.discovery.ProfileManager.ACTION_PROFILE_READY);
         LocalBroadcastManager.getInstance(this).registerReceiver(profileReadyReceiver, profileFilter);
 
-        initDrawerHeader();
-        // 账号数据变化（登录/切号/编辑资料/前台静默同步）时自动重绑侧边栏账号区
+        // 侧边栏账号区完全由会话驱动：observe 在 onStart 先回放当前账号完成首绑,
+        // 之后登录/切号/编辑资料/前台静默同步的每次写回都会自动重绑,不再需要
+        // 手动 initDrawerHeader() 首绑 + Dev.refreshUser 在 onResume 补刷那一套。
         SessionManager.INSTANCE.getLoggedInAccount().observe(this, account -> initDrawerHeader());
         baseBind.drawerHeader.setOnClickListener(v -> openMyUserPage());
         // 侧边栏头像单击进自己主页；长按仍是 R18 临时过滤开关
@@ -709,8 +710,8 @@ public class MainActivity extends BaseActivity<ActivityCoverBinding> {
     @Override
     protected void onResume() {
         super.onResume();
-        // 回到前台时静默拉一次自己的资料（去抖 + 失败静默），在站外换头像后也能自动更新；
-        // 侧边栏账号区由 loggedInAccount 观察者负责重绑，Dev.refreshUser 开关已不再需要。
+        // 回到前台时静默拉一次自己的资料(去抖 + 失败静默),在站外换头像后也能自动更新;
+        // 侧边栏账号区由 loggedInAccount 观察者负责重绑。
         SessionManager.INSTANCE.syncLoggedInProfileIfNeeded();
         // 发现入口(画像)/ 聊天室 / 广场开关可能在别的页面变化,回来时重建抽屉
         buildDrawerMenu();

--- a/app/src/main/java/ceui/lisa/activities/UActivity.kt
+++ b/app/src/main/java/ceui/lisa/activities/UActivity.kt
@@ -125,6 +125,15 @@ class UActivity : BaseActivity<ActivityNewUserBinding>(), Display<UserDetailResp
         }
     }
 
+    /** 看的是自己：把服务端最新资料回写会话，侧边栏/“我的”头像跟着更新。 */
+    private fun writeBackSelfProfile(userResponse: UserDetailResponse) {
+        if (userId.toLong() != SessionManager.loggedInUid) return
+        val loxiaUser = Shaft.sGson.fromJson(
+            Shaft.sGson.toJson(userResponse.user), ceui.loxia.User::class.java
+        )
+        SessionManager.ingestFreshUser(loxiaUser, userId.toLong())
+    }
+
     override fun initData() {
         if (Shaft.sSettings.isUseArtworkV3) {
             val intent = Intent(mContext, UserActivityV3::class.java)
@@ -141,6 +150,7 @@ class UActivity : BaseActivity<ActivityNewUserBinding>(), Display<UserDetailResp
                 override fun success(userResponse: UserDetailResponse) {
                     ObjectPool.updateUser(userResponse.user)
                     mUserViewModel.user.value = userResponse
+                    writeBackSelfProfile(userResponse)
                     runCatching {
                         val loxiaUser = Shaft.sGson.fromJson(Shaft.sGson.toJson(userResponse.user), ceui.loxia.User::class.java)
                         (application as? ceui.loxia.ServicesProvider)?.entityWrapper?.visitUser(this@UActivity, loxiaUser)

--- a/app/src/main/java/ceui/lisa/activities/UserActivityV3.kt
+++ b/app/src/main/java/ceui/lisa/activities/UserActivityV3.kt
@@ -237,12 +237,22 @@ class UserActivityV3 : BaseActivity<ActivityUserV3Binding>() {
                     // user LiveData 更新 → displayUser 重绑 header UI(幂等)。
                     ObjectPool.updateUser(userResponse.user)
                     mUserViewModel.user.value = userResponse
+                    writeBackSelfProfile(userResponse)
                 }
 
                 override fun must() {
                     baseBind.refreshLayout.isRefreshing = false
                 }
             })
+    }
+
+    /** 看的是自己：把服务端最新资料回写会话，侧边栏/“我的”头像跟着更新。 */
+    private fun writeBackSelfProfile(userResponse: UserDetailResponse) {
+        if (userId.toLong() != SessionManager.loggedInUid) return
+        val loxiaUser = Shaft.sGson.fromJson(
+            Shaft.sGson.toJson(userResponse.user), ceui.loxia.User::class.java
+        )
+        SessionManager.ingestFreshUser(loxiaUser, userId.toLong())
     }
 
     override fun initData() {
@@ -255,6 +265,7 @@ class UserActivityV3 : BaseActivity<ActivityUserV3Binding>() {
                 override fun success(userResponse: UserDetailResponse) {
                     ObjectPool.updateUser(userResponse.user)
                     mUserViewModel.user.value = userResponse
+                    writeBackSelfProfile(userResponse)
                     // Record user visit history
                     runCatching {
                         val loxiaUser = Shaft.sGson.fromJson(Shaft.sGson.toJson(userResponse.user), ceui.loxia.User::class.java)

--- a/app/src/main/java/ceui/lisa/fragments/FragmentEditFile.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentEditFile.java
@@ -34,7 +34,6 @@ import ceui.lisa.models.Preset;
 import ceui.lisa.models.UserDetailResponse;
 import ceui.lisa.models.UserModel;
 import ceui.lisa.utils.Common;
-import ceui.lisa.utils.Dev;
 import ceui.lisa.utils.GlideUtil;
 import ceui.lisa.utils.Local;
 import ceui.lisa.utils.Params;
@@ -153,7 +152,6 @@ public class FragmentEditFile extends BaseLazyFragment<FragmentEditFileBinding> 
                                     if (newUser != null) {
                                         newUser.getUser().setIs_login(true);
                                         Local.saveUser(newUser);
-                                        Dev.refreshUser = true;
                                         mActivity.finish();
                                     }
                                 }

--- a/app/src/main/java/ceui/lisa/fragments/FragmentLocalUsers.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentLocalUsers.java
@@ -23,7 +23,6 @@ import ceui.lisa.databinding.RecyLocalUserBinding;
 import ceui.lisa.http.NullCtrl;
 import ceui.lisa.models.UserModel;
 import ceui.lisa.utils.Common;
-import ceui.lisa.utils.Dev;
 import ceui.lisa.utils.GlideUtil;
 import ceui.lisa.utils.Local;
 import ceui.lisa.utils.Params;
@@ -123,7 +122,6 @@ public class FragmentLocalUsers extends BaseFragment<FragmentLocalUserBinding> {
             @Override
             public void onClick(View v) {
                 Local.saveUser(userModel);
-                Dev.refreshUser = true;
                 Common.restart();
                 mActivity.finish();
             }

--- a/app/src/main/java/ceui/lisa/fragments/FragmentLogin.kt
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentLogin.kt
@@ -37,7 +37,6 @@ import ceui.lisa.databinding.ItemLanguageRowBinding
 import ceui.lisa.models.UserModel
 import ceui.lisa.utils.ClipBoardUtils
 import ceui.lisa.utils.Common
-import ceui.lisa.utils.Dev
 import ceui.lisa.utils.Local
 import ceui.lisa.utils.Params
 import ceui.pixiv.i18n.AppLocales
@@ -536,7 +535,6 @@ class FragmentLogin : BaseFragment<ActivityLoginBinding>() {
             return
         }
         Local.saveUser(exportUser)
-        Dev.refreshUser = true
         UserEntity().apply {
             loginTime = System.currentTimeMillis()
             userID = exportUser.user.id

--- a/app/src/main/java/ceui/lisa/fragments/FragmentSettingsData.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSettingsData.java
@@ -35,7 +35,6 @@ import ceui.lisa.models.UserModel;
 import ceui.lisa.utils.BackupUtils;
 import ceui.lisa.utils.BackupUtils.BackupEntity;
 import ceui.lisa.utils.Common;
-import ceui.lisa.utils.Dev;
 import ceui.lisa.utils.Local;
 import ceui.lisa.utils.Params;
 import ceui.lisa.utils.Settings;
@@ -309,7 +308,6 @@ public class FragmentSettingsData extends SettingsPageFragment<FragmentSettingsD
                         dialog.dismiss();
                         target.getUser().setIs_login(true);
                         Local.saveUser(target);
-                        Dev.refreshUser = true;
                         Common.restart();
                     }
                 })

--- a/app/src/main/java/ceui/lisa/utils/Dev.java
+++ b/app/src/main/java/ceui/lisa/utils/Dev.java
@@ -2,8 +2,6 @@ package ceui.lisa.utils;
 
 public class Dev {
 
-    public static boolean refreshUser = false;
-
     public static boolean hideMainActivityStatus = true;
 
 

--- a/app/src/main/java/ceui/pixiv/session/SessionManager.kt
+++ b/app/src/main/java/ceui/pixiv/session/SessionManager.kt
@@ -8,15 +8,20 @@ import ceui.lisa.activities.Shaft
 import ceui.lisa.models.UserModel
 import ceui.lisa.utils.Common
 import ceui.loxia.AccountResponse
+import ceui.loxia.Client
 import ceui.loxia.Event
 import ceui.loxia.ObjectPool
 import ceui.loxia.User
+import ceui.loxia.UserGender
 import ceui.pixiv.login.InvalidRefreshTokenException
 import ceui.pixiv.login.PixivLogin
 import com.google.gson.Gson
 import com.tencent.mmkv.MMKV
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -200,6 +205,74 @@ object SessionManager {
             _loggedInAccount.postValue(accountResponse)
         }
     }
+
+    private val profileSyncScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private const val PROFILE_SYNC_COOLDOWN_MS = 10 * 60 * 1000L
+    private const val PROFILE_SYNC_FAILURE_COOLDOWN_MS = 60 * 1000L
+    @Volatile
+    private var lastProfileSyncAt = 0L
+    @Volatile
+    private var lastProfileSyncFailedAt = 0L
+    @Volatile
+    private var profileSyncInFlight = false
+
+    /**
+     * 把服务端刚拉到的“自己”的资料合并进当前会话并持久化。
+     *
+     * [uid] 是请求发起时的登录 uid，写入前再和当前会话比对，防止“请求在途时切换了账号”
+     * 把上一个账号的资料盖到当前账号头上。必须在主线程调用（内部 setValue 更新 LiveData）。
+     */
+    fun ingestFreshUser(fresh: User?, uid: Long) {
+        if (fresh == null || !fresh.exist()) return
+        val current = _loggedInAccount.value ?: return
+        val old = current.user ?: return
+        if (old.id != uid) return
+        val merged = current.copy(user = old.mergedWith(fresh))
+        prefStore.putString(USER_KEY, gson.toJson(merged))
+        _loggedInAccount.value = merged
+    }
+
+    /**
+     * 前台静默同步：去抖 + 单飞 + 失败静默。头像/昵称在站外被修改后，
+     * 回到前台会自动拉一次自己的 user/detail 并写回会话。
+     */
+    fun syncLoggedInProfileIfNeeded() {
+        val uid = loggedInUid
+        if (uid == 0L) return
+        val now = System.currentTimeMillis()
+        if (now - lastProfileSyncAt < PROFILE_SYNC_COOLDOWN_MS) return
+        if (now - lastProfileSyncFailedAt < PROFILE_SYNC_FAILURE_COOLDOWN_MS) return
+        if (profileSyncInFlight) return
+        profileSyncInFlight = true
+        profileSyncScope.launch {
+            try {
+                val fresh = Client.appApi.getUserProfile(uid).user
+                withContext(Dispatchers.Main) {
+                    ingestFreshUser(fresh, uid)
+                }
+                lastProfileSyncAt = System.currentTimeMillis()
+            } catch (t: Throwable) {
+                Timber.w(t, "sync logged-in profile failed, keep cached data")
+                lastProfileSyncFailedAt = System.currentTimeMillis()
+            } finally {
+                profileSyncInFlight = false
+            }
+        }
+    }
+
+    /** fresh 有值的字段覆盖旧值，缺的字段保留旧值——避免 user/detail 缺 mail_address 等字段时把会话弄丢信息。 */
+    private fun User.mergedWith(fresh: User): User = copy(
+        account = fresh.account ?: account,
+        name = fresh.name ?: name,
+        pixiv_id = fresh.pixiv_id ?: pixiv_id,
+        profile_image_urls = fresh.profile_image_urls ?: profile_image_urls,
+        is_mail_authorized = fresh.is_mail_authorized ?: is_mail_authorized,
+        is_premium = fresh.is_premium ?: is_premium,
+        mail_address = fresh.mail_address ?: mail_address,
+        x_restrict = fresh.x_restrict ?: x_restrict,
+        comment = fresh.comment ?: comment,
+        gender = if (fresh.gender != UserGender.UNKNOWN) fresh.gender else gender,
+    )
 
     /**
      * Returns "Bearer xxx" format token for API Authorization header.

--- a/app/src/main/java/ceui/pixiv/session/SessionManager.kt
+++ b/app/src/main/java/ceui/pixiv/session/SessionManager.kt
@@ -1,5 +1,6 @@
 package ceui.pixiv.session
 
+import android.os.SystemClock
 import android.text.TextUtils
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -12,11 +13,11 @@ import ceui.loxia.Client
 import ceui.loxia.Event
 import ceui.loxia.ObjectPool
 import ceui.loxia.User
-import ceui.loxia.UserGender
 import ceui.pixiv.login.InvalidRefreshTokenException
 import ceui.pixiv.login.PixivLogin
 import com.google.gson.Gson
 import com.tencent.mmkv.MMKV
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -25,6 +26,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import timber.log.Timber
+import java.util.concurrent.atomic.AtomicBoolean
 
 object SessionManager {
 
@@ -209,25 +211,37 @@ object SessionManager {
     private val profileSyncScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private const val PROFILE_SYNC_COOLDOWN_MS = 10 * 60 * 1000L
     private const val PROFILE_SYNC_FAILURE_COOLDOWN_MS = 60 * 1000L
+
+    /**
+     * 冷却时间戳走开机后的单调时钟，不用墙钟：墙钟被用户改或被 NTP 往回拨时，
+     * `now - last` 会变成负数，两条冷却判断恒成立，静默同步会一直被冻到时钟追回来
+     * （同类事故见 PixivActionQueue 的冷却钳制）。
+     * `null` = 本进程还没同步过，用它和 elapsedRealtime 开机瞬间的 0 区分开——
+     * 否则开机 10 分钟内启动 App 会被误判成「刚同步过」。
+     */
     @Volatile
-    private var lastProfileSyncAt = 0L
+    private var lastProfileSyncAt: Long? = null
     @Volatile
-    private var lastProfileSyncFailedAt = 0L
-    @Volatile
-    private var profileSyncInFlight = false
+    private var lastProfileSyncFailedAt: Long? = null
+    private val profileSyncInFlight = AtomicBoolean(false)
 
     /**
      * 把服务端刚拉到的“自己”的资料合并进当前会话并持久化。
      *
      * [uid] 是请求发起时的登录 uid，写入前再和当前会话比对，防止“请求在途时切换了账号”
      * 把上一个账号的资料盖到当前账号头上。必须在主线程调用（内部 setValue 更新 LiveData）。
+     *
+     * 合并结果和旧值一致时直接返回：这条路径每次回前台都会走一遍，无变化还落盘 + 发
+     * LiveData，会让所有观察者（侧边栏、「我的」）白重绑一次。
      */
     fun ingestFreshUser(fresh: User?, uid: Long) {
         if (fresh == null || !fresh.exist()) return
         val current = _loggedInAccount.value ?: return
         val old = current.user ?: return
         if (old.id != uid) return
-        val merged = current.copy(user = old.mergedWith(fresh))
+        val mergedUser = old.mergedWith(fresh)
+        if (mergedUser == old) return
+        val merged = current.copy(user = mergedUser)
         prefStore.putString(USER_KEY, gson.toJson(merged))
         _loggedInAccount.value = merged
     }
@@ -239,28 +253,35 @@ object SessionManager {
     fun syncLoggedInProfileIfNeeded() {
         val uid = loggedInUid
         if (uid == 0L) return
-        val now = System.currentTimeMillis()
-        if (now - lastProfileSyncAt < PROFILE_SYNC_COOLDOWN_MS) return
-        if (now - lastProfileSyncFailedAt < PROFILE_SYNC_FAILURE_COOLDOWN_MS) return
-        if (profileSyncInFlight) return
-        profileSyncInFlight = true
+        val now = SystemClock.elapsedRealtime()
+        lastProfileSyncAt?.let { if (now - it < PROFILE_SYNC_COOLDOWN_MS) return }
+        lastProfileSyncFailedAt?.let { if (now - it < PROFILE_SYNC_FAILURE_COOLDOWN_MS) return }
+        if (!profileSyncInFlight.compareAndSet(false, true)) return
         profileSyncScope.launch {
             try {
                 val fresh = Client.appApi.getUserProfile(uid).user
                 withContext(Dispatchers.Main) {
                     ingestFreshUser(fresh, uid)
                 }
-                lastProfileSyncAt = System.currentTimeMillis()
+                lastProfileSyncAt = SystemClock.elapsedRealtime()
+            } catch (ex: CancellationException) {
+                throw ex
             } catch (t: Throwable) {
                 Timber.w(t, "sync logged-in profile failed, keep cached data")
-                lastProfileSyncFailedAt = System.currentTimeMillis()
+                lastProfileSyncFailedAt = SystemClock.elapsedRealtime()
             } finally {
-                profileSyncInFlight = false
+                profileSyncInFlight.set(false)
             }
         }
     }
 
-    /** fresh 有值的字段覆盖旧值，缺的字段保留旧值——避免 user/detail 缺 mail_address 等字段时把会话弄丢信息。 */
+    /**
+     * fresh 有值的字段覆盖旧值，缺的字段保留旧值——避免 user/detail 缺 mail_address 等字段时把会话弄丢信息。
+     *
+     * 只合并可空字段：它们缺省就是 null，能把「服务端没返回」和「服务端返回了空」区分开。
+     * 非空且带默认值的字段（如 `gender` 默认 MALE）做不到这个区分，合进来等于拿默认值
+     * 覆盖真实值，所以一律不动。
+     */
     private fun User.mergedWith(fresh: User): User = copy(
         account = fresh.account ?: account,
         name = fresh.name ?: name,
@@ -271,7 +292,6 @@ object SessionManager {
         mail_address = fresh.mail_address ?: mail_address,
         x_restrict = fresh.x_restrict ?: x_restrict,
         comment = fresh.comment ?: comment,
-        gender = if (fresh.gender != UserGender.UNKNOWN) fresh.gender else gender,
     )
 
     /**

--- a/app/src/main/java/ceui/pixiv/ui/me/MeFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/me/MeFragment.kt
@@ -53,8 +53,8 @@ class MeFragment : Fragment(R.layout.fragment_me) {
         // hero 不需要 statusBar top padding —— 背景图就该延伸到 status bar 下面;
         // 内容(avatar 行)靠 layout_gravity=bottom 自然在底部,不受 inset 影响。
 
-        // 头像/昵称跟随会话变化自动重绑：登录态、切号、编辑资料、前台静默同步都会 post 新值。
-        // LiveData 首次 observe 会立即回调当前值，等价于原来的 bindUserHeader(view)。
+        // 头像/昵称跟随会话变化自动重绑:登录态、切号、编辑资料、前台静默同步都会写回新值。
+        // observe 会在视图 STARTED 时先回放一次当前账号完成首绑,取代原来的 bindUserHeader(view)。
         SessionManager.loggedInAccount.observe(viewLifecycleOwner) { bindUserHeader(view) }
         bindHeroBackground(view)
         bindStatsRow(view)

--- a/app/src/main/java/ceui/pixiv/ui/me/MeFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/me/MeFragment.kt
@@ -53,7 +53,9 @@ class MeFragment : Fragment(R.layout.fragment_me) {
         // hero 不需要 statusBar top padding —— 背景图就该延伸到 status bar 下面;
         // 内容(avatar 行)靠 layout_gravity=bottom 自然在底部,不受 inset 影响。
 
-        bindUserHeader(view)
+        // 头像/昵称跟随会话变化自动重绑：登录态、切号、编辑资料、前台静默同步都会 post 新值。
+        // LiveData 首次 observe 会立即回调当前值，等价于原来的 bindUserHeader(view)。
+        SessionManager.loggedInAccount.observe(viewLifecycleOwner) { bindUserHeader(view) }
         bindHeroBackground(view)
         bindStatsRow(view)
         bindSections(view)
@@ -69,9 +71,10 @@ class MeFragment : Fragment(R.layout.fragment_me) {
         if (uid == 0L) return
 
         viewLifecycleOwner.lifecycleScope.launch {
-            val bannerUrl = runCatching {
-                Client.appApi.getUserProfile(uid).profile?.background_image_url
-            }.getOrNull()
+            // 这次请求本身就带着自己的最新 user，顺手回写会话，头像/昵称一起更新
+            val profile = runCatching { Client.appApi.getUserProfile(uid) }.getOrNull()
+            SessionManager.ingestFreshUser(profile?.user, uid)
+            val bannerUrl = profile?.profile?.background_image_url
             if (!bannerUrl.isNullOrEmpty() && view != null) {
                 Glide.with(this@MeFragment)
                     .load(GlideUrlChild(bannerUrl))


### PR DESCRIPTION
关联 #978 反馈的 Bugs 第一点：「当用户更改自己的 pixiv 头像，侧边栏的头像不会更新」。

## 问题根因
侧边栏头像只读取登录时缓存的 SessionManager.loggedInUser（MMKV 快照），唯一的刷新开关 Dev.refreshUser
只在登录/切号/还原账号/应用内编辑资料时置位。在站外更换头像后，没有任何路径把服务端最新资料写回会话；
打开自己主页时 user/detail 虽然拉到了新头像，也只更新 ObjectPool，不回写 SessionManager。

## 改动方案
1. SessionManager 新增 ingestFreshUser：把服务端刚拉到的「自己」的资料合并写回会话并持久化。
   - uid 校验，防止请求在途时切换账号把旧账号资料盖到当前账号上；
   - 缺字段保留旧值（user/detail 不一定带 mail_address / is_mail_authorized，避免整体替换丢信息）。
2. SessionManager 新增 syncLoggedInProfileIfNeeded：回到前台时静默拉一次自己的 user/detail。
   - 10 分钟去抖 + 单飞（防重复请求乱序覆盖）+ 失败 60 秒冷却且完全静默，离线不崩、不弹错。
3. MainActivity：侧边栏账号区改为观察 loggedInAccount LiveData 自动重绑，onResume 触发静默同步，
   移除 Dev.refreshUser 特判。
4. UActivity / UserActivityV3 / MeFragment：看自己主页或「我的」tab 时，把已经拉到的资料顺手回写会话，
   零额外请求。

## 更新时机
- 打开 App / 回到前台：静默同步成功即刷新（通常 1~3 秒）；
- 打开自己主页或「我的」tab：秒级更新（复用页面已有请求）；
- 在自己主页下拉刷新：同步更新。

## 离线行为
同步失败时静默保留旧缓存：不 crash、不闪默认图、不弹错误提示；恢复网络后下次回前台自动重试。

## 改动文件
app/src/main/java/ceui/pixiv/session/SessionManager.kt
app/src/main/java/ceui/lisa/activities/MainActivity.java
app/src/main/java/ceui/lisa/activities/UActivity.kt
app/src/main/java/ceui/lisa/activities/UserActivityV3.kt
app/src/main/java/ceui/pixiv/ui/me/MeFragment.kt

## 验证情况
已真机验证：打开自己主页拉到新头像后返回主界面，侧边栏头像确认为新头像。
说明：本次验证覆盖的是「主页拉取 → 回写会话 → 侧边栏重绑」这条路径；
「站外换头像后直接回前台自动同步」的静默同步路径尚未单独验证。
