### PR TITLE
feat(detail): V3 插画/小说详情收藏次数可点，查看收藏用户（关联 #978）

### DIFF
--- a/app/src/main/java/ceui/lisa/activities/TemplateActivity.java
+++ b/app/src/main/java/ceui/lisa/activities/TemplateActivity.java
@@ -177,6 +177,10 @@ public class TemplateActivity extends BaseActivity<ActivityFragmentBinding> impl
                             intent.getIntExtra(Params.USER_ID, 0));
                 case "喜欢这个作品的用户":
                     return LikeUsersFeedFragment.newInstance((IllustsBean) intent.getSerializableExtra(Params.CONTENT));
+                case "喜欢这部小说的用户":
+                    return LikeUsersFeedFragment.newInstance(
+                            intent.getLongExtra(Params.NOVEL_ID, 0L),
+                            intent.getStringExtra(Params.TITLE));
                 case "小说系列详情": {
                     // Legacy 路由——桥接到新页 NovelSeriesFragment。保留 case
                     // 兼容外部深链或仍在路上的字符串拼接调用；内部入口都已迁到

--- a/app/src/main/java/ceui/lisa/http/AppApi.java
+++ b/app/src/main/java/ceui/lisa/http/AppApi.java
@@ -461,6 +461,9 @@ public interface AppApi {
     @GET("v1/illust/bookmark/users?filter=for_android")
     Observable<ListSimpleUser> getUsersWhoLikeThisIllust(@Query("illust_id") int illust_id);
 
+    @GET("v1/novel/bookmark/users?filter=for_android")
+    Observable<ListSimpleUser> getUsersWhoLikeThisNovel(@Query("novel_id") long novel_id);
+
     @GET("v2/novel/series")
     Observable<ListNovelOfSeries> getNovelSeries(@Query("series_id") int series_id);
 

--- a/app/src/main/java/ceui/lisa/repo/SimpleUserRepo.kt
+++ b/app/src/main/java/ceui/lisa/repo/SimpleUserRepo.kt
@@ -16,6 +16,13 @@ class SimpleUserRepo(private val illustID: Int) : RemoteRepo<ListSimpleUser>() {
     }
 }
 
+/**
+ * 「喜欢这部小说的用户」——插画版 [SimpleUserRepo] 的小说孪生体。
+ *
+ * `v1/novel/bookmark/users` 不在 app-api 的公开文档里，但确实存在：无 token 打它回 400
+ * （OAuth 报错，说明路由命中），打一个不存在的路径回 404。响应结构与插画版一致
+ * （`users` + `next_url`），所以翻页照旧共用 getNextSimpleUser。
+ */
 class NovelBookmarkUserRepo(private val novelID: Long) : RemoteRepo<ListSimpleUser>() {
 
     override fun initApi(): Observable<ListSimpleUser> {

--- a/app/src/main/java/ceui/lisa/repo/SimpleUserRepo.kt
+++ b/app/src/main/java/ceui/lisa/repo/SimpleUserRepo.kt
@@ -15,3 +15,14 @@ class SimpleUserRepo(private val illustID: Int) : RemoteRepo<ListSimpleUser>() {
         return Retro.getAppApi().getNextSimpleUser(nextUrl)
     }
 }
+
+class NovelBookmarkUserRepo(private val novelID: Long) : RemoteRepo<ListSimpleUser>() {
+
+    override fun initApi(): Observable<ListSimpleUser> {
+        return Retro.getAppApi().getUsersWhoLikeThisNovel(novelID)
+    }
+
+    override fun initNextApi(): Observable<ListSimpleUser> {
+        return Retro.getAppApi().getNextSimpleUser(nextUrl)
+    }
+}

--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkSectionRenderers.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkSectionRenderers.kt
@@ -338,6 +338,20 @@ internal fun ArtworkV3Fragment.statsRenderer() =
     feedRenderer<ArtworkStatsItem, SectionV3StatsBinding>(
         inflate = SectionV3StatsBinding::inflate,
         fullSpan = true,
+        create = { cell ->
+            val wrap = cell.binding.statBookmarkWrap
+            applyTouchScale(wrap)
+            wrap.setOnClickListener {
+                val illust = cell.item.illust
+                val ctx = wrap.context
+                ctx.startActivity(
+                    Intent(ctx, TemplateActivity::class.java).apply {
+                        putExtra(Params.CONTENT, illust)
+                        putExtra(TemplateActivity.EXTRA_FRAGMENT, "喜欢这个作品的用户")
+                    }
+                )
+            }
+        },
     ) { cell ->
         val illust = cell.item.illust
         val fmt = NumberFormat.getNumberInstance()

--- a/app/src/main/java/ceui/pixiv/ui/novel/NovelTextFeed.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/NovelTextFeed.kt
@@ -3,6 +3,7 @@ package ceui.pixiv.ui.novel
 import android.content.Intent
 import android.content.res.ColorStateList
 import android.net.Uri
+import android.view.MotionEvent
 import android.view.View
 import androidx.core.text.HtmlCompat
 import androidx.core.view.isVisible
@@ -11,6 +12,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 import ceui.lisa.R
 import ceui.lisa.activities.Shaft
+import ceui.lisa.activities.TemplateActivity
 import ceui.lisa.fragments.WebNovelParser
 import ceui.pixiv.ui.bookmark.SelectTagBottomSheet
 import ceui.lisa.databinding.CellNovelActionsBinding
@@ -244,6 +246,22 @@ fun novelProfileRenderer(
     return feedRenderer(
         inflate = CellNovelProfileBinding::inflate,
         fullSpan = true,
+        create = { cell ->
+            val wrap = cell.binding.statBookmarkWrap
+            applyTouchScale(wrap)
+            wrap.setOnClickListener {
+                val novelId = cell.item.novelId
+                val ctx = wrap.context
+                val title = ObjectPool.get<Novel>(novelId).value?.title
+                ctx.startActivity(
+                    Intent(ctx, TemplateActivity::class.java).apply {
+                        putExtra(TemplateActivity.EXTRA_FRAGMENT, "喜欢这部小说的用户")
+                        putExtra(Params.NOVEL_ID, novelId)
+                        putExtra(Params.TITLE, title)
+                    }
+                )
+            }
+        },
         recycle = { cell -> slots[cell]?.detach() },
     ) { cell ->
         val b = cell.binding
@@ -283,6 +301,19 @@ fun novelProfileRenderer(
             b.chipNovelLink.bindCopyLinkChip(R.string.novel_chip_novel_link, novelUrl)
             b.chipOpenNovelLink.bindOpenLinkChip(R.string.novel_chip_open_novel_link, novelUrl)
         }
+    }
+}
+
+private fun applyTouchScale(view: View, scale: Float = 0.97f) {
+    view.setOnTouchListener { v, event ->
+        when (event.action) {
+            MotionEvent.ACTION_DOWN ->
+                v.animate().scaleX(scale).scaleY(scale).setDuration(200).start()
+
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL ->
+                v.animate().scaleX(1f).scaleY(1f).setDuration(200).start()
+        }
+        false
     }
 }
 

--- a/app/src/main/java/ceui/pixiv/ui/user/LikeUsersFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/user/LikeUsersFeedFragment.kt
@@ -45,10 +45,12 @@ import kotlinx.coroutines.withContext
 
 /**
  * 「喜欢这个作品的用户」列表页（feeds 框架版，替代 legacy [ceui.lisa.fragments.FragmentListSimpleUser] +
- * SimpleUserAdapter(非 muted)）。
+ * SimpleUserAdapter(非 muted)）。插画、小说共用本页：插画走 [Params.CONTENT]([IllustsBean])，
+ * 小说走 [Params.NOVEL_ID] + [Params.TITLE]，除数据源和标题外的一切（行渲染、关注同步）完全复用。
  *
  * TemplateActivity 宿主、自带 toolbar（fragment_toolbar_feed）。数据源直接包裹既有的
- * [SimpleUserRepo]（getUsersWhoLikeThisIllust + getNextSimpleUser），把 Rx→suspend 桥一下即可，
+ * [SimpleUserRepo]（getUsersWhoLikeThisIllust + getNextSimpleUser）或
+ * [NovelBookmarkUserRepo]（getUsersWhoLikeThisNovel + getNextSimpleUser），把 Rx→suspend 桥一下即可，
  * 翻页跟随 next_url。
  *
  * **row 复刻 muted 那套 recy_simple_user，但去掉 muted 专属交互**：这里是普通的「点赞用户」列表，
@@ -67,8 +69,8 @@ class LikeUsersFeedFragment : FeedFragment(R.layout.fragment_toolbar_feed) {
     private val binding by viewBinding(FragmentToolbarFeedBinding::bind)
 
     override val feedViewModel by feedViewModels {
-        // 零捕获：先把 arg 读进局部 val，只把 illustId(Int) 传进 source（source 归 VM 长期持有，
-        // 绝不能捕获 Fragment）。
+        // 零捕获：先把 arg 读进局部 val，只把作品 id（插画 Int / 小说 Long）传进 source
+        // （source 归 VM 长期持有，绝不能捕获 Fragment）。
         val args = requireArguments()
         val novelId = args.getLong(Params.NOVEL_ID, 0L).takeIf { it != 0L }
         val illust = args.getSerializable(Params.CONTENT) as? IllustsBean
@@ -113,11 +115,12 @@ class LikeUsersFeedFragment : FeedFragment(R.layout.fragment_toolbar_feed) {
         pinHostGlide(userGlide)
         setUpToolbar(binding, feedBinding.feedListView)
         // 标题读局部 val（零捕获），复刻 legacy getToolbarTitle。
+        // 小说侧的标题是调用方从 ObjectPool 顺手取的，取不到就是 null——orEmpty 兜住，
+        // 宁可少个书名也不能把「喜欢null的用户」摆到 toolbar 上。
         val args = requireArguments()
-        val novelId = args.getLong(Params.NOVEL_ID, 0L).takeIf { it != 0L }
         val title = args.getString(Params.TITLE)
             ?: (args.getSerializable(Params.CONTENT) as? IllustsBean)?.title
-        binding.toolbarTitle.text = "喜欢" + title + "的用户"
+        binding.toolbarTitle.text = "喜欢" + title.orEmpty() + "的用户"
 
         LocalBroadcastManager.getInstance(requireContext())
             .registerReceiver(followSyncReceiver, IntentFilter(Params.LIKED_USER))
@@ -265,12 +268,13 @@ class LikeUserFeedItem(
 }
 
 /**
- * 点赞用户数据源：包裹 [SimpleUserRepo]（cursor = next_url）。
- * load(null) → initApi(getUsersWhoLikeThisIllust)；load(cursor) → setNextUrl + initNextApi(getNextSimpleUser)。
+ * 点赞用户数据源：包裹 [SimpleUserRepo] / [NovelBookmarkUserRepo]（cursor = next_url）。
+ * load(null) → initApi(getUsersWhoLikeThisIllust / getUsersWhoLikeThisNovel)；
+ * load(cursor) → setNextUrl + initNextApi(getNextSimpleUser)——翻页两边共用同一个 next_url 接口。
  * 请求发起切 IO（awaitFirstValue 内部 subscribeOn(io)，此处外层 withContext 只为对齐既有桥接写法）；
  * 映射切 Default。短页 / 无 next_url（空串）即到底返回 null。
  *
- * 零 Fragment 捕获：只吃 illustId(Int)，repo 内部持 illustId + next_url 分页状态。
+ * 零 Fragment 捕获：只吃作品 id（插画 Int / 小说 Long），repo 内部持 id + next_url 分页状态。
  */
 class LikeUsersFeedSource private constructor(
     private val repo: RemoteRepo<ListSimpleUser>,

--- a/app/src/main/java/ceui/pixiv/ui/user/LikeUsersFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/user/LikeUsersFeedFragment.kt
@@ -10,11 +10,13 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewbinding.ViewBinding
 import ceui.lisa.R
+import ceui.lisa.core.RemoteRepo
 import ceui.lisa.databinding.FragmentToolbarFeedBinding
 import ceui.lisa.databinding.RecySimpleUserBinding
 import ceui.lisa.model.ListSimpleUser
 import ceui.lisa.models.IllustsBean
 import ceui.lisa.models.UserBean
+import ceui.lisa.repo.NovelBookmarkUserRepo
 import ceui.lisa.repo.SimpleUserRepo
 import ceui.lisa.utils.Common
 import ceui.lisa.utils.GlideUtil
@@ -67,8 +69,14 @@ class LikeUsersFeedFragment : FeedFragment(R.layout.fragment_toolbar_feed) {
     override val feedViewModel by feedViewModels {
         // 零捕获：先把 arg 读进局部 val，只把 illustId(Int) 传进 source（source 归 VM 长期持有，
         // 绝不能捕获 Fragment）。
-        val illust = requireArguments().getSerializable(Params.CONTENT) as IllustsBean
-        LikeUsersFeedSource(illust.id)
+        val args = requireArguments()
+        val novelId = args.getLong(Params.NOVEL_ID, 0L).takeIf { it != 0L }
+        val illust = args.getSerializable(Params.CONTENT) as? IllustsBean
+        when {
+            novelId != null -> LikeUsersFeedSource(novelId)
+            illust != null -> LikeUsersFeedSource(illust.id)
+            else -> error("LikeUsersFeedFragment 缺少作品参数")
+        }
     }
 
     /**
@@ -105,8 +113,11 @@ class LikeUsersFeedFragment : FeedFragment(R.layout.fragment_toolbar_feed) {
         pinHostGlide(userGlide)
         setUpToolbar(binding, feedBinding.feedListView)
         // 标题读局部 val（零捕获），复刻 legacy getToolbarTitle。
-        val illust = requireArguments().getSerializable(Params.CONTENT) as IllustsBean
-        binding.toolbarTitle.text = "喜欢" + illust.title + "的用户"
+        val args = requireArguments()
+        val novelId = args.getLong(Params.NOVEL_ID, 0L).takeIf { it != 0L }
+        val title = args.getString(Params.TITLE)
+            ?: (args.getSerializable(Params.CONTENT) as? IllustsBean)?.title
+        binding.toolbarTitle.text = "喜欢" + title + "的用户"
 
         LocalBroadcastManager.getInstance(requireContext())
             .registerReceiver(followSyncReceiver, IntentFilter(Params.LIKED_USER))
@@ -214,6 +225,16 @@ class LikeUsersFeedFragment : FeedFragment(R.layout.fragment_toolbar_feed) {
                 }
             }
         }
+
+        @JvmStatic
+        fun newInstance(novelId: Long, novelTitle: String?): LikeUsersFeedFragment {
+            return LikeUsersFeedFragment().apply {
+                arguments = Bundle().apply {
+                    putLong(Params.NOVEL_ID, novelId)
+                    putString(Params.TITLE, novelTitle)
+                }
+            }
+        }
     }
 }
 
@@ -251,9 +272,12 @@ class LikeUserFeedItem(
  *
  * 零 Fragment 捕获：只吃 illustId(Int)，repo 内部持 illustId + next_url 分页状态。
  */
-class LikeUsersFeedSource(illustId: Int) : FeedSource<String> {
+class LikeUsersFeedSource private constructor(
+    private val repo: RemoteRepo<ListSimpleUser>,
+) : FeedSource<String> {
 
-    private val repo = SimpleUserRepo(illustId)
+    constructor(illustId: Int) : this(SimpleUserRepo(illustId))
+    constructor(novelId: Long) : this(NovelBookmarkUserRepo(novelId))
 
     override suspend fun load(cursor: String?): FeedPage<String> {
         val resp: ListSimpleUser = if (cursor == null) {

--- a/app/src/main/res/layout/cell_novel_profile.xml
+++ b/app/src/main/res/layout/cell_novel_profile.xml
@@ -66,6 +66,7 @@
 
                 <!-- Bookmarks -->
                 <LinearLayout
+                    android:id="@+id/stat_bookmark_wrap"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"

--- a/app/src/main/res/layout/section_v3_stats.xml
+++ b/app/src/main/res/layout/section_v3_stats.xml
@@ -56,6 +56,7 @@
 
         <!-- Bookmarks -->
         <LinearLayout
+            android:id="@+id/stat_bookmark_wrap"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"


### PR DESCRIPTION
## 关联
关联 #978 的「其它信息」第 2 点：V3 界面不支持查看插画或小说的收藏用户。

## 背景
经典详情页点收藏次数会进「喜欢这个作品的用户」列表；V3 沉浸式插画详情和小说详情（V3 阅读页的档案卡）的收藏数都只是展示，没有接线。本次把两个入口补齐，并复用同一套用户列表页。

## 改动
1. **V3 插画详情**：收藏统计列（数字 + label 整列）可点，跳「喜欢这个作品的用户」页，复用经典入口同一个 `LikeUsersFeedFragment`。
2. **小说详情**：收藏统计列可点，跳新增的「喜欢这部小说的用户」页。
3. **新增端点** `GET v1/novel/bookmark/users`：app-api 未公开文档，已用「无鉴权 400 / 不存在路径 404」对照探测确认存在，响应结构与插画版一致（`users` + `next_url`）。
4. **`LikeUsersFeedFragment` 泛化**为插画/小说共用：数据源按参数分支、标题按作品取，行渲染、关注同步等全部复用，不复制页面代码。
5. **交互与 V3 一致**：整列可点 + `applyTouchScale` 按压缩放反馈；0 收藏也可点，空列表走既有空态。

## 分页（改动说明）
本 PR 未新增显式分页控件。经评估，显式分页与项目「列表滚动加载」的界面设计理念不符，予以搁置；收藏用户列表沿用 feeds 框架既有的 `next_url` 游标滚动加载机制，无额外改动。

## 测试
- 实测 V3 插画详情、小说详情点收藏数均能进入列表，列表数据与web页面匹配。

## 风险
- `v1/novel/bookmark/users` 不在公开文档中，以对照探测确认存在；若 pixiv 后续调整响应结构，列表可能为空，需按实际返回跟进。