### PR TITLE
feat(user): 小说作者页 banner 与关注列表预览格改用小说封面


### DIFF
--- a/app/src/main/java/ceui/lisa/activities/UserActivityV3.kt
+++ b/app/src/main/java/ceui/lisa/activities/UserActivityV3.kt
@@ -35,6 +35,7 @@ import ceui.loxia.ProgressTextButton
 import ceui.loxia.WebUserDetail
 import ceui.pixiv.session.SessionManager
 import ceui.pixiv.utils.setOnClick
+import ceui.pixiv.ui.common.coverUrl
 import com.bumptech.glide.Glide
 import com.google.android.material.tabs.TabLayoutMediator
 import com.qmuiteam.qmui.skin.QMUISkinManager
@@ -74,6 +75,7 @@ class UserActivityV3 : BaseActivity<ActivityUserV3Binding>() {
     // 把旋转前保存的 fragment state 当成「已废弃」清掉。
     private val tabKinds = mutableListOf<TabKind>()
     private var pagerAdapter: FragmentStateAdapter? = null
+    private var novelBannerLoading = false
 
     // user/detail 返回的确定数量(插画/漫画/小说/公开插画收藏),>0 时追加到 tab label 后面。
     // 收藏 tab 用 total_illust_bookmarks_public —— 与 header 统计条同源;小说收藏数 API 不给,不凑。
@@ -236,6 +238,8 @@ class UserActivityV3 : BaseActivity<ActivityUserV3Binding>() {
                     // UserBean 池更新 → updateFollowState 重绑关注按钮;
                     // user LiveData 更新 → displayUser 重绑 header UI(幂等)。
                     ObjectPool.updateUser(userResponse.user)
+                    // 下拉刷新后允许重选最新有封面小说(封面可能随新投稿变化)
+                    mUserViewModel.setNovelBannerLoaded(false)
                     mUserViewModel.user.value = userResponse
                 }
 
@@ -491,6 +495,12 @@ class UserActivityV3 : BaseActivity<ActivityUserV3Binding>() {
             }
         }
 
+        // 纯小说作者通常没有 profile 背景图(background_image_url 为空)：
+        // 拉一页小说列表，挑最新一篇有真实封面(非占位图)的作品当 banner。
+        if (bannerUrl.isNullOrEmpty() && isNovelistOnly && !mUserViewModel.isNovelBannerLoaded()) {
+            loadNovelCoverBanner()
+        }
+
         // Avatar
         Glide.with(mContext).load(GlideUtil.getHead(user)).into(baseBind.userAvatar)
         val avatarUrl = user.profile_image_urls?.getMaxImage()
@@ -547,6 +557,39 @@ class UserActivityV3 : BaseActivity<ActivityUserV3Binding>() {
         // 收藏数不再进统计条 —— 「收藏」tab label 自带数字(updateTabCount)
 
         // 标签筛选条(issue #569)不再单独请求 —— 改由插画列表首屏回调 onUserIllustFirstPage 驱动,复用同一份数据
+    }
+
+    /**
+     * 纯小说作者页 banner 兜底：拉一页 /v1/user/novels，
+     * 挑最新一篇 URL 不含 novel_thumb 占位的小说封面做背景，点击跳该小说详情。
+     * 失败或无封面时静默，保留现有渐变占位。
+     */
+    private fun loadNovelCoverBanner() {
+        if (novelBannerLoading) return
+        novelBannerLoading = true
+        lifecycleScope.launch {
+            val resp = runCatching { Client.appApi.getUserCreatedNovels(userId.toLong()) }.getOrNull()
+            val novel = resp?.novels?.firstOrNull {
+                it.coverUrl?.contains("/common/images/novel_thumb/") == false
+            }
+            novelBannerLoading = false
+            if (novel == null || isDestroyed) return@launch
+            val cover = novel.coverUrl ?: return@launch
+            mUserViewModel.novelBannerNovelId = novel.id
+            mUserViewModel.setNovelBannerLoaded(true)
+            baseBind.bannerImage.visibility = View.VISIBLE
+            baseBind.bannerImage.colorFilter = android.graphics.PorterDuffColorFilter(
+                0x66000000.toInt(),
+                android.graphics.PorterDuff.Mode.SRC_ATOP,
+            )
+            Glide.with(mContext).load(GlideUtil.getUrl(cover)).into(baseBind.bannerImage)
+            baseBind.bannerImage.setOnClickListener {
+                startActivity(Intent(this@UserActivityV3, TemplateActivity::class.java).apply {
+                    putExtra(TemplateActivity.EXTRA_FRAGMENT, "小说详情")
+                    putExtra(Params.NOVEL_ID, novel.id)
+                })
+            }
+        }
     }
 
     private fun displayWebUserDetail(detail: WebUserDetail) {

--- a/app/src/main/java/ceui/lisa/activities/UserActivityV3.kt
+++ b/app/src/main/java/ceui/lisa/activities/UserActivityV3.kt
@@ -2,6 +2,8 @@ package ceui.lisa.activities
 
 import android.content.DialogInterface
 import android.content.Intent
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
 import android.os.Bundle
 import android.text.TextUtils
 import android.view.View
@@ -30,20 +32,24 @@ import ceui.lisa.viewmodel.AppLevelViewModel
 import ceui.lisa.viewmodel.UserViewModel
 import ceui.loxia.Client
 import ceui.loxia.Event
+import ceui.loxia.Novel
 import ceui.loxia.ObjectPool
 import ceui.loxia.ProgressTextButton
 import ceui.loxia.WebUserDetail
 import ceui.pixiv.session.SessionManager
+import ceui.pixiv.ui.common.realCoverUrl
+import ceui.pixiv.ui.common.tryOpenNovelReaderDirect
 import ceui.pixiv.utils.setOnClick
-import ceui.pixiv.ui.common.coverUrl
 import com.bumptech.glide.Glide
 import com.google.android.material.tabs.TabLayoutMediator
 import com.qmuiteam.qmui.skin.QMUISkinManager
 import com.qmuiteam.qmui.widget.dialog.QMUIDialog.MenuDialogBuilder
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import timber.log.Timber
 import java.text.NumberFormat
 
 private const val KEY_TAB_KINDS = "user_v3_tab_kinds"
@@ -239,7 +245,8 @@ class UserActivityV3 : BaseActivity<ActivityUserV3Binding>() {
                     // user LiveData 更新 → displayUser 重绑 header UI(幂等)。
                     ObjectPool.updateUser(userResponse.user)
                     // 下拉刷新后允许重选最新有封面小说(封面可能随新投稿变化)
-                    mUserViewModel.setNovelBannerLoaded(false)
+                    mUserViewModel.novelBannerFetched = false
+                    mUserViewModel.novelBannerNovel = null
                     mUserViewModel.user.value = userResponse
                 }
 
@@ -482,23 +489,16 @@ class UserActivityV3 : BaseActivity<ActivityUserV3Binding>() {
         // Banner
         val bannerUrl = profile.background_image_url
         if (!bannerUrl.isNullOrEmpty()) {
-            baseBind.bannerImage.visibility = View.VISIBLE
-            // 40% 黑色 overlay 贴在图片像素上 — 用 colorFilter 而不是单独 scrim view，
-            // 和 CollapsingToolbarLayout 的 parallax + contentScrim 不会打架。
-            baseBind.bannerImage.colorFilter = android.graphics.PorterDuffColorFilter(
-                0x66000000.toInt(),
-                android.graphics.PorterDuff.Mode.SRC_ATOP,
-            )
-            Glide.with(mContext).load(GlideUtil.getUrl(bannerUrl)).into(baseBind.bannerImage)
-            baseBind.bannerImage.setOnClickListener {
-                openImageDetail(bannerUrl, "user_${user.id}_profile_banner")
+            showBanner(bannerUrl) { openImageDetail(bannerUrl, "user_${user.id}_profile_banner") }
+        } else if (isNovelistOnly) {
+            // 纯小说作者通常没有 profile 背景图(background_image_url 为空)：
+            // 拉一页小说列表，挑最新一篇有真实封面(非占位图)的作品当 banner。
+            val picked = mUserViewModel.novelBannerNovel
+            when {
+                // 已选过：重建后直接重绑,不重复请求(选择存活在 ViewModel 上)
+                picked != null -> bindNovelCoverBanner(picked)
+                !mUserViewModel.novelBannerFetched -> loadNovelCoverBanner()
             }
-        }
-
-        // 纯小说作者通常没有 profile 背景图(background_image_url 为空)：
-        // 拉一页小说列表，挑最新一篇有真实封面(非占位图)的作品当 banner。
-        if (bannerUrl.isNullOrEmpty() && isNovelistOnly && !mUserViewModel.isNovelBannerLoaded()) {
-            loadNovelCoverBanner()
         }
 
         // Avatar
@@ -560,35 +560,53 @@ class UserActivityV3 : BaseActivity<ActivityUserV3Binding>() {
     }
 
     /**
-     * 纯小说作者页 banner 兜底：拉一页 /v1/user/novels，
-     * 挑最新一篇 URL 不含 novel_thumb 占位的小说封面做背景，点击跳该小说详情。
-     * 失败或无封面时静默，保留现有渐变占位。
+     * 显示 header banner。40% 黑色 overlay 贴在图片像素上 —— 用 colorFilter 而不是单独 scrim view，
+     * 和 CollapsingToolbarLayout 的 parallax + contentScrim 不会打架。
+     */
+    private fun showBanner(url: String, onClick: () -> Unit) {
+        baseBind.bannerImage.visibility = View.VISIBLE
+        baseBind.bannerImage.colorFilter = PorterDuffColorFilter(0x66000000, PorterDuff.Mode.SRC_ATOP)
+        Glide.with(mContext).load(GlideUtil.getUrl(url)).into(baseBind.bannerImage)
+        baseBind.bannerImage.setOnClickListener { onClick() }
+    }
+
+    /** 拿某篇小说的封面当 banner，点击进这篇小说（先过「列表点击直接进正文」设置）。 */
+    private fun bindNovelCoverBanner(novel: Novel) {
+        val cover = novel.realCoverUrl ?: return
+        showBanner(cover) {
+            if (tryOpenNovelReaderDirect(novel.id)) return@showBanner
+            startActivity(Intent(this, TemplateActivity::class.java).apply {
+                putExtra(TemplateActivity.EXTRA_FRAGMENT, "小说详情")
+                putExtra(Params.NOVEL_ID, novel.id)
+            })
+        }
+    }
+
+    /**
+     * 纯小说作者页 banner 兜底：拉一页 /v1/user/novels，挑最新一篇有真实封面（非占位图）的作品。
+     * 选中结果记在 ViewModel 上，Activity 重建后直接重绑、不重复请求；下拉刷新时页面清掉它重选。
+     * 请求失败静默保留渐变占位，且不落 fetched 标记，下次进 displayUser 还能再试。
      */
     private fun loadNovelCoverBanner() {
         if (novelBannerLoading) return
         novelBannerLoading = true
         lifecycleScope.launch {
-            val resp = runCatching { Client.appApi.getUserCreatedNovels(userId.toLong()) }.getOrNull()
-            val novel = resp?.novels?.firstOrNull {
-                it.coverUrl?.contains("/common/images/novel_thumb/") == false
-            }
-            novelBannerLoading = false
-            if (novel == null || isDestroyed) return@launch
-            val cover = novel.coverUrl ?: return@launch
-            mUserViewModel.novelBannerNovelId = novel.id
-            mUserViewModel.setNovelBannerLoaded(true)
-            baseBind.bannerImage.visibility = View.VISIBLE
-            baseBind.bannerImage.colorFilter = android.graphics.PorterDuffColorFilter(
-                0x66000000.toInt(),
-                android.graphics.PorterDuff.Mode.SRC_ATOP,
-            )
-            Glide.with(mContext).load(GlideUtil.getUrl(cover)).into(baseBind.bannerImage)
-            baseBind.bannerImage.setOnClickListener {
-                startActivity(Intent(this@UserActivityV3, TemplateActivity::class.java).apply {
-                    putExtra(TemplateActivity.EXTRA_FRAGMENT, "小说详情")
-                    putExtra(Params.NOVEL_ID, novel.id)
-                })
-            }
+            val resp = try {
+                Client.appApi.getUserCreatedNovels(userId.toLong())
+            } catch (ce: CancellationException) {
+                // 页面销毁 → lifecycleScope 取消：必须放行，否则协程取消被当成一次「请求失败」吞掉
+                throw ce
+            } catch (ex: Exception) {
+                Timber.w(ex, "拉取小说封面 banner 失败")
+                null
+            } finally {
+                novelBannerLoading = false
+            } ?: return@launch
+
+            mUserViewModel.novelBannerFetched = true
+            val novel = resp.novels.firstOrNull { it.realCoverUrl != null } ?: return@launch
+            mUserViewModel.novelBannerNovel = novel
+            bindNovelCoverBanner(novel)
         }
     }
 

--- a/app/src/main/java/ceui/lisa/viewmodel/UserViewModel.java
+++ b/app/src/main/java/ceui/lisa/viewmodel/UserViewModel.java
@@ -25,4 +25,21 @@ public class UserViewModel extends ViewModel {
 
     public MutableLiveData<Event<Integer>> refreshEvent = new MutableLiveData<>();
 
+    /**
+     * 纯小说作者页 banner：本次 ViewModel 生命周期内只拉一次小说列表，
+     * 下拉刷新时由页面重置，以便换到最新有封面的作品。
+     */
+    private boolean novelBannerLoaded = false;
+
+    /** banner 选中的小说 id，点击跳小说详情用（旋转后仍有效）。 */
+    public long novelBannerNovelId = 0L;
+
+    public boolean isNovelBannerLoaded() {
+        return novelBannerLoaded;
+    }
+
+    public void setNovelBannerLoaded(boolean novelBannerLoaded) {
+        this.novelBannerLoaded = novelBannerLoaded;
+    }
+
 }

--- a/app/src/main/java/ceui/lisa/viewmodel/UserViewModel.java
+++ b/app/src/main/java/ceui/lisa/viewmodel/UserViewModel.java
@@ -5,6 +5,7 @@ import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 import ceui.lisa.models.UserDetailResponse;
 import ceui.loxia.Event;
+import ceui.loxia.Novel;
 import ceui.loxia.WebUserDetail;
 
 public class UserViewModel extends ViewModel {
@@ -26,20 +27,17 @@ public class UserViewModel extends ViewModel {
     public MutableLiveData<Event<Integer>> refreshEvent = new MutableLiveData<>();
 
     /**
-     * 纯小说作者页 banner：本次 ViewModel 生命周期内只拉一次小说列表，
-     * 下拉刷新时由页面重置，以便换到最新有封面的作品。
+     * 纯小说作者页 banner 兜底（issue #978）：本次 ViewModel 生命周期内是否已成功拉过小说列表。
+     * 「一篇有封面的都没有」也算拉过，避免每次 displayUser 都重打一次请求；
+     * 请求失败不落这个标记，好让下次进 displayUser 还能再试。
      */
-    private boolean novelBannerLoaded = false;
+    public boolean novelBannerFetched = false;
 
-    /** banner 选中的小说 id，点击跳小说详情用（旋转后仍有效）。 */
-    public long novelBannerNovelId = 0L;
-
-    public boolean isNovelBannerLoaded() {
-        return novelBannerLoaded;
-    }
-
-    public void setNovelBannerLoaded(boolean novelBannerLoaded) {
-        this.novelBannerLoaded = novelBannerLoaded;
-    }
+    /**
+     * banner 选中的那篇小说（封面 URL + 点击目标）。深色模式/语言切换会真正重建 Activity
+     * （configChanges 只挡了旋转），ViewModel 连同这份选择存活 —— 页面据此直接重绑 banner，
+     * 不必也不该再打一次请求。下拉刷新时页面清空它，以便换到最新投稿的封面。
+     */
+    public Novel novelBannerNovel = null;
 
 }

--- a/app/src/main/java/ceui/loxia/Models.kt
+++ b/app/src/main/java/ceui/loxia/Models.kt
@@ -511,7 +511,7 @@ interface KListShow<T> {
 data class UserPreview(
     val illusts: List<Illust> = listOf(),
     val is_muted: Boolean? = null,
-    val novels: List<Any>? = null,
+    val novels: List<Novel>? = null,
     val user: User? = null
 ) : Serializable
 

--- a/app/src/main/java/ceui/pixiv/ui/common/NovelExt.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/NovelExt.kt
@@ -1,0 +1,10 @@
+package ceui.pixiv.ui.common
+
+import ceui.loxia.Novel
+
+/**
+ * 小说封面 URL：app-api 小说列表只给缩略图，按清晰度取 large → medium → square_medium。
+ * 列表卡片与作者页 banner 共用同一份取图规则，避免各处内联顺序不一致。
+ */
+val Novel.coverUrl: String?
+    get() = image_urls?.let { it.large ?: it.medium ?: it.square_medium }

--- a/app/src/main/java/ceui/pixiv/ui/common/NovelExt.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/NovelExt.kt
@@ -2,9 +2,20 @@ package ceui.pixiv.ui.common
 
 import ceui.loxia.Novel
 
+/** 作者没设封面时 app-api 回的占位图路径 —— 拿它当背景/补位图等于铺一张灰底。 */
+private const val NOVEL_THUMB_PLACEHOLDER = "/common/images/novel_thumb/"
+
 /**
  * 小说封面 URL：app-api 小说列表只给缩略图，按清晰度取 large → medium → square_medium。
  * 列表卡片与作者页 banner 共用同一份取图规则，避免各处内联顺序不一致。
  */
 val Novel.coverUrl: String?
     get() = image_urls?.let { it.large ?: it.medium ?: it.square_medium }
+
+/**
+ * 「能看的」封面 URL：[coverUrl] 去掉 app-api 的占位图。
+ * 用于拿小说封面当图使的场景（作者页 banner、关注列表预览格补位）——那里宁可留空也不该铺灰底。
+ * 小说列表卡片不用它：卡片的封面位固定要占着，占位图也得画。
+ */
+val Novel.realCoverUrl: String?
+    get() = coverUrl?.takeUnless { it.contains(NOVEL_THUMB_PLACEHOLDER) }

--- a/app/src/main/java/ceui/pixiv/ui/common/NovelFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/NovelFeedFragment.kt
@@ -188,7 +188,7 @@ abstract class NovelFeedFragment(
         b.novelTag.setTags(tags)
         b.novelTag.isVisible = tags.isNotEmpty()
 
-        val coverUrl = novel.image_urls?.let { it.large ?: it.medium ?: it.square_medium }
+        val coverUrl = novel.coverUrl
         novelGlide.load(GlideUtil.getUrl(coverUrl))
             .placeholder(R.color.v3_surface_2).error(R.color.v3_surface_2)
             .into(b.cover)

--- a/app/src/main/java/ceui/pixiv/ui/common/UserFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/UserFeedFragment.kt
@@ -125,7 +125,7 @@ abstract class UserFeedFragment(
         val user = preview.user
         val ctx = b.root.context
 
-        // 3 张方形预览图，边长 = 屏宽/3。只显示插画预览（用户裁决：不足留空，见类文档）。
+        // 3 张方形预览图，边长 = 屏宽/3。默认只显示插画预览（不足留空，见类文档）。
         val size = ctx.resources.displayMetrics.widthPixels / 3
         val slots = listOf(b.userShowOne, b.userShowTwo, b.userShowThree)
         slots.forEach { iv ->
@@ -140,11 +140,9 @@ abstract class UserFeedFragment(
         }
         val illusts = preview.illusts
         // 关注列表打开 fillPreviewWithNovelCovers 时，插画不足的位置用小说封面补位
-        //（跳过 novel_thumb 占位图，与作者页 banner 同口径）。
+        //（realCoverUrl 跳过占位图，与作者页 banner 同口径 —— 补位铺一张灰底还不如留空）。
         val novelCovers = if (fillPreviewWithNovelCovers) {
-            preview.novels.orEmpty()
-                .mapNotNull { it.coverUrl }
-                .filterNot { it.contains("/common/images/novel_thumb/") }
+            preview.novels.orEmpty().mapNotNull { it.realCoverUrl }
         } else {
             emptyList()
         }

--- a/app/src/main/java/ceui/pixiv/ui/common/UserFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/UserFeedFragment.kt
@@ -39,11 +39,10 @@ private val PAYLOAD_USER_FOLLOW = Any()
  * 粉丝 [ceui.pixiv.ui.user.UserFansFeedFragment]、推荐用户 [ceui.pixiv.ui.user.RecmdUserFeedFragment]、
  * 画师榜 [ceui.pixiv.ui.recommend.ArtistRankFeedFragment]。
  *
- * **3 张预览图只显插画，不足留空——这是用户裁决，适用于本基类的每一个页面，别再翻。**
- * legacy `UAdapter` 在插画不足 3 张时会拿小说封面补位；迁移时问过一轮
- *「关注列表里小说家密度比搜索页高得多，是不是该恢复补位」，答复是**不需要**。
- * 所以 [ceui.loxia.UserPreview.novels] 保持 `List<Any>?`（拿不到封面 URL 也无所谓），
- * 不必为了补位把它改成 `List<Novel>`。
+ * **3 张预览图默认只显插画，不足留空**。legacy `UAdapter` 在插画不足 3 张时会拿小说封面补位；
+ * 关注列表里小说家密度高、空三格观感差，所以由 [ceui.pixiv.ui.user.FollowUserFeedFragment]
+ * 打开 [fillPreviewWithNovelCovers] 恢复补位，其余用户列表页维持「不足留空」。
+ * 补位需要封面 URL，[ceui.loxia.UserPreview.novels] 相应解析为 `List<Novel>`。
  *
  * 卡片布局与交互语义源自 legacy `UAdapter`（迁移时逐条对齐）。**该类已随最后一个调用方一起
  * 删除**，要考古去 git 历史，别在工作区找。
@@ -51,6 +50,13 @@ private val PAYLOAD_USER_FOLLOW = Any()
 abstract class UserFeedFragment(
     @LayoutRes contentLayoutId: Int = R.layout.fragment_feed,
 ) : FeedFragment(contentLayoutId) {
+
+    /**
+     * 插画不足 3 张时是否用小说封面补位（对齐 legacy UAdapter 的行为）。
+     * 默认关：搜索/相关/粉丝等用户列表页保持「不足留空」；
+     * 关注列表由 FollowUserFeedFragment 打开，因为那里小说家密度高、空三格观感差。
+     */
+    protected open val fillPreviewWithNovelCovers: Boolean = false
 
     /**
      * 头像 + 3 张预览图的 Glide 请求管理器，建一次复用（对齐插画侧 [IllustFeedFragment.illustGlide]）。
@@ -133,9 +139,18 @@ abstract class UserFeedFragment(
             }
         }
         val illusts = preview.illusts
+        // 关注列表打开 fillPreviewWithNovelCovers 时，插画不足的位置用小说封面补位
+        //（跳过 novel_thumb 占位图，与作者页 banner 同口径）。
+        val novelCovers = if (fillPreviewWithNovelCovers) {
+            preview.novels.orEmpty()
+                .mapNotNull { it.coverUrl }
+                .filterNot { it.contains("/common/images/novel_thumb/") }
+        } else {
+            emptyList()
+        }
         slots.forEachIndexed { i, iv ->
-            val illust = illusts.getOrNull(i)
-            val url = illust?.image_urls?.let { it.square_medium ?: it.medium }
+            val url = illusts.getOrNull(i)?.image_urls?.let { it.square_medium ?: it.medium }
+                ?: novelCovers.getOrNull(i - illusts.size)
             userGlide.load(GlideUtil.getUrl(url)).placeholder(R.color.light_bg).into(iv)
         }
 

--- a/app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFeed.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFeed.kt
@@ -38,6 +38,7 @@ import ceui.pixiv.feeds.FeedSource
 import ceui.pixiv.feeds.feedRenderer
 import ceui.pixiv.ui.common.NovelActionReceiver
 import ceui.pixiv.ui.common.NovelMultiSelectReceiver
+import ceui.pixiv.ui.common.coverUrl
 import ceui.pixiv.ui.common.bindCopyChip
 import ceui.pixiv.ui.common.bindCopyLinkChip
 import ceui.pixiv.ui.common.bindOpenLinkChip
@@ -254,7 +255,7 @@ fun novelSeriesCardRenderer(): FeedRenderer<NovelSeriesCardFeedItem, CellNovelV3
         val fmt = NumberFormat.getInstance()
 
         // cover
-        val coverUrl = novel.image_urls?.let { it.medium ?: it.square_medium ?: it.large }
+        val coverUrl = novel.coverUrl
         Glide.with(ctx).load(GlideUtil.getUrl(coverUrl))
             .placeholder(R.color.v3_surface_2).error(R.color.v3_surface_2)
             .centerCrop().into(b.novelCover)

--- a/app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFeed.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFeed.kt
@@ -38,10 +38,10 @@ import ceui.pixiv.feeds.FeedSource
 import ceui.pixiv.feeds.feedRenderer
 import ceui.pixiv.ui.common.NovelActionReceiver
 import ceui.pixiv.ui.common.NovelMultiSelectReceiver
-import ceui.pixiv.ui.common.coverUrl
 import ceui.pixiv.ui.common.bindCopyChip
 import ceui.pixiv.ui.common.bindCopyLinkChip
 import ceui.pixiv.ui.common.bindOpenLinkChip
+import ceui.pixiv.ui.common.coverUrl
 import ceui.pixiv.ui.detail.SeriesAuthorFeedItem
 import ceui.pixiv.ui.detail.SeriesCaptionFeedItem
 import ceui.pixiv.ui.detail.SeriesSectionLabelFeedItem

--- a/app/src/main/java/ceui/pixiv/ui/user/FollowUserFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/user/FollowUserFeedFragment.kt
@@ -46,6 +46,9 @@ import kotlinx.coroutines.launch
  */
 class FollowUserFeedFragment : UserFeedFragment() {
 
+    /** 关注列表里小说家密度高：插画不足 3 张时用小说封面补位（对齐 legacy UAdapter）。 */
+    override val fillPreviewWithNovelCovers: Boolean = true
+
     // legacy 用 int USER_ID（TemplateActivity 路由 getIntExtra / FragmentCollection 传
     // (int) SessionManager.loggedInUid）；loxia 侧接口收 Long，取用处再转。
     private val userId: Int by lazy(LazyThreadSafetyMode.NONE) {


### PR DESCRIPTION
## 关联

#978「其它信息」第 1 点：小说作者没有像插画作者一样拥有预览图，方案为用小说封面做背景（原描述标注实现难度较大，这里用现成的列表封面数据低成本落地）。

## 背景

纯小说作者无法设置 profile 背景图（`background_image_url` 恒为空），作者页 header 只有渐变占位；关注列表里小说作者的 3 个预览格也因没有插画而全空（legacy `UAdapter` 曾用小说封面补位，feeds 迁移时被砍掉）。

## 改动

1. **作者页 banner 兜底（UserActivityV3）**——对应 #978「其它信息」第 1 点
   - 纯小说作者（插画 0 + 漫画 0 + 小说 > 0）且无自定义背景图时，进页拉一页 `/v1/user/novels`，取最新一篇有真实封面（URL 不含 `novel_thumb` 占位）的小说封面做 banner。
   - 复用现有 banner 视图与 40% 黑色 overlay，点击跳该小说详情。
   - 每个 ViewModel 生命周期只拉一次，失败静默回退渐变占位；下拉刷新重新选最新封面。

2. **关注列表预览格恢复小说封面补位（扩展对齐旧版）**
   - `UserPreview.novels` 由 `List<Any>` 改为 `List<Novel>`，从而拿到封面 URL。
   - `UserFeedFragment` 新增 `fillPreviewWithNovelCovers` 开关（默认关，其余用户列表页维持「不足留空」）；`FollowUserFeedFragment` 打开开关，插画不足 3 张时用小说封面补位、跳过占位图——对齐 legacy `UAdapter` 的行为。

3. **抽公共取图规则**
   - 新增 `Novel.coverUrl` 扩展（large → medium → square_medium），统一小说列表卡片（`NovelFeedFragment` / `NovelSeriesFeed`，原两份内联取图顺序不一致）、作者页 banner、关注列表三处逻辑。

## 验证

真机实测：关注的纯小说作者在关注列表和作者页均达成预期效果。

## 注意事项

- banner 用的是列表接口缩略图（≤240px），全宽拉伸会略糊；高清封面（`master1200`）只有 web 详情接口有，需 cookie + 额外请求，当前未做，列为后续增强。
- 未做 R18 过滤（与现有 banner 行为一致），如需可再议。
- 其他用户列表页未开启补位；以后想扩，打开对应 Fragment 的开关即可。
