### PR TITLE
fix(history): 多选勾选卡片不再重发图片加载——选择态走增量 payload 只刷勾标，消除图片闪烁

### DIFF
--- a/app/src/main/java/ceui/lisa/fragments/HistoryFeed.kt
+++ b/app/src/main/java/ceui/lisa/fragments/HistoryFeed.kt
@@ -35,6 +35,9 @@ import java.util.Locale
 /** 历史卡封面高度下限 = 宽的 0.5 倍(对齐改造前 `coerceAtLeast(itemWidth / 2)` 的语义)。 */
 private const val MIN_HISTORY_HEIGHT_RATIO = 0.5f
 
+/** 历史选择态变化的增量 payload：只刷勾标/删除钮，不重跑图片加载。 */
+private val PAYLOAD_HISTORY_SELECTION = Any()
+
 // ── FeedItem 模型（原 HistoryIllustHolder / HistoryNovelHolder 的数据部分）─────────────
 // isSelectionMode / isSelected 由 FragmentHistoryList.syncSelection 通过 updateItems 回灌。
 
@@ -298,6 +301,28 @@ fun FragmentHistoryList.historyIllustRenderer(): FeedRenderer<HistoryIllustFeedI
             }
         },
         recycle = { it.binding.illustImage.clearGlideOnRecycle() },
+        // 选择态变化（isSelectionMode/isSelected）只刷勾标与删除钮，不重跑 Glide——
+        // 全量重绑会让 Glide 清掉当前 bitmap 换占位色再异步载入，造成勾选瞬间图片闪烁。
+        changePayload = { old, new ->
+            if (old.entity.illustID == new.entity.illustID &&
+                old.entity.time == new.entity.time &&
+                (old.isSelectionMode != new.isSelectionMode || old.isSelected != new.isSelected)
+            ) {
+                PAYLOAD_HISTORY_SELECTION
+            } else {
+                null
+            }
+        },
+        bindPayloads = { cell, payloads ->
+            if (payloads.all { it === PAYLOAD_HISTORY_SELECTION }) {
+                val item = cell.item
+                HistorySelectBadge.bind(cell.binding.selectCheck, item.isSelectionMode, item.isSelected)
+                cell.binding.deleteItem.isVisible = !item.isSelectionMode
+                true
+            } else {
+                false
+            }
+        },
     ) { cell ->
         val binding = cell.binding
         val item = cell.item
@@ -381,6 +406,27 @@ fun FragmentHistoryList.historyNovelRenderer(): FeedRenderer<HistoryNovelFeedIte
             }
         },
         recycle = { it.binding.illustImage.clearGlideOnRecycle() },
+        // 同 historyIllustRenderer：选择态只刷勾标与删除钮，避免重发 Glide 造成闪烁。
+        changePayload = { old, new ->
+            if (old.entity.illustID == new.entity.illustID &&
+                old.entity.time == new.entity.time &&
+                (old.isSelectionMode != new.isSelectionMode || old.isSelected != new.isSelected)
+            ) {
+                PAYLOAD_HISTORY_SELECTION
+            } else {
+                null
+            }
+        },
+        bindPayloads = { cell, payloads ->
+            if (payloads.all { it === PAYLOAD_HISTORY_SELECTION }) {
+                val item = cell.item
+                HistorySelectBadge.bind(cell.binding.selectCheck, item.isSelectionMode, item.isSelected)
+                cell.binding.deleteItem.isVisible = !item.isSelectionMode
+                true
+            } else {
+                false
+            }
+        },
     ) { cell ->
         val binding = cell.binding
         val item = cell.item

--- a/app/src/main/java/ceui/lisa/fragments/HistoryUserFeed.kt
+++ b/app/src/main/java/ceui/lisa/fragments/HistoryUserFeed.kt
@@ -29,6 +29,9 @@ import timber.log.Timber
 // ── FeedItem 模型（原 HistoryUserHolder 的数据部分）。isSelectionMode/isSelected 由
 //    FragmentHistoryUserList.syncSelection 通过 updateItems 回灌，键为 entity.id(uid)。──
 
+/** 历史选择态变化的增量 payload：只刷勾标/删除钮，不重跑头像加载。 */
+private val PAYLOAD_HISTORY_SELECTION = Any()
+
 data class HistoryUserFeedItem(
     val entity: GeneralEntity,
     val user: User?,
@@ -147,6 +150,29 @@ fun FragmentHistoryUserList.historyUserRenderer(): FeedRenderer<HistoryUserFeedI
             }
         },
         recycle = { it.binding.userAvatar.clearGlideOnRecycle() },
+        // 选择态变化（isSelectionMode/isSelected）只刷勾标与删除钮，不重跑头像 Glide 加载。
+        changePayload = { old, new ->
+            // 用户 tab 的 data class equals 是 entity+user+两个选择字段；
+            // 选择流程里 entity/user 引用不变，引用相等即可安全走增量。
+            if (old.entity == new.entity &&
+                old.user === new.user &&
+                (old.isSelectionMode != new.isSelectionMode || old.isSelected != new.isSelected)
+            ) {
+                PAYLOAD_HISTORY_SELECTION
+            } else {
+                null
+            }
+        },
+        bindPayloads = { cell, payloads ->
+            if (payloads.all { it === PAYLOAD_HISTORY_SELECTION }) {
+                val item = cell.item
+                HistorySelectBadge.bind(cell.binding.selectCheck, item.isSelectionMode, item.isSelected)
+                cell.binding.deleteItem.isVisible = !item.isSelectionMode
+                true
+            } else {
+                false
+            }
+        },
     ) { cell ->
         val binding = cell.binding
         val item = cell.item


### PR DESCRIPTION
fix(history): 多选勾选卡片不再重发图片加载——选择态走增量 payload 只刷勾标，消除图片闪烁

## 问题

浏览记录页（插画/漫画、小说、用户三个 tab）进入多选后，勾选卡片时封面有概率性快速闪烁：图片瞬间被占位底色顶掉一两个帧再弹回来。

## 根因

1. 勾选 → `syncSelection` 把 `isSelected` 回灌成 `FeedItem` 字段（`equals` 含选择态）→ DiffUtil 判定该卡片内容变化。
2. 历史页三个 renderer 没有实现 `changePayload`/`bindPayloads`，框架按 `FULL_REBIND` 原地全量重绑（FeedAdapter.kt）。
3. 全量重绑必然重新执行 `Glide.load(...).into(image)`：Glide 先 clear 旧请求，`ImageViewTarget.onLoadCleared` 立刻把当前 bitmap 换成占位色（`v3_surface_2`），再起新请求。
4. `GlideUrlChild` 每次构造都新建一个捕获局部变量的 headers lambda（GlideUrlChild.java），而 `GlideUrl.equals/hashCode` 要求 headers 也相等——于是新请求的 `EngineKey` 与旧请求永远不同，内存缓存必 miss，只能异步走磁盘缓存；占位色在此期间被绘制出来，闪 1~N 帧。能否看到取决于磁盘解码与下一帧绘制的赛跑，所以表现是"概率性"。

## 修复

给三个历史 renderer（插画/小说/用户）补 `changePayload`/`bindPayloads`：仅当业务内容不变、只选择态字段变化时走增量绑定，只调 `HistorySelectBadge.bind` 并更新删除钮显隐，**完全不重跑 Glide**。

- 勾选/取消单卡：只刷勾标，图片不动；
- 进入/退出多选（全列表 `isSelectionMode` 翻转）：从"整页图片重载"变成只显隐勾标与删除钮；
- 其余内容变化（刷新换代、浏览时间更新等）仍回落全量重绑，行为与之前一致。

## 涉及文件

- `app/src/main/java/ceui/lisa/fragments/HistoryFeed.kt`（插画 + 小说 renderer）
- `app/src/main/java/ceui/lisa/fragments/HistoryUserFeed.kt`（用户 renderer）

## 验证

- 真机实测：多选下反复勾选/取消单卡，图片不再闪烁；全选/取消全选只刷勾标。

## 备注（可后续单独处理）

根因里第 4 点是全 app 共性问题：`GlideUrlChild` 的 headers 没有按内容实现 equals/hashCode，导致 Glide 活跃资源/内存缓存对任何"重新构造的同一 URL"都认不出来。本 PR 用增量绑定绕开了历史页这条触发路径；后续若把 headers 改成内容相等，可让全站图片重绑都命中内存缓存。