### PR TITLE
feat(detail): 多 P 后续页空白容器改用 P1 宽高先验占位,ajax 缺失时压缩首帧跳

### DIFF
--- a/app/src/main/java/ceui/lisa/adapters/IllustAdapter.java
+++ b/app/src/main/java/ceui/lisa/adapters/IllustAdapter.java
@@ -115,6 +115,9 @@ public class IllustAdapter extends AbstractIllustAdapter<ViewHolder<RecyIllustDe
      *   <li>兜底(无 cookie / 精简 bean 无尺寸):图片解码后由 {@link #rememberDecodedRatio}
      *       用位图宽高定下。</li>
      * </ul>
+     * ajax 缺失时,多 P 后续页还会先用 P1 宽高当「先验占位」过渡(见
+     * {@link #applyRatioOrPlaceholder},先验高超 maxHeight 时退回旧全高占位):
+     * 只设展示盒、不落本表,解码校正照常发生。
      * 缓存进此表 → 滑走再回、回收重绑时首帧直接套用,消除抖动;{@link #release()} 时清空。
      */
     private final Map<Integer, Float> pageRatio = new ConcurrentHashMap<>();
@@ -329,15 +332,40 @@ public class IllustAdapter extends AbstractIllustAdapter<ViewHolder<RecyIllustDe
     }
 
     /**
-     * ratio 已知就套用(首帧即终值),未知就退回占位高({@code maxHeight} 或布局默认)并返回
-     * {@code changeSize=true} —— 让 {@link #loadIllust} 走「解码后定 ratio」的兜底路径。
+     * ratio 已知就套用(首帧即终值),未知时先试 P1 先验占位,再退回占位高({@code maxHeight} 或
+     * 布局默认)并返回 {@code changeSize=true} —— 让 {@link #loadIllust} 走「解码后定 ratio」的兜底路径。
+     *
+     * <p>多 P 后续页在 ajax 尺寸缺失(无 cookie / R18 / 受限 / 精简 bean)时,原先一律拿整屏高
+     * {@code maxHeight} 当空白容器,图一到再从全高跳到自然高,首帧跳幅度最大。这里改用
+     * {@link IllustsBean} 的 P1 宽高当先验比例:同画布作品占位 ≈ 自然高,首帧跳基本归零;
+     * 混比作品也由解码校正一帧内回真值。
+     *
+     * <p>先验高超过 {@code maxHeight}(P1 为超长竖图)时退回旧的全高占位——把「先验过高」这个
+     * 最坏分支直接还原成旧行为,保证改动不劣于旧版;长条作品维持既有体验,不做放大跳变的冒险。
+     *
+     * <p>先验只是过渡,不是真值:不写 {@link #pageRatio},仍返回 {@code changeSize=true}。
+     * 两层 {@code illust}/{@code illust_hd} 同时设 ratio,保持同盒同框(回收重绑时
+     * {@code illust_hd} 可能残留上一轮的 ratio,单设 {@code illust} 会让原图 overlay 短暂错位)。
+     *
      * @return changeSize:true 表示 ratio 未知、需解码后定。
      */
     private boolean applyRatioOrPlaceholder(ViewHolder<RecyIllustDetailBinding> holder, int position) {
         Float ratio = pageRatio.get(position);
         if (ratio != null && ratio > 0f) {
             holder.baseBind.illust.setHeightRatio(ratio);
+            holder.baseBind.illustHd.setHeightRatio(ratio);
             return false;
+        }
+        // 多 P 后续页:P1 宽高(bean 必有)当先验比例占位,替代 maxHeight 全高空白容器。
+        // 先验高不超过 maxHeight 才生效:P1 超长竖图退回旧占位,把混比作品的最坏跳变限制在旧行为量级。
+        if (position > 0 && allIllust.getWidth() > 0 && allIllust.getHeight() > 0) {
+            float prior = (float) allIllust.getHeight() / allIllust.getWidth();
+            int priorHeight = Math.round((float) imageSize * prior);
+            if (maxHeight <= 0 || priorHeight <= maxHeight) {
+                holder.baseBind.illust.setHeightRatio(prior);
+                holder.baseBind.illustHd.setHeightRatio(prior);
+                return true;
+            }
         }
         int placeholder = maxHeight > 0 ? maxHeight : holder.baseBind.illust.getLayoutParams().height;
         setFixedHeight(holder, placeholder);
@@ -347,6 +375,8 @@ public class IllustAdapter extends AbstractIllustAdapter<ViewHolder<RecyIllustDe
     /** 关掉 ratio 自measure、改用固定像素高(扁图垫底 / 尺寸未知的占位)。FIT_CENTER 居中不裁。 */
     private void setFixedHeight(ViewHolder<RecyIllustDetailBinding> holder, int height) {
         holder.baseBind.illust.setHeightRatio(0f);
+        // 固定高盒子里 illust_hd 也关 ratio,靠 RelativeLayout 四边对齐跟随 illust,避免残留旧 ratio 错位。
+        holder.baseBind.illustHd.setHeightRatio(0f);
         ViewGroup.LayoutParams params = holder.baseBind.illust.getLayoutParams();
         if (params != null && height > 0 && params.height != height) {
             params.height = height;
@@ -371,7 +401,6 @@ public class IllustAdapter extends AbstractIllustAdapter<ViewHolder<RecyIllustDe
         int naturalHeight = Math.round((float) imageSize * ratio);
         if (position == 0 && allIllust.getPage_count() == 1 && maxHeight > 0 && naturalHeight < maxHeight) {
             setFixedHeight(holder, maxHeight);
-            holder.baseBind.illustHd.setHeightRatio(0f);
         } else {
             holder.baseBind.illust.setHeightRatio(ratio);
             holder.baseBind.illustHd.setHeightRatio(ratio);

--- a/app/src/main/java/ceui/pixiv/ui/detail/CollapsibleIllustAdapter.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/CollapsibleIllustAdapter.kt
@@ -124,6 +124,8 @@ class CollapsibleIllustAdapter(
         // 极端宽封面:关掉 ratio 自 measure,拔到 maxHeight 固定高、FIT_CENTER 居中,给足上黑边托住 toolbar。
         val target = if (coverMaxHeight > 0) coverMaxHeight else coverToolbarClearance()
         image.setHeightRatio(0f)
+        // 兜高后 illust_hd 同样关 ratio,靠对齐跟随 illust 盒子,避免回收重绑残留旧 ratio 导致 overlay 错位。
+        holder.baseBind.illustHd.setHeightRatio(0f)
         val lp = image.layoutParams ?: return
         if (lp.height != target) {
             lp.height = target

--- a/app/src/main/res/layout/recy_illust_detail.xml
+++ b/app/src/main/res/layout/recy_illust_detail.xml
@@ -12,7 +12,9 @@
 
         <!-- 高度由 setHeightRatio 在 onMeasure 里按真实宽算(对齐瀑布流 recy_illust_stagger):
              ratio 已知(P1 靠 IllustsBean、多 P 靠网页 ajax、兜底靠解码位图)→ 首帧就量在终值,
-             不再有「兜底高→自然高」的跳。ratio 未设(=0)时退回下面的 240dp 占位高。 -->
+             不再有「兜底高→自然高」的跳。ajax 缺失时多 P 后续页先用 P1 宽高当先验占位
+             (见 IllustAdapter.applyRatioOrPlaceholder),进一步压缩首帧跳;ratio 未设(=0,
+             单 P 精简 bean / pos 0 无尺寸)时退回下面的 240dp 占位高。 -->
         <ceui.lisa.view.DynamicHeightImageView
             android:id="@+id/illust"
             android:layout_width="match_parent"


### PR DESCRIPTION
# 多 P 详情页空白容器改用 IllustsBean 宽高先验占位，ajax 缺失时压缩首帧跳

> 分支：`patch-8-12`
> 提交：`9e0c4b60a` feat(detail): 多 P 后续页空白容器改用 P1 宽高先验占位,ajax 缺失时压缩首帧跳

## 背景

PR #977 的 review 结论（collaborator，已 close）：`floorCoverHeight` 的类型门槛有逻辑 bug（`||` 应为 `&&`，且多 P 可达路径恒 return，兜高被静默关闭）；按作品类型切分不是正确轴；未触及「首进 vs 滚回不一致」根因——这部分已由 `874f394` 按另一条路径修复（兜高挂 `applyPixelSize` 统一入口、阈值 160→120dp、类型无关）。review 明确保留了这一处：

> 值得保留的部分：applyRatioOrPlaceholder 用 IllustsBean 宽高当「空白容器」替代 maxHeight 固定占位，是个不错的正交优化（缓解 ajax 尺寸缺失时后续页的首帧跳）。欢迎 rebase 到最新 classic 后把 PR 缩成只含这一处再提（连带的注释同步也需按 874f394 的新口径重写）。

本 PR 按该意见缩窄为只含这一处：**不触碰兜高/垫高逻辑**，只改 `applyRatioOrPlaceholder` 的兜底占位策略并加固边界。

## 改动内容

### 1. applyRatioOrPlaceholder：P1 宽高当先验占位

- 该页真 ratio 未定（网页 ajax `/ajax/illust/{id}/pages` 缺失：无 cookie / R18 / 受限 / 精简 bean）时，多 P 后续页先用 `IllustsBean` 第 0 页宽高（bean 必有）当「最开始的空白容器」：占位高 = 屏宽 × P1 高/宽，替代整屏 `maxHeight` 固定高；
- 同画布作品占位 ≈ 自然高，首帧跳基本归零；混比作品仍由解码校正一帧内回真值；
- **先验高超过 `maxHeight`（P1 为超长竖图）退回旧全高占位**：把「先验过高」的最坏分支还原成旧行为，保证改动不劣于旧版；
- **先验不落 `pageRatio`、仍返回 `changeSize=true`**：先验只是过渡不是真值，解码后 `rememberDecodedRatio` 照常以真值覆盖，回收重绑不会把先验当真值跳过校正。

### 2. illust / illust_hd 两层同框（顺带修既有隐患）

- `applyRatioOrPlaceholder` 的 pageRatio 命中分支、先验分支均同时设两层 ratio（原先只设 `illust`）；
- `setFixedHeight` 统一复位 `illust_hd` ratio（固定高盒子靠 RelativeLayout 四边对齐跟随）；
- `CollapsibleIllustAdapter.floorCoverHeight` 兜高时同样复位 `illust_hd`；
- 消除回收重绑时 `illust_hd` 残留上一页 ratio 导致的原图 overlay 错位（裁切/letterbox 不一致）。

### 3. 注释口径同步

- `pageRatio` 三来源说明补充「先验占位不落表、解码校正照常」；
- `applyRatioOrPlaceholder` / `rememberDecodedRatio` / `seedPageDimensions` KDoc 按新口径重写；
- `recy_illust_detail.xml` 占位注释同步。

## 与 #977 的差异

| 项 | #977 | 本 PR |
|---|---|---|
| applyRatioOrPlaceholder 先验占位 | 有 | 保留并加固（maxHeight 上限、两层 ratio 同步） |
| floorCoverHeight 类型门槛 / 多 P 插画首图不再垫高 | 有（逻辑 bug，兜高被静默关闭） | 移除，不触碰垫高语义 |
| 按作品类型切分兜高 | 有（非正确轴） | 无 |
| 注释同步口径 | 旧口径 | 按 874f394 后的新口径 |

## 涉及文件

- `app/src/main/java/ceui/lisa/adapters/IllustAdapter.java`
- `app/src/main/java/ceui/pixiv/ui/detail/CollapsibleIllustAdapter.kt`
- `app/src/main/res/layout/recy_illust_detail.xml`

## 提交

- `9e0c4b60a` feat(detail): 多 P 后续页空白容器改用 P1 宽高先验占位,ajax 缺失时压缩首帧跳