### PR TITLE
模型下载页支持「复制下载链接或导入本地模型包」，漫画翻译首次准备支持失败后导入与点击重试

### DIFF
--- a/app/src/main/java/ceui/pixiv/ui/common/ModelDownloadFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/ModelDownloadFragment.kt
@@ -99,6 +99,22 @@ abstract class ModelDownloadFragment : BaseLazyFragment<FragmentRembgModelDownlo
         baseBind.btnImport.visibility = android.view.View.GONE
     }
 
+    /** 导入本地模型包：复用下载页的转圈动画，导入中隐藏所有操作入口，避免重复触发。 */
+    private fun showImportingState() {
+        baseBind.progressArea.visibility = android.view.View.VISIBLE
+        baseBind.progressRing.isIndeterminate = true
+        baseBind.progressPercent.text = "0%"
+        baseBind.progressSizeText.visibility = android.view.View.VISIBLE
+        baseBind.progressSizeText.text = getString(
+            R.string.string_rembg_model_download_size, "0 MB", model.sizeLabel
+        )
+        baseBind.statusText.visibility = android.view.View.VISIBLE
+        baseBind.statusText.text = getString(R.string.model_download_importing)
+        baseBind.btnPrimary.visibility = android.view.View.GONE
+        baseBind.btnSecondary.visibility = android.view.View.GONE
+        baseBind.btnImport.visibility = android.view.View.GONE
+    }
+
     private fun showDoneState() {
         baseBind.progressArea.visibility = android.view.View.VISIBLE
         baseBind.progressRing.isIndeterminate = false
@@ -256,13 +272,48 @@ abstract class ModelDownloadFragment : BaseLazyFragment<FragmentRembgModelDownlo
     }
 
     private fun showCopyOrImportDialog() {
-        importController = ModelImportController(this, importPicker, getManager(), model) { success ->
+        importController = ModelImportController(
+            this,
+            importPicker,
+            getManager(),
+            model,
+            onImportStarted = {
+                if (isAdded && view != null) showImportingState()
+            },
+            onProgress = { bytesRead, totalBytes ->
+                if (!isAdded || view == null) return@ModelImportController
+                view?.post {
+                    if (!isAdded || view == null) return@post
+                    val now = System.currentTimeMillis()
+                    if (now - lastUIUpdateTime < 300) return@post
+                    lastUIUpdateTime = now
+                    val percent = if (totalBytes > 0) {
+                        (bytesRead * 100 / totalBytes).toInt().coerceIn(0, 100)
+                    } else {
+                        0
+                    }
+                    baseBind.progressRing.isIndeterminate = totalBytes <= 0
+                    baseBind.progressRing.setProgressCompat(percent, true)
+                    baseBind.progressPercent.text = "$percent%"
+                    val readMB = String.format("%.1f MB", bytesRead / 1_048_576.0)
+                    val totalMB = if (totalBytes > 0) {
+                        String.format("%.1f MB", totalBytes / 1_048_576.0)
+                    } else {
+                        model.sizeLabel
+                    }
+                    baseBind.progressSizeText.text = getString(
+                        R.string.string_rembg_model_download_size, readMB, totalMB
+                    )
+                }
+            },
+        ) { success ->
             if (!isAdded || view == null) return@ModelImportController
             if (success) {
                 Common.showToast(getString(R.string.model_download_import_success))
                 showDoneState()
             } else {
                 Common.showToast(getString(R.string.model_download_import_invalid))
+                showInitState()
             }
         }
         importController?.showCopyOrImportDialog()

--- a/app/src/main/java/ceui/pixiv/ui/common/ModelDownloadFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/ModelDownloadFragment.kt
@@ -277,33 +277,36 @@ abstract class ModelDownloadFragment : BaseLazyFragment<FragmentRembgModelDownlo
             importPicker,
             getManager(),
             model,
+            canStart = { downloadJob?.isActive != true },
             onImportStarted = {
                 if (isAdded && view != null) showImportingState()
             },
             onProgress = { bytesRead, totalBytes ->
-                if (!isAdded || view == null) return@ModelImportController
-                view?.post {
-                    if (!isAdded || view == null) return@post
-                    val now = System.currentTimeMillis()
-                    if (now - lastUIUpdateTime < 300) return@post
+                // 回调在 IO 线程逐 chunk 触发,和下载路径一样先节流再 post,
+                // 否则本地拷贝速度下每 8KB 一个 Runnable 会灌满主线程消息队列
+                val now = System.currentTimeMillis()
+                if (now - lastUIUpdateTime >= 300) {
                     lastUIUpdateTime = now
-                    val percent = if (totalBytes > 0) {
-                        (bytesRead * 100 / totalBytes).toInt().coerceIn(0, 100)
-                    } else {
-                        0
+                    view?.post {
+                        if (!isAdded || view == null) return@post
+                        if (totalBytes > 0) {
+                            val percent = (bytesRead * 100 / totalBytes).toInt().coerceIn(0, 100)
+                            baseBind.progressRing.isIndeterminate = false
+                            baseBind.progressRing.setProgressCompat(percent, true)
+                            baseBind.progressPercent.text = "$percent%"
+                        }
+                        // 拿不到总大小时保持转圈,不碰 setProgressCompat ——
+                        // material 会把 indeterminate 指示器就地切回 determinate
+                        val readMB = String.format("%.1f MB", bytesRead / 1_048_576.0)
+                        val totalMB = if (totalBytes > 0) {
+                            String.format("%.1f MB", totalBytes / 1_048_576.0)
+                        } else {
+                            model.sizeLabel
+                        }
+                        baseBind.progressSizeText.text = getString(
+                            R.string.string_rembg_model_download_size, readMB, totalMB
+                        )
                     }
-                    baseBind.progressRing.isIndeterminate = totalBytes <= 0
-                    baseBind.progressRing.setProgressCompat(percent, true)
-                    baseBind.progressPercent.text = "$percent%"
-                    val readMB = String.format("%.1f MB", bytesRead / 1_048_576.0)
-                    val totalMB = if (totalBytes > 0) {
-                        String.format("%.1f MB", totalBytes / 1_048_576.0)
-                    } else {
-                        model.sizeLabel
-                    }
-                    baseBind.progressSizeText.text = getString(
-                        R.string.string_rembg_model_download_size, readMB, totalMB
-                    )
                 }
             },
         ) { success ->

--- a/app/src/main/java/ceui/pixiv/ui/common/ModelDownloadFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/ModelDownloadFragment.kt
@@ -1,11 +1,13 @@
 package ceui.pixiv.ui.common
 
 import androidx.annotation.StringRes
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import ceui.lisa.R
 import ceui.lisa.databinding.FragmentRembgModelDownloadBinding
 import ceui.lisa.fragments.BaseLazyFragment
+import ceui.lisa.utils.Common
 import ceui.pixiv.utils.setOnClick
 import com.qmuiteam.qmui.widget.dialog.QMUIDialog
 import com.qmuiteam.qmui.widget.dialog.QMUIDialogAction
@@ -28,6 +30,12 @@ abstract class ModelDownloadFragment : BaseLazyFragment<FragmentRembgModelDownlo
     @StringRes protected abstract fun doneTextRes(): Int
 
     private val model: DownloadableModel by lazy { resolveModel() }
+    private var importController: ModelImportController? = null
+    private val importPicker = registerForActivityResult(
+        ActivityResultContracts.OpenDocument(),
+    ) { uri ->
+        importController?.handlePickedUri(uri)
+    }
 
     override fun initLayout() {
         mLayoutID = R.layout.fragment_rembg_model_download
@@ -62,6 +70,8 @@ abstract class ModelDownloadFragment : BaseLazyFragment<FragmentRembgModelDownlo
         baseBind.btnSecondary.visibility = android.view.View.GONE
 
         baseBind.btnPrimary.setOnClick { startDownload() }
+        baseBind.btnImport.visibility = android.view.View.VISIBLE
+        baseBind.btnImport.setOnClick { showCopyOrImportDialog() }
     }
 
     private fun showDownloadingState() {
@@ -86,6 +96,7 @@ abstract class ModelDownloadFragment : BaseLazyFragment<FragmentRembgModelDownlo
         baseBind.btnSecondary.text = getString(R.string.string_rembg_model_cancel)
         applyDefaultSecondaryColor()
         baseBind.btnSecondary.setOnClick { cancelDownload() }
+        baseBind.btnImport.visibility = android.view.View.GONE
     }
 
     private fun showDoneState() {
@@ -107,6 +118,7 @@ abstract class ModelDownloadFragment : BaseLazyFragment<FragmentRembgModelDownlo
             ContextCompat.getColor(requireContext(), R.color.buttonTextRed)
         )
         baseBind.btnSecondary.setOnClick { confirmDeleteModel() }
+        baseBind.btnImport.visibility = android.view.View.GONE
     }
 
     private fun applyDefaultSecondaryColor() {
@@ -154,6 +166,7 @@ abstract class ModelDownloadFragment : BaseLazyFragment<FragmentRembgModelDownlo
         baseBind.btnSecondary.text = getString(R.string.string_cancel)
         applyDefaultSecondaryColor()
         baseBind.btnSecondary.setOnClick { activity?.finish() }
+        baseBind.btnImport.visibility = android.view.View.GONE
     }
 
     private fun startDownload() {
@@ -240,5 +253,18 @@ abstract class ModelDownloadFragment : BaseLazyFragment<FragmentRembgModelDownlo
         downloadJob = null
         getManager().deleteModel(requireContext(), model)
         showInitState()
+    }
+
+    private fun showCopyOrImportDialog() {
+        importController = ModelImportController(this, importPicker, getManager(), model) { success ->
+            if (!isAdded || view == null) return@ModelImportController
+            if (success) {
+                Common.showToast(getString(R.string.model_download_import_success))
+                showDoneState()
+            } else {
+                Common.showToast(getString(R.string.model_download_import_invalid))
+            }
+        }
+        importController?.showCopyOrImportDialog()
     }
 }

--- a/app/src/main/java/ceui/pixiv/ui/common/ModelDownloadManager.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/ModelDownloadManager.kt
@@ -1,6 +1,7 @@
 package ceui.pixiv.ui.common
 
 import android.content.Context
+import android.net.Uri
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
@@ -9,6 +10,7 @@ import okhttp3.Request
 import timber.log.Timber
 import java.io.File
 import java.io.FileOutputStream
+import java.io.RandomAccessFile
 import java.util.concurrent.TimeUnit
 import java.util.zip.ZipInputStream
 import kotlin.coroutines.coroutineContext
@@ -69,39 +71,8 @@ abstract class ModelDownloadManager {
                 }
             }
 
-            // 解压到 staging 目录,成功后整目录换入 —— 解压中途进程被杀不会留下
-            // 「文件 exists 但内容残缺」的半成品让 isModelReady 误判 ready。
-            val dir = modelDir(context, model)
-            val staging = File(dir.parentFile, dir.name + ".staging")
-            staging.deleteRecursively()
-            staging.mkdirs()
-            ZipInputStream(tempZip.inputStream()).use { zip ->
-                var entry = zip.nextEntry
-                while (entry != null) {
-                    if (!entry.isDirectory) {
-                        val file = File(staging, entry.name)
-                        // zip-slip 防护:条目名可能带 ../,canonical 路径必须落在目标目录内
-                        if (!file.canonicalPath.startsWith(staging.canonicalPath + File.separator)) {
-                            throw SecurityException("zip entry escapes target dir: ${entry.name}")
-                        }
-                        file.parentFile?.mkdirs()
-                        FileOutputStream(file).use { output ->
-                            zip.copyTo(output)
-                        }
-                    }
-                    zip.closeEntry()
-                    entry = zip.nextEntry
-                }
-            }
-            dir.deleteRecursively()
-            if (!staging.renameTo(dir)) {
-                staging.deleteRecursively()
-                throw IllegalStateException("rename ${staging.name} → ${dir.name} failed")
-            }
-
-            val ready = model.modelFiles.all { File(dir, it).exists() }
-            Timber.d("$logTag ${model.assetDir} download complete, ready=$ready")
-            ready
+            // 下载与导入共用同一套校验安装流程，保证两边行为一致
+            installZip(context, model, tempZip)
         } catch (e: Exception) {
             Timber.e(e, "$logTag download error: ${model.assetDir}")
             false
@@ -110,8 +81,107 @@ abstract class ModelDownloadManager {
         }
     }
 
+    /**
+     * 导入本地已下载好的模型包（zip）。
+     *
+     * 流式拷贝到 cache 目录后复用 [installZip]：staging 解压 → 校验 modelFiles 全部存在 →
+     * 整目录换入。校验规则与现网下载逻辑一致：必需文件齐全即视为正确，多余文件不判错；
+     * 解压中途失败不会留下「文件 exists 但内容残缺」的半成品让 isModelReady 误判 ready。
+     */
+    suspend fun importModel(
+        context: Context,
+        model: DownloadableModel,
+        uri: Uri,
+    ): Boolean = withContext(Dispatchers.IO) {
+        val tempZip = File(context.cacheDir, "model_import_${model.assetDir}.zip")
+        try {
+            val input = context.contentResolver.openInputStream(uri) ?: return@withContext false
+            var importedBytes = 0L
+            input.use { stream ->
+                FileOutputStream(tempZip).use { output ->
+                    val buffer = ByteArray(8192)
+                    var n: Int
+                    while (stream.read(buffer).also { n = it } != -1) {
+                        importedBytes += n
+                        if (importedBytes > MAX_IMPORT_FILE_BYTES) {
+                            throw IllegalArgumentException("model zip too large: $importedBytes bytes")
+                        }
+                        output.write(buffer, 0, n)
+                    }
+                }
+            }
+            if (importedBytes == 0L) {
+                Timber.w("$logTag ${model.assetDir} import failed: empty file")
+                return@withContext false
+            }
+            installZip(context, model, tempZip)
+        } catch (e: Exception) {
+            Timber.e(e, "$logTag import error: ${model.assetDir}")
+            false
+        } finally {
+            tempZip.delete()
+        }
+    }
+
+    /**
+     * 校验并安装模型 zip（下载/导入共用）。
+     * 先快速校验 zip 魔数，再解压到 staging 目录，成功后整目录换入。
+     */
+    private fun installZip(context: Context, model: DownloadableModel, tempZip: File): Boolean {
+        val magic = ByteArray(4)
+        if (tempZip.length() < 4) {
+            Timber.w("$logTag ${model.assetDir} too small to be a zip")
+            return false
+        }
+        RandomAccessFile(tempZip, "r").use { raf ->
+            raf.readFully(magic)
+        }
+        if (!magic.contentEquals(ZIP_MAGIC)) {
+            Timber.w("$logTag ${model.assetDir} not a valid zip")
+            return false
+        }
+
+        val dir = modelDir(context, model)
+        val staging = File(dir.parentFile, dir.name + ".staging")
+        staging.deleteRecursively()
+        staging.mkdirs()
+        ZipInputStream(tempZip.inputStream()).use { zip ->
+            var entry = zip.nextEntry
+            while (entry != null) {
+                if (!entry.isDirectory) {
+                    val file = File(staging, entry.name)
+                    // zip-slip 防护：条目名可能带 ../，canonical 路径必须落在目标目录内
+                    if (!file.canonicalPath.startsWith(staging.canonicalPath + File.separator)) {
+                        throw SecurityException("zip entry escapes target dir: ${entry.name}")
+                    }
+                    file.parentFile?.mkdirs()
+                    FileOutputStream(file).use { output ->
+                        zip.copyTo(output)
+                    }
+                }
+                zip.closeEntry()
+                entry = zip.nextEntry
+            }
+        }
+        dir.deleteRecursively()
+        if (!staging.renameTo(dir)) {
+            staging.deleteRecursively()
+            throw IllegalStateException("rename ${staging.name} -> ${dir.name} failed")
+        }
+
+        val ready = model.modelFiles.all { File(dir, it).exists() }
+        Timber.d("$logTag ${model.assetDir} install complete, ready=$ready")
+        return ready
+    }
+
     fun deleteModel(context: Context, model: DownloadableModel) {
         val dir = modelDir(context, model)
         if (dir.exists()) dir.deleteRecursively()
+    }
+
+    companion object {
+        private val ZIP_MAGIC = byteArrayOf(0x50, 0x4B, 0x03, 0x04)
+        // 模型包最大不超过 100MB，512MB 上限只用于拦截误选超大文件，避免撑爆 cache
+        private const val MAX_IMPORT_FILE_BYTES = 512L * 1024 * 1024
     }
 }

--- a/app/src/main/java/ceui/pixiv/ui/common/ModelDownloadManager.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/ModelDownloadManager.kt
@@ -3,6 +3,7 @@ package ceui.pixiv.ui.common
 import android.content.Context
 import android.net.Uri
 import android.provider.OpenableColumns
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
@@ -74,6 +75,8 @@ abstract class ModelDownloadManager {
 
             // 下载与导入共用同一套校验安装流程，保证两边行为一致
             installZip(context, model, tempZip)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Timber.e(e, "$logTag download error: ${model.assetDir}")
             false
@@ -120,6 +123,8 @@ abstract class ModelDownloadManager {
                 return@withContext false
             }
             installZip(context, model, tempZip)
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Timber.e(e, "$logTag import error: ${model.assetDir}")
             false

--- a/app/src/main/java/ceui/pixiv/ui/common/ModelDownloadManager.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/ModelDownloadManager.kt
@@ -2,6 +2,7 @@ package ceui.pixiv.ui.common
 
 import android.content.Context
 import android.net.Uri
+import android.provider.OpenableColumns
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
@@ -92,21 +93,25 @@ abstract class ModelDownloadManager {
         context: Context,
         model: DownloadableModel,
         uri: Uri,
+        onProgress: (bytesRead: Long, totalBytes: Long) -> Unit = { _, _ -> },
     ): Boolean = withContext(Dispatchers.IO) {
         val tempZip = File(context.cacheDir, "model_import_${model.assetDir}.zip")
         try {
             val input = context.contentResolver.openInputStream(uri) ?: return@withContext false
             var importedBytes = 0L
+            val totalBytes = querySize(context, uri)
             input.use { stream ->
                 FileOutputStream(tempZip).use { output ->
                     val buffer = ByteArray(8192)
                     var n: Int
                     while (stream.read(buffer).also { n = it } != -1) {
+                        coroutineContext.ensureActive()
                         importedBytes += n
                         if (importedBytes > MAX_IMPORT_FILE_BYTES) {
                             throw IllegalArgumentException("model zip too large: $importedBytes bytes")
                         }
                         output.write(buffer, 0, n)
+                        onProgress(importedBytes, totalBytes)
                     }
                 }
             }
@@ -122,6 +127,16 @@ abstract class ModelDownloadManager {
             tempZip.delete()
         }
     }
+
+    /** 从 SAF URI 读取文件大小，拿不到（部分 provider 不支持）返回 -1，UI 走不确定进度。 */
+    private fun querySize(context: Context, uri: Uri): Long = runCatching {
+        context.contentResolver.query(uri, arrayOf(OpenableColumns.SIZE), null, null, null)
+            ?.use { cursor ->
+                if (!cursor.moveToFirst()) return@use -1L
+                val index = cursor.getColumnIndex(OpenableColumns.SIZE)
+                if (index >= 0 && !cursor.isNull(index)) cursor.getLong(index) else -1L
+            } ?: -1L
+    }.getOrDefault(-1L)
 
     /**
      * 校验并安装模型 zip（下载/导入共用）。

--- a/app/src/main/java/ceui/pixiv/ui/common/ModelImportController.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/ModelImportController.kt
@@ -31,8 +31,12 @@ class ModelImportController(
     private val picker: ActivityResultLauncher<Array<String>>,
     private val manager: ModelDownloadManager,
     private val model: DownloadableModel,
+    private val onImportStarted: () -> Unit = {},
+    private val onProgress: (bytesRead: Long, totalBytes: Long) -> Unit = { _, _ -> },
     private val onImported: (Boolean) -> Unit,
 ) {
+    /** 防重入：导入进行中再次选文件直接忽略，避免并发写同一个临时 zip / staging 目录。 */
+    private var importInFlight = false
 
     fun showCopyOrImportDialog() {
         val ctx = fragment.requireContext()
@@ -74,13 +78,16 @@ class ModelImportController(
 
     /** 文件选择回调统一入口：拿到 URI 后在 IO 线程导入，校验结果回抛给 [onImported]。 */
     fun handlePickedUri(uri: Uri?) {
-        if (uri == null) return
+        if (uri == null || importInFlight) return
         val ctx = fragment.context ?: return
         if (!fragment.isAdded || fragment.view == null) return
+        importInFlight = true
+        onImportStarted()
         fragment.viewLifecycleOwner.lifecycleScope.launch {
             val success = withContext(Dispatchers.IO) {
-                manager.importModel(ctx, model, uri)
+                manager.importModel(ctx, model, uri, onProgress)
             }
+            importInFlight = false
             onImported(success)
         }
     }

--- a/app/src/main/java/ceui/pixiv/ui/common/ModelImportController.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/ModelImportController.kt
@@ -1,0 +1,99 @@
+package ceui.pixiv.ui.common
+
+import android.content.ActivityNotFoundException
+import android.content.ClipData
+import android.content.Context
+import android.net.Uri
+import androidx.activity.result.ActivityResultLauncher
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import ceui.lisa.R
+import ceui.lisa.utils.ClipBoardUtils
+import ceui.lisa.utils.Common
+import com.qmuiteam.qmui.skin.QMUISkinManager
+import com.qmuiteam.qmui.widget.dialog.QMUIDialog
+import com.qmuiteam.qmui.widget.dialog.QMUIDialogAction
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+/**
+ * 「复制链接或导入已下载好的文件」统一控制器，供模型下载页与漫画翻译首次准备 sheet 共用。
+ *
+ * 文件选择姿势对齐项目还原/导入代码（FragmentHistoryTabs / SynonymDictFragment）：
+ * 宿主 Fragment 用 registerForActivityResult(ActivityResultContracts.OpenDocument) 注册 launcher，
+ * 通过 MIME 类型数组设置 zip 相关文件类型；选中后在 IO 线程读取文件，
+ * 交给 [ModelDownloadManager.importModel] 做与现网下载一致的校验安装。
+ */
+class ModelImportController(
+    private val fragment: Fragment,
+    private val picker: ActivityResultLauncher<Array<String>>,
+    private val manager: ModelDownloadManager,
+    private val model: DownloadableModel,
+    private val onImported: (Boolean) -> Unit,
+) {
+
+    fun showCopyOrImportDialog() {
+        val ctx = fragment.requireContext()
+        val builder = QMUIDialog.MessageDialogBuilder(ctx)
+            .setTitle(R.string.model_download_dialog_title)
+            .setSkinManager(QMUISkinManager.defaultInstance(ctx))
+            .setMessage(fragment.getString(R.string.model_download_dialog_message))
+
+        if (model.downloadUrl != null) {
+            builder.addAction(
+                0,
+                fragment.getString(R.string.model_download_copy_link),
+                QMUIDialogAction.ACTION_PROP_POSITIVE,
+            ) { dialog, _ ->
+                dialog.dismiss()
+                copyLink(ctx, model)
+            }
+        }
+        builder.addAction(
+            0,
+            fragment.getString(R.string.model_download_import_file),
+            QMUIDialogAction.ACTION_PROP_POSITIVE,
+        ) { dialog, _ ->
+            dialog.dismiss()
+            launchPicker()
+        }
+        builder.show()
+    }
+
+    /** 系统缺少可用的文件选择器（DocumentsUI/文件管理器）时启动会抛异常，兜底弹 toast 而不是崩页面。 */
+    private fun launchPicker() {
+        try {
+            picker.launch(ZIP_MIME_TYPES)
+        } catch (e: ActivityNotFoundException) {
+            Timber.e(e, "model import: no activity for document picker")
+            Common.showToast(fragment.getString(R.string.model_download_picker_unavailable))
+        }
+    }
+
+    /** 文件选择回调统一入口：拿到 URI 后在 IO 线程导入，校验结果回抛给 [onImported]。 */
+    fun handlePickedUri(uri: Uri?) {
+        if (uri == null) return
+        val ctx = fragment.context ?: return
+        if (!fragment.isAdded || fragment.view == null) return
+        fragment.viewLifecycleOwner.lifecycleScope.launch {
+            val success = withContext(Dispatchers.IO) {
+                manager.importModel(ctx, model, uri)
+            }
+            onImported(success)
+        }
+    }
+
+    private fun copyLink(ctx: Context, model: DownloadableModel) {
+        val url = model.downloadUrl ?: return
+        if (ClipBoardUtils.setPrimaryClip(ctx, ClipData.newPlainText("model-download-link", url))) {
+            Common.showToast(ctx.getString(R.string.msg_link_copied))
+        }
+    }
+
+    companion object {
+        private val ZIP_MIME_TYPES =
+            arrayOf("application/zip", "application/x-zip-compressed", "application/octet-stream")
+    }
+}

--- a/app/src/main/java/ceui/pixiv/ui/common/ModelImportController.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/ModelImportController.kt
@@ -31,6 +31,7 @@ class ModelImportController(
     private val picker: ActivityResultLauncher<Array<String>>,
     private val manager: ModelDownloadManager,
     private val model: DownloadableModel,
+    private val canStart: () -> Boolean = { true },
     private val onImportStarted: () -> Unit = {},
     private val onProgress: (bytesRead: Long, totalBytes: Long) -> Unit = { _, _ -> },
     private val onImported: (Boolean) -> Unit,
@@ -78,7 +79,9 @@ class ModelImportController(
 
     /** 文件选择回调统一入口：拿到 URI 后在 IO 线程导入，校验结果回抛给 [onImported]。 */
     fun handlePickedUri(uri: Uri?) {
-        if (uri == null || importInFlight) return
+        // canStart 兜的是选择器打开期间宿主状态变化的窗口（分屏下用户可以边选文件边点开始下载），
+        // 导入和下载并发跑 installZip 会撞同一个 staging 目录
+        if (uri == null || importInFlight || !canStart()) return
         val ctx = fragment.context ?: return
         if (!fragment.isAdded || fragment.view == null) return
         importInFlight = true

--- a/app/src/main/java/ceui/pixiv/ui/translate/MangaTranslatePrepSheet.kt
+++ b/app/src/main/java/ceui/pixiv/ui/translate/MangaTranslatePrepSheet.kt
@@ -5,10 +5,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.lifecycle.lifecycleScope
 import ceui.lisa.R
 import ceui.lisa.databinding.DialogMangaTranslatePrepBinding
+import ceui.lisa.utils.Common
 import ceui.pixiv.ui.common.DownloadableModel
+import ceui.pixiv.ui.common.ModelImportController
 import ceui.pixiv.ui.common.ModelDownloadManager
 import ceui.pixiv.ui.search.v3.V3BottomSheetBase
 import ceui.pixiv.utils.setOnClick
@@ -42,6 +45,12 @@ class MangaTranslatePrepSheet : V3BottomSheetBase() {
 
     private val ctdModel = ComicTextDetectorModel.CTD_BASE
     private val ocrModel = MangaOcrModel.MANGA_OCR_BASE
+    private var importController: ModelImportController? = null
+    private val importPicker = registerForActivityResult(
+        ActivityResultContracts.OpenDocument(),
+    ) { uri ->
+        importController?.handlePickedUri(uri)
+    }
 
     /** Activity 在 show 前注入:两模型都就绪后 sheet 自动 dismiss 并触发这条 callback。 */
     fun setOnReady(callback: () -> Unit) {
@@ -83,6 +92,31 @@ class MangaTranslatePrepSheet : V3BottomSheetBase() {
 
         binding.btnPrimary.setOnClick { onPrimaryClick(ctx) }
         binding.btnSecondary.setOnClick { dismissAllowingStateLoss() }
+        binding.ctdImportLink.setOnClick { showCopyOrImportDialog(isCtd = true) }
+        binding.ocrImportLink.setOnClick { showCopyOrImportDialog(isCtd = false) }
+    }
+
+    /** 复制链接 / 导入已下载好的文件：CTD 与 OCR 各自独立入口，复用同一个对话框与导入流程。 */
+    private fun showCopyOrImportDialog(isCtd: Boolean) {
+        if (_binding == null) return
+        val ctx = requireContext()
+        val manager = if (isCtd) ComicTextDetectorModelManager else MangaOcrModelManager
+        val model = if (isCtd) ctdModel else ocrModel
+        importController = ModelImportController(this, importPicker, manager, model) { success ->
+            if (_binding == null) return@ModelImportController
+            if (success) {
+                renderRowState(ctx, isCtd, RowState.Ready)
+                binding.btnPrimary.text = if (bothReady(ctx)) {
+                    getString(R.string.manga_translate_prep_cta_ready)
+                } else {
+                    getString(R.string.manga_translate_prep_cta)
+                }
+                Common.showToast(ctx.getString(R.string.model_download_import_success))
+            } else {
+                Common.showToast(ctx.getString(R.string.model_download_import_invalid))
+            }
+        }
+        importController?.showCopyOrImportDialog()
     }
 
     /** 根据当前模型 ready 状态决定初始 CTA 文案。两个都 ready 直接亮「开始翻译」。 */
@@ -206,18 +240,21 @@ class MangaTranslatePrepSheet : V3BottomSheetBase() {
         val progress: LinearProgressIndicator
         val statusIcon: ImageView
         val spinner: CircularProgressIndicator
+        val importLink: TextView
         val descRes: Int
         if (isCtd) {
             statusText = binding.ctdStatus
             progress = binding.ctdProgress
             statusIcon = binding.ctdStatusIcon
             spinner = binding.ctdStatusSpinner
+            importLink = binding.ctdImportLink
             descRes = R.string.manga_translate_prep_model_ctd_desc
         } else {
             statusText = binding.ocrStatus
             progress = binding.ocrProgress
             statusIcon = binding.ocrStatusIcon
             spinner = binding.ocrStatusSpinner
+            importLink = binding.ocrImportLink
             descRes = R.string.manga_translate_prep_model_ocr_desc
         }
 
@@ -230,6 +267,7 @@ class MangaTranslatePrepSheet : V3BottomSheetBase() {
                 // 待下载状态不画右侧 icon —— 之前那个下载箭头会让人误以为是「点这里下载这一个」,
                 // 状态文案左侧已经说了「待下载」,右边留空,只有下载中 / 完成 / 失败才挂图标。
                 statusIcon.visibility = View.GONE
+                importLink.visibility = View.VISIBLE
             }
             is RowState.Downloading -> {
                 val readMB = String.format("%.1f MB", state.bytesRead / 1_048_576.0)
@@ -253,6 +291,7 @@ class MangaTranslatePrepSheet : V3BottomSheetBase() {
                 }
                 spinner.visibility = View.VISIBLE
                 statusIcon.visibility = View.GONE
+                importLink.visibility = View.GONE
             }
             RowState.Ready -> {
                 statusText.text = getString(R.string.manga_translate_prep_status_ready)
@@ -262,6 +301,7 @@ class MangaTranslatePrepSheet : V3BottomSheetBase() {
                 statusIcon.visibility = View.VISIBLE
                 statusIcon.setImageResource(R.drawable.ic_file_download_done_24dp)
                 statusIcon.imageTintList = android.content.res.ColorStateList.valueOf(palette.primary)
+                importLink.visibility = View.GONE
             }
             RowState.Failed -> {
                 statusText.text = getString(R.string.manga_translate_prep_status_failed)
@@ -273,6 +313,7 @@ class MangaTranslatePrepSheet : V3BottomSheetBase() {
                 statusIcon.imageTintList = android.content.res.ColorStateList.valueOf(
                     ctx.getColor(R.color.buttonTextRed),
                 )
+                importLink.visibility = View.VISIBLE
             }
         }
     }

--- a/app/src/main/java/ceui/pixiv/ui/translate/MangaTranslatePrepSheet.kt
+++ b/app/src/main/java/ceui/pixiv/ui/translate/MangaTranslatePrepSheet.kt
@@ -42,6 +42,7 @@ class MangaTranslatePrepSheet : V3BottomSheetBase() {
 
     private var onReady: (() -> Unit)? = null
     private var downloadJob: Job? = null
+    private var importing = false
 
     private val ctdModel = ComicTextDetectorModel.CTD_BASE
     private val ocrModel = MangaOcrModel.MANGA_OCR_BASE
@@ -102,8 +103,23 @@ class MangaTranslatePrepSheet : V3BottomSheetBase() {
         val ctx = requireContext()
         val manager = if (isCtd) ComicTextDetectorModelManager else MangaOcrModelManager
         val model = if (isCtd) ctdModel else ocrModel
-        importController = ModelImportController(this, importPicker, manager, model) { success ->
+        importController = ModelImportController(
+            this,
+            importPicker,
+            manager,
+            model,
+            onImportStarted = {
+                if (_binding == null) return@ModelImportController
+                importing = true
+                binding.btnPrimary.isClickable = false
+                binding.btnPrimary.alpha = 0.55F
+                renderRowState(ctx, isCtd, RowState.Importing)
+            },
+        ) { success ->
             if (_binding == null) return@ModelImportController
+            importing = false
+            binding.btnPrimary.isClickable = true
+            binding.btnPrimary.alpha = 1F
             if (success) {
                 renderRowState(ctx, isCtd, RowState.Ready)
                 binding.btnPrimary.text = if (bothReady(ctx)) {
@@ -113,6 +129,8 @@ class MangaTranslatePrepSheet : V3BottomSheetBase() {
                 }
                 Common.showToast(ctx.getString(R.string.model_download_import_success))
             } else {
+                renderRowState(ctx, isCtd, RowState.Failed)
+                binding.btnPrimary.text = getString(R.string.manga_translate_prep_cta_retry)
                 Common.showToast(ctx.getString(R.string.model_download_import_invalid))
             }
         }
@@ -142,7 +160,7 @@ class MangaTranslatePrepSheet : V3BottomSheetBase() {
      * - 至少一个缺 → 顺序下完缺的那个 / 那几个,完成后 fire onReady + dismiss
      */
     private fun onPrimaryClick(ctx: Context) {
-        if (downloadJob?.isActive == true) return
+        if (downloadJob?.isActive == true || importing) return
 
         if (bothReady(ctx)) {
             fireReadyAndDismiss()
@@ -223,6 +241,7 @@ class MangaTranslatePrepSheet : V3BottomSheetBase() {
     private sealed class RowState {
         object Pending : RowState()
         data class Downloading(val bytesRead: Long, val totalBytes: Long) : RowState()
+        object Importing : RowState()
         object Ready : RowState()
         object Failed : RowState()
     }
@@ -293,6 +312,15 @@ class MangaTranslatePrepSheet : V3BottomSheetBase() {
                 } else {
                     progress.isIndeterminate = true
                 }
+                spinner.visibility = View.VISIBLE
+                statusIcon.visibility = View.GONE
+                importLink.visibility = View.GONE
+            }
+            RowState.Importing -> {
+                statusText.text = getString(R.string.manga_translate_prep_status_importing)
+                statusText.setTextColor(ctx.getColor(R.color.v3_text_2))
+                progress.visibility = View.VISIBLE
+                progress.isIndeterminate = true
                 spinner.visibility = View.VISIBLE
                 statusIcon.visibility = View.GONE
                 importLink.visibility = View.GONE

--- a/app/src/main/java/ceui/pixiv/ui/translate/MangaTranslatePrepSheet.kt
+++ b/app/src/main/java/ceui/pixiv/ui/translate/MangaTranslatePrepSheet.kt
@@ -258,6 +258,10 @@ class MangaTranslatePrepSheet : V3BottomSheetBase() {
             descRes = R.string.manga_translate_prep_model_ocr_desc
         }
 
+        // 只有失败态才把 status 文案做成可点击的重试入口，其他状态一律清掉监听
+        statusText.isClickable = false
+        statusText.setOnClickListener(null)
+
         when (state) {
             RowState.Pending -> {
                 statusText.text = getString(R.string.manga_translate_prep_status_pending, getString(descRes))
@@ -314,6 +318,8 @@ class MangaTranslatePrepSheet : V3BottomSheetBase() {
                     ctx.getColor(R.color.buttonTextRed),
                 )
                 importLink.visibility = View.VISIBLE
+                statusText.isClickable = true
+                statusText.setOnClickListener { onPrimaryClick(ctx) }
             }
         }
     }

--- a/app/src/main/java/ceui/pixiv/ui/translate/MangaTranslatePrepSheet.kt
+++ b/app/src/main/java/ceui/pixiv/ui/translate/MangaTranslatePrepSheet.kt
@@ -100,6 +100,9 @@ class MangaTranslatePrepSheet : V3BottomSheetBase() {
     /** 复制链接 / 导入已下载好的文件：CTD 与 OCR 各自独立入口，复用同一个对话框与导入流程。 */
     private fun showCopyOrImportDialog(isCtd: Boolean) {
         if (_binding == null) return
+        // 下载或另一行导入进行中不再开新导入：两条路径并发跑 installZip 会撞同一个
+        // staging 目录,可能换入「文件齐全但内容错乱」的模型目录
+        if (importing || downloadJob?.isActive == true) return
         val ctx = requireContext()
         val manager = if (isCtd) ComicTextDetectorModelManager else MangaOcrModelManager
         val model = if (isCtd) ctdModel else ocrModel
@@ -108,6 +111,7 @@ class MangaTranslatePrepSheet : V3BottomSheetBase() {
             importPicker,
             manager,
             model,
+            canStart = { !importing && downloadJob?.isActive != true },
             onImportStarted = {
                 if (_binding == null) return@ModelImportController
                 importing = true
@@ -277,9 +281,10 @@ class MangaTranslatePrepSheet : V3BottomSheetBase() {
             descRes = R.string.manga_translate_prep_model_ocr_desc
         }
 
-        // 只有失败态才把 status 文案做成可点击的重试入口，其他状态一律清掉监听
-        statusText.isClickable = false
+        // 只有失败态才把 status 文案做成可点击的重试入口，其他状态一律清掉监听。
+        // 顺序不能反:setOnClickListener(null) 会把 clickable 重新置回 true
         statusText.setOnClickListener(null)
+        statusText.isClickable = false
 
         when (state) {
             RowState.Pending -> {

--- a/app/src/main/res/layout/dialog_manga_translate_prep.xml
+++ b/app/src/main/res/layout/dialog_manga_translate_prep.xml
@@ -134,6 +134,19 @@
                         android:textColor="@color/v3_text_3"
                         android:textSize="11sp"
                         tools:text="待下载 · 气泡 / 文本框检测" />
+
+                    <TextView
+                        android:id="@+id/ctd_import_link"
+                        style="@style/textMontserratMedium"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="2dp"
+                        android:padding="6dp"
+                        android:stateListAnimator="@animator/button_press_alpha"
+                        android:text="@string/model_download_copy_or_import"
+                        android:textColor="?attr/colorPrimary"
+                        android:textSize="12sp"
+                        tools:text="复制链接或导入已下载好的文件" />
                 </LinearLayout>
 
                 <!-- 状态指示器:待下载留空 + 下载中转圈 + 完成对勾 + 失败感叹号。
@@ -248,6 +261,19 @@
                         android:textColor="@color/v3_text_3"
                         android:textSize="11sp"
                         tools:text="待下载 · 日文识别" />
+
+                    <TextView
+                        android:id="@+id/ocr_import_link"
+                        style="@style/textMontserratMedium"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="2dp"
+                        android:padding="6dp"
+                        android:stateListAnimator="@animator/button_press_alpha"
+                        android:text="@string/model_download_copy_or_import"
+                        android:textColor="?attr/colorPrimary"
+                        android:textSize="12sp"
+                        tools:text="复制链接或导入已下载好的文件" />
                 </LinearLayout>
 
                 <FrameLayout

--- a/app/src/main/res/layout/dialog_manga_translate_prep.xml
+++ b/app/src/main/res/layout/dialog_manga_translate_prep.xml
@@ -141,12 +141,12 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="2dp"
-                        android:padding="6dp"
+                        android:paddingVertical="2dp"
                         android:stateListAnimator="@animator/button_press_alpha"
                         android:text="@string/model_download_copy_or_import"
                         android:textColor="?attr/colorPrimary"
-                        android:textSize="12sp"
-                        tools:text="复制链接或导入已下载好的文件" />
+                        android:textSize="11sp"
+                        tools:text="复制下载链接或者导入模型文件" />
                 </LinearLayout>
 
                 <!-- 状态指示器:待下载留空 + 下载中转圈 + 完成对勾 + 失败感叹号。
@@ -268,12 +268,12 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginTop="2dp"
-                        android:padding="6dp"
+                        android:paddingVertical="2dp"
                         android:stateListAnimator="@animator/button_press_alpha"
                         android:text="@string/model_download_copy_or_import"
                         android:textColor="?attr/colorPrimary"
-                        android:textSize="12sp"
-                        tools:text="复制链接或导入已下载好的文件" />
+                        android:textSize="11sp"
+                        tools:text="复制下载链接或者导入模型文件" />
                 </LinearLayout>
 
                 <FrameLayout

--- a/app/src/main/res/layout/fragment_rembg_model_download.xml
+++ b/app/src/main/res/layout/fragment_rembg_model_download.xml
@@ -213,6 +213,22 @@
                         tools:text="取消下载"
                         tools:visibility="visible" />
 
+                    <!-- 复制链接 / 导入已下载好的文件入口，仅初始态显示 -->
+                    <TextView
+                        android:id="@+id/btn_import"
+                        style="@style/textMontserratRegular"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="4dp"
+                        android:padding="12dp"
+                        android:stateListAnimator="@animator/button_press_alpha"
+                        android:text="@string/model_download_copy_or_import"
+                        android:textColor="@color/secondary_text_color"
+                        android:textSize="13sp"
+                        android:visibility="gone"
+                        tools:text="复制链接或导入已下载好的文件"
+                        tools:visibility="visible" />
+
                 </LinearLayout>
             </androidx.core.widget.NestedScrollView>
         </FrameLayout>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -2369,4 +2369,6 @@
     <string name="model_download_import_success">Model imported</string>
     <string name="model_download_import_invalid">Invalid file. Please make sure it is the Zip archive of this model.</string>
     <string name="model_download_picker_unavailable">Unable to open the file picker. Please check your system file manager.</string>
+    <string name="model_download_importing">Importing model…</string>
+    <string name="manga_translate_prep_status_importing">Importing model…</string>
 </resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -2361,4 +2361,12 @@
     <string name="mute_sheet_empty">This work has no tags</string>
     <string name="mute_sheet_summary">%1$d / %2$d selected</string>
     <string name="private_follow_by_default">Follow artists privately by default</string>
+    <string name="model_download_copy_or_import">Copy download link or import model file</string>
+    <string name="model_download_dialog_title">Copy link or import?</string>
+    <string name="model_download_dialog_message">Copy the download link and download it another way, then import the Zip archive of this model.</string>
+    <string name="model_download_copy_link">Copy download link</string>
+    <string name="model_download_import_file">Import model file</string>
+    <string name="model_download_import_success">Model imported</string>
+    <string name="model_download_import_invalid">Invalid file. Please make sure it is the Zip archive of this model.</string>
+    <string name="model_download_picker_unavailable">Unable to open the file picker. Please check your system file manager.</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -2361,4 +2361,12 @@
     <string name="mute_sheet_empty">この作品にはタグがありません</string>
     <string name="mute_sheet_summary">%1$d / %2$d 件選択</string>
     <string name="private_follow_by_default">デフォルトで非公開フォロー</string>
+    <string name="model_download_copy_or_import">ダウンロードリンクをコピーするか、モデルファイルをインポート</string>
+    <string name="model_download_dialog_title">リンクをコピーしますか、それともインポートしますか</string>
+    <string name="model_download_dialog_message">ダウンロードリンクをコピーして他の方法でダウンロードし、このモデルの Zip 圧縮ファイルをインポートできます</string>
+    <string name="model_download_copy_link">ダウンロードリンクをコピー</string>
+    <string name="model_download_import_file">モデルファイルをインポート</string>
+    <string name="model_download_import_success">モデルのインポートが完了しました</string>
+    <string name="model_download_import_invalid">ファイルが正しくありません。このモデルの Zip 圧縮ファイルかどうか確認してください</string>
+    <string name="model_download_picker_unavailable">ファイル選択画面を開けませんでした。システムのファイルマネージャーを確認してください</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -2369,4 +2369,6 @@
     <string name="model_download_import_success">モデルのインポートが完了しました</string>
     <string name="model_download_import_invalid">ファイルが正しくありません。このモデルの Zip 圧縮ファイルかどうか確認してください</string>
     <string name="model_download_picker_unavailable">ファイル選択画面を開けませんでした。システムのファイルマネージャーを確認してください</string>
+    <string name="model_download_importing">モデルをインポート中…</string>
+    <string name="manga_translate_prep_status_importing">モデルをインポート中…</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2369,4 +2369,6 @@
     <string name="model_download_import_success">모델 가져오기 완료</string>
     <string name="model_download_import_invalid">파일이 올바르지 않습니다. 이 모델의 Zip 압축 파일인지 확인해 주세요</string>
     <string name="model_download_picker_unavailable">파일 선택기를 열 수 없습니다. 시스템 파일 관리자를 확인해 주세요</string>
+    <string name="model_download_importing">모델 가져오는 중…</string>
+    <string name="manga_translate_prep_status_importing">모델 가져오는 중…</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2361,4 +2361,12 @@
     <string name="mute_sheet_empty">이 작품에는 태그가 없습니다</string>
     <string name="mute_sheet_summary">%1$d / %2$d 선택됨</string>
     <string name="private_follow_by_default">기본으로 비공개 팔로우</string>
+    <string name="model_download_copy_or_import">다운로드 링크 복사 또는 모델 파일 가져오기</string>
+    <string name="model_download_dialog_title">링크 복사 또는 가져오기</string>
+    <string name="model_download_dialog_message">다운로드 링크를 복사해 다른 방법으로 다운로드한 후 이 모델의 Zip 압축 파일을 가져올 수 있습니다</string>
+    <string name="model_download_copy_link">다운로드 링크 복사</string>
+    <string name="model_download_import_file">모델 파일 가져오기</string>
+    <string name="model_download_import_success">모델 가져오기 완료</string>
+    <string name="model_download_import_invalid">파일이 올바르지 않습니다. 이 모델의 Zip 압축 파일인지 확인해 주세요</string>
+    <string name="model_download_picker_unavailable">파일 선택기를 열 수 없습니다. 시스템 파일 관리자를 확인해 주세요</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2361,4 +2361,12 @@
     <string name="mute_sheet_empty">У этой работы нет тегов</string>
     <string name="mute_sheet_summary">Выбрано %1$d / %2$d</string>
     <string name="private_follow_by_default">По умолчанию подписываться приватно</string>
+    <string name="model_download_copy_or_import">Скопировать ссылку для скачивания или импортировать файл модели</string>
+    <string name="model_download_dialog_title">Скопировать ссылку или импортировать?</string>
+    <string name="model_download_dialog_message">Скопируйте ссылку для скачивания, скачайте другим способом, а затем импортируйте Zip-архив этой модели</string>
+    <string name="model_download_copy_link">Скопировать ссылку для скачивания</string>
+    <string name="model_download_import_file">Импортировать файл модели</string>
+    <string name="model_download_import_success">Модель импортирована</string>
+    <string name="model_download_import_invalid">Неверный файл. Убедитесь, что это Zip-архив этой модели</string>
+    <string name="model_download_picker_unavailable">Не удалось открыть выбор файла. Проверьте системный файловый менеджер</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2369,4 +2369,6 @@
     <string name="model_download_import_success">Модель импортирована</string>
     <string name="model_download_import_invalid">Неверный файл. Убедитесь, что это Zip-архив этой модели</string>
     <string name="model_download_picker_unavailable">Не удалось открыть выбор файла. Проверьте системный файловый менеджер</string>
+    <string name="model_download_importing">Импорт модели…</string>
+    <string name="manga_translate_prep_status_importing">Импорт модели…</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -2369,4 +2369,6 @@
     <string name="model_download_import_success">Model içe aktarıldı</string>
     <string name="model_download_import_invalid">Dosya hatalı. Lütfen bu modele ait Zip arşivi olduğundan emin olun</string>
     <string name="model_download_picker_unavailable">Dosya seçici açılamadı. Sistem dosya yöneticisini kontrol edin</string>
+    <string name="model_download_importing">Model içe aktarılıyor…</string>
+    <string name="manga_translate_prep_status_importing">Model içe aktarılıyor…</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -2361,4 +2361,12 @@
     <string name="mute_sheet_empty">Bu eserde etiket yok</string>
     <string name="mute_sheet_summary">%1$d / %2$d seçildi</string>
     <string name="private_follow_by_default">Sanatçıları varsayılan olarak gizli takip et</string>
+    <string name="model_download_copy_or_import">İndirme bağlantısını kopyala veya model dosyasını içe aktar</string>
+    <string name="model_download_dialog_title">Bağlantıyı kopyala mı, yoksa içe aktar mı?</string>
+    <string name="model_download_dialog_message">İndirme bağlantısını kopyalayıp başka bir yöntemle indirdikten sonra bu modele ait Zip arşivini içe aktarabilirsiniz</string>
+    <string name="model_download_copy_link">İndirme bağlantısını kopyala</string>
+    <string name="model_download_import_file">Model dosyasını içe aktar</string>
+    <string name="model_download_import_success">Model içe aktarıldı</string>
+    <string name="model_download_import_invalid">Dosya hatalı. Lütfen bu modele ait Zip arşivi olduğundan emin olun</string>
+    <string name="model_download_picker_unavailable">Dosya seçici açılamadı. Sistem dosya yöneticisini kontrol edin</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -2371,4 +2371,6 @@
     <string name="model_download_import_success">模型匯入成功</string>
     <string name="model_download_import_invalid">檔案錯誤，請確認是該模型的 Zip 壓縮檔</string>
     <string name="model_download_picker_unavailable">無法開啟檔案選擇器，請檢查系統檔案管理員</string>
+    <string name="model_download_importing">正在匯入模型…</string>
+    <string name="manga_translate_prep_status_importing">正在匯入模型…</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -2363,4 +2363,12 @@
     <string name="mute_sheet_empty">這個作品沒有標籤</string>
     <string name="mute_sheet_summary">已選 %1$d / %2$d</string>
     <string name="private_follow_by_default">關注作者預設私人關注</string>
+    <string name="model_download_copy_or_import">複製下載連結或匯入模型檔案</string>
+    <string name="model_download_dialog_title">複製連結還是匯入</string>
+    <string name="model_download_dialog_message">可複製下載連結用其他方式下載後，再匯入該模型的 Zip 壓縮檔</string>
+    <string name="model_download_copy_link">複製下載連結</string>
+    <string name="model_download_import_file">匯入模型檔案</string>
+    <string name="model_download_import_success">模型匯入成功</string>
+    <string name="model_download_import_invalid">檔案錯誤，請確認是該模型的 Zip 壓縮檔</string>
+    <string name="model_download_picker_unavailable">無法開啟檔案選擇器，請檢查系統檔案管理員</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2577,4 +2577,6 @@
     <string name="model_download_import_success">模型导入成功</string>
     <string name="model_download_import_invalid">文件错误，请确认是该模型的 Zip 压缩包</string>
     <string name="model_download_picker_unavailable">无法打开文件选择器，请检查系统文件管理器</string>
+    <string name="model_download_importing">正在导入模型…</string>
+    <string name="manga_translate_prep_status_importing">正在导入模型…</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2569,4 +2569,12 @@
     <string name="mute_sheet_empty">这个作品没有标签</string>
     <string name="mute_sheet_summary">已选 %1$d / %2$d</string>
     <string name="private_follow_by_default">关注作者默认私人关注</string>
+    <string name="model_download_copy_or_import">复制下载链接或者导入模型文件</string>
+    <string name="model_download_dialog_title">复制链接还是导入</string>
+    <string name="model_download_dialog_message">可复制下载链接用其他方式下载后再导入该模型的 Zip 压缩包</string>
+    <string name="model_download_copy_link">复制下载链接</string>
+    <string name="model_download_import_file">导入模型文件</string>
+    <string name="model_download_import_success">模型导入成功</string>
+    <string name="model_download_import_invalid">文件错误，请确认是该模型的 Zip 压缩包</string>
+    <string name="model_download_picker_unavailable">无法打开文件选择器，请检查系统文件管理器</string>
 </resources>


### PR DESCRIPTION
# 模型下载页支持「复制下载链接或导入本地模型包」，漫画翻译首次准备支持失败后导入与点击重试

> 分支：`patch-8-13-1`（wangwang-code fork；本地 remote 名为 `my`）
> 提交：`724e803d4` feat(ai) + `c4e6687fc` fix(translate) + `fbcd56c95` fix(translate) + `2239219a8` feat(ai)

## 背景

AI 功能（抠图 ISNet-Anime、离线翻译 Opus-MT/NLLB、Manga-OCR、文本框检测、RIFE 补帧）的模型包托管在 GitHub Releases，App 内直连下载在不佳的网络环境容易失败，且没有离线导入通道，用户只能反复重试。

本次给所有模型下载页加「复制链接或导入已下载好的文件」入口：可以复制官方下载链接，用浏览器/下载器；同时可导入下载好的 zip文件，导入校验与现网下载完全一致。

## 改动内容

### 1. 模型下载页（6 个页面共用基类，一处改动全部生效）

- 初始态新增「复制下载链接或者导入模型文件」入口，弹 QMUI 对话框：复制下载链接 / 导入模型文件（无下载链接的内置模型只显示导入，弹窗不带取消按钮，点外部关闭）；
- 复制走 `ClipBoardUtils`，成功 toast「链接已复制」；
- 导入走 SAF 文件选择器（`ACTION_OPEN_DOCUMENT`，zip 相关 MIME 过滤，`registerForActivityResult(OpenDocument)` 现代写法），选中后在 IO 线程读取；
- 系统缺少可用的文件选择器时捕获 `ActivityNotFoundException`，toast 提示而不是崩页面。

### 2. 导入校验（ModelDownloadManager）

- 抽出下载/导入共用的 `installZip`：zip 魔数校验 → staging 解压（zip-slip 防护）→ 校验 `modelFiles` 全部存在 → 整目录原子换入，中途失败不会留下半成品目录；
- 校验规则与现网下载逻辑一致：必需文件齐全即视为正确，多余文件不判错；
- 导入流式拷贝到 cache 目录，512MB 上限拦截误选超大文件，避免撑爆缓存。

### 3. 漫画翻译首次准备 sheet（MangaTranslatePrepSheet）

- CTD / OCR 两行各加独立「复制链接或导入模型文件」入口，导入成功后该行刷新为「已就绪」并同步底部 CTA 文案；
- 入口按行状态显隐：下载中 / 模型就绪隐藏，下载失败时显示在「下载失败，点击重试」下方，作为失败后的替代路径；
- 修复「下载失败，点击重试」文案没有点击事件的问题：失败态点击该行文字直接重试（与底部 CTA 同一条路径，成功后照常进入翻译）；
- 导入链接字号与状态文案对齐（11sp），去掉多余间距。

### 4. 导入进度反馈与防重入

- 下载页导入复用下载的转圈动画：显示「正在导入模型…」，导入中隐藏所有操作入口；
- 导入真实进度：SAF `OpenableColumns.SIZE` 读取文件总大小，实时更新进度环百分比与「已读 MB / 总 MB」；拿不到总大小时保持转圈并显示模型标注大小；
- 漫画翻译准备 sheet：新增导入中行状态，复用下载行的线性进度 + spinner，CTA 置灰；成功 → 已就绪，失败 → 失败态 + 重试；
- 防重入：控制器 `importInFlight` + sheet `importing` 标志，导入期间入口 / CTA 不可重复触发，避免并发写临时 zip / staging；
- 导入拷贝循环补 `ensureActive()`，页面销毁能及时取消；
- 新增「正在导入模型…」两条文案（下载页 + sheet），同步 7 个语言。

## 涉及文件

- `app/src/main/java/ceui/pixiv/ui/common/ModelDownloadManager.kt`
- `app/src/main/java/ceui/pixiv/ui/common/ModelImportController.kt`（新增，弹窗 + 文件选择 + 导入回调统一控制器）
- `app/src/main/java/ceui/pixiv/ui/common/ModelDownloadFragment.kt`
- `app/src/main/java/ceui/pixiv/ui/translate/MangaTranslatePrepSheet.kt`
- `app/src/main/res/layout/fragment_rembg_model_download.xml`
- `app/src/main/res/layout/dialog_manga_translate_prep.xml`
- `app/src/main/res/values*/strings.xml`（7 个语言：新增 10 条模型导入文案）

## 提交

- `724e803d4` feat(ai): 模型下载页支持复制下载链接或导入本地模型包（zip）
- `c4e6687fc` fix(translate): 漫画翻译准备 sheet 下载失败文案支持点击重试
- `fbcd56c95` fix(translate): 模型导入链接对齐状态文案字号并去掉多余间距
- `2239219a8` feat(ai): 模型导入实时进度反馈与防重入

## 测试情况

- 导入校验与现网下载共用同一套安装流程，行为一致；
- 导入较大模型时进度实时反馈（下载页「已读 MB / 总 MB」+ 进度环，sheet 行内进度 / spinner）；导入期间入口与 CTA 不可重复触发；
- 真机验证：复制链接后剪贴板可粘贴；选非 zip 或错误zip包报「文件错误」；选对 zip 后页面有加载动画且变为就绪状态；漫画翻译 sheet 失败态点击「下载失败，点击重试」能重新下载。
