### PR TITLE
fix(translate): 漫画翻译退出及时取消 + AI 翻译 Token 保护二次确认

### DIFF
--- a/app/src/main/java/ceui/lisa/activities/ImageDetailActivity.kt
+++ b/app/src/main/java/ceui/lisa/activities/ImageDetailActivity.kt
@@ -58,6 +58,7 @@ import ceui.pixiv.utils.animateFadeInQuickly
 import ceui.pixiv.utils.animateFadeOutQuickly
 import com.blankj.utilcode.util.BarUtils
 import com.google.android.material.progressindicator.CircularProgressIndicator
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -441,6 +442,17 @@ class ImageDetailActivity : BaseActivity<ActivityImageDetailBinding?>() {
         })
     }
 
+    override fun onDestroy() {
+        // 用户返回退出页面时立刻停掉翻译流水线并弹「翻译已取消」:
+        // 不 cancel 的话 Google/AI 的阻塞 HTTP 会继续跑到超时,晚到的异常
+        // 会被当成「翻译失败」误报给已经离开的用户。
+        // 旋转等配置变更不走 isFinishing,ViewModel 存活、翻译继续,不打断。
+        if (isFinishing) {
+            translationViewModel.cancelActiveWorkflow()
+        }
+        super.onDestroy()
+    }
+
     private fun performAiRembg(illust: IllustsBean, pageIndex: Int, model: RembgModel) {
         val imageUrl = IllustDownload.getUrl(illust, pageIndex, Params.IMAGE_RESOLUTION_ORIGINAL)
             ?: IllustDownload.getUrl(illust, pageIndex, Params.IMAGE_RESOLUTION_LARGE) ?: return
@@ -604,6 +616,9 @@ class ImageDetailActivity : BaseActivity<ActivityImageDetailBinding?>() {
     private suspend fun awaitLoadedFile(imageUrl: String): File? =
         try {
             ImageLoaderV3.obtain(imageUrl).awaitFile()
+        } catch (e: CancellationException) {
+            // 页面销毁导致协程取消:重抛,别把「取消」当成加载失败弹「识别失败」
+            throw e
         } catch (e: Exception) {
             null
         }

--- a/app/src/main/java/ceui/lisa/activities/ImageDetailActivity.kt
+++ b/app/src/main/java/ceui/lisa/activities/ImageDetailActivity.kt
@@ -58,6 +58,9 @@ import ceui.pixiv.utils.animateFadeInQuickly
 import ceui.pixiv.utils.animateFadeOutQuickly
 import com.blankj.utilcode.util.BarUtils
 import com.google.android.material.progressindicator.CircularProgressIndicator
+import com.qmuiteam.qmui.skin.QMUISkinManager
+import com.qmuiteam.qmui.widget.dialog.QMUIDialog
+import com.qmuiteam.qmui.widget.dialog.QMUIDialogAction
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -433,13 +436,48 @@ class ImageDetailActivity : BaseActivity<ActivityImageDetailBinding?>() {
         // 系统不再回调 onBackPressed,必须用 OnBackPressedDispatcher 接管。
         onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
-                if (index == baseBind!!.viewPager.currentItem) {
-                    finishAfterTransition()
-                } else {
-                    mActivity.finish()
-                }
+                if (maybeConfirmAiExit()) return
+                finishViewer()
             }
         })
+    }
+
+    /**
+     * AI 翻译已向接口发过 POST(有 Token 成本)时,返回/手势退出前弹二次确认,
+     * 防止手滑退出白烧 Token。确认退出才取消流水线;选「继续翻译」则留在页面。
+     * Google 免费端点 / 还没发请求的阶段不弹,直接走原退出逻辑。
+     */
+    private fun maybeConfirmAiExit(): Boolean {
+        if (!translationViewModel.shouldConfirmAiExit()) return false
+        QMUIDialog.MessageDialogBuilder(this)
+            .setTitle(R.string.ai_translate_exit_confirm_title)
+            .setMessage(R.string.ai_translate_exit_confirm_message)
+            .setSkinManager(QMUISkinManager.defaultInstance(this))
+            .addAction(
+                0,
+                getString(R.string.ai_translate_exit_confirm_stay),
+                QMUIDialogAction.ACTION_PROP_NEGATIVE
+            ) { dialog, _ -> dialog.dismiss() }
+            .addAction(
+                0,
+                getString(R.string.ai_translate_exit_confirm_exit),
+                QMUIDialogAction.ACTION_PROP_POSITIVE
+            ) { dialog, _ ->
+                dialog.dismiss()
+                translationViewModel.cancelActiveWorkflow()
+                finishViewer()
+            }
+            .show()
+        return true
+    }
+
+    /** 统一的退出动作:停在进入页走共享元素返回动画,滑到别的页直接关。 */
+    private fun finishViewer() {
+        if (index == baseBind!!.viewPager.currentItem) {
+            finishAfterTransition()
+        } else {
+            mActivity.finish()
+        }
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/ceui/lisa/activities/ImageTranslationViewModel.kt
+++ b/app/src/main/java/ceui/lisa/activities/ImageTranslationViewModel.kt
@@ -28,6 +28,7 @@ import ceui.pixiv.ui.upscale.OcrTextRegion
 import ceui.pixiv.ui.upscale.scaledBy
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -62,6 +63,19 @@ class ImageTranslationViewModel : ViewModel() {
     private val _translatedPaths = MutableLiveData<Map<Int, String>>(emptyMap())
     val translatedPaths: LiveData<Map<Int, String>> get() = _translatedPaths.asLiveData()
 
+    /** 当前正在跑的 pipeline job;页面销毁时用它及时取消工作流。 */
+    private var pipelineJob: Job? = null
+
+    /**
+     * 页面销毁/用户离开触发的取消标记。置位后即使底层阻塞调用晚到的真实异常
+     * (超时、断网、HTTP 错误)逃逸出来,也不再当成「翻译失败」弹给用户——
+     * 那只是取消后的残留噪音,统一按取消语义处理。
+     */
+    private var cancelledByUser = false
+
+    /** 「翻译已取消」toast 是否已弹过,避免 cancelActiveWorkflow 与协程收尾各弹一次。 */
+    private var cancelToastShown = false
+
     /**
      * 「圈选翻译」请求事件:Activity 菜单点了之后塞进目标 pageIndex,对应那页的
      * [ceui.lisa.fragments.FragmentImageDetail] 观察到自己 index 命中就进圈选模式,
@@ -80,6 +94,26 @@ class ImageTranslationViewModel : ViewModel() {
     }
 
     /**
+     * 页面销毁时调用:立即停掉当前 pipeline 并弹「翻译已取消」。
+     * 已在跑才弹;没在跑(已成功/已失败)直接忽略,避免退出页面时误弹。
+     */
+    fun cancelActiveWorkflow() {
+        val job = pipelineJob
+        if (_running.value != true || job == null || !job.isActive) return
+        cancelledByUser = true
+        job.cancel()
+        maybeToastCancelled()
+    }
+
+    /** 取消已由用户触发(页面销毁/离开)时补一次「翻译已取消」反馈;已弹过则跳过。 */
+    private fun maybeToastCancelled() {
+        if (!cancelToastShown) {
+            cancelToastShown = true
+            Common.showToast(R.string.string_ai_manga_translate_cancelled)
+        }
+    }
+
+    /**
      * 启动 pipeline。已在跑就直接 return false,UI 自己决定要不要 toast。
      */
     fun start(
@@ -91,19 +125,30 @@ class ImageTranslationViewModel : ViewModel() {
     ): Boolean {
         if (_running.value == true) return false
         _running.value = true
+        cancelledByUser = false
+        cancelToastShown = false
         val app = context.applicationContext
-        viewModelScope.launch {
+        pipelineJob = viewModelScope.launch {
             try {
                 runPipeline(app, imageFile, pageIndex, ocrModel, ctdModel)
             } catch (e: CancellationException) {
-                // 页面/VM 销毁触发取消:必须重抛,不能当普通失败 toast,否则状态被吞
+                // 页面/VM 销毁触发取消:必须重抛,不能当普通失败 toast,否则状态被吞。
+                // 兜底弹「翻译已取消」——cancelActiveWorkflow 没走到(如系统销毁)时,
+                // 协程收尾到这里才给用户反馈;已弹过则不重复。
+                if (cancelledByUser) maybeToastCancelled()
                 throw e
             } catch (e: Exception) {
-                Timber.e(e, "ImageTranslationVM: pipeline failed")
-                Common.showToast(R.string.string_ai_manga_translate_failed)
+                if (cancelledByUser) {
+                    // 取消后晚到的阻塞调用异常:不是真实失败,不再弹「翻译失败」
+                    Timber.d(e, "ImageTranslationVM: error after user cancelled, ignored")
+                } else {
+                    Timber.e(e, "ImageTranslationVM: pipeline failed")
+                    Common.showToast(R.string.string_ai_manga_translate_failed)
+                }
             } finally {
                 _status.postValue(null)
                 _running.postValue(false)
+                pipelineJob = null
             }
         }
         return true
@@ -126,7 +171,7 @@ class ImageTranslationViewModel : ViewModel() {
                 }.onFailure { Timber.e(it, "loadModel failed") }.isSuccess
             }
             if (!loaded) {
-                Common.showToast(R.string.string_ai_ocr_failed)
+                if (!cancelledByUser) Common.showToast(R.string.string_ai_ocr_failed)
                 return
             }
         }
@@ -138,10 +183,12 @@ class ImageTranslationViewModel : ViewModel() {
         }
         val regions = ocrResult?.regions
         if (regions.isNullOrEmpty()) {
-            Common.showToast(
-                if (ocrResult == null) R.string.string_ai_ocr_failed
-                else R.string.string_ai_ocr_empty
-            )
+            if (!cancelledByUser) {
+                Common.showToast(
+                    if (ocrResult == null) R.string.string_ai_ocr_failed
+                    else R.string.string_ai_ocr_empty
+                )
+            }
             return
         }
 
@@ -161,13 +208,18 @@ class ImageTranslationViewModel : ViewModel() {
             throw e
         } catch (e: Exception) {
             // 按引擎给明确提示(谷歌被墙 → 需要代理;AI → 真实错误),别让用户当 app bug
-            Timber.e(e, "translateBatch failed")
-            promptTranslateFailedIfPossible(e)
+            if (cancelledByUser) {
+                // 页面已销毁:取消后晚到的真实错误不再弹提示,避免在别的页面误报
+                Timber.d(e, "ImageTranslationVM: translate error after user cancelled, ignored")
+            } else {
+                Timber.e(e, "translateBatch failed")
+                promptTranslateFailedIfPossible(e)
+            }
             return
         }
         if (translations.isEmpty()) {
             // batch 走完了但一条没回 — Google 多半是代理半通不通(per-item fallback 全失败)
-            promptTranslateFailedIfPossible(null)
+            if (!cancelledByUser) promptTranslateFailedIfPossible(null)
             return
         }
 
@@ -179,7 +231,7 @@ class ImageTranslationViewModel : ViewModel() {
             }.onFailure { Timber.e(it, "renderTranslated failed") }.getOrNull()
         }
         if (outFile == null) {
-            Common.showToast(R.string.string_ai_manga_translate_failed)
+            if (!cancelledByUser) Common.showToast(R.string.string_ai_manga_translate_failed)
             return
         }
 
@@ -210,18 +262,26 @@ class ImageTranslationViewModel : ViewModel() {
     ): Boolean {
         if (_running.value == true) return false
         _running.value = true
+        cancelledByUser = false
+        cancelToastShown = false
         val app = context.applicationContext
-        viewModelScope.launch {
+        pipelineJob = viewModelScope.launch {
             try {
                 runManualPipeline(app, originalFile, pageIndex, normLeft, normTop, normRight, normBottom, ocrModel)
             } catch (e: CancellationException) {
+                if (cancelledByUser) maybeToastCancelled()
                 throw e
             } catch (e: Exception) {
-                Timber.e(e, "ImageTranslationVM: manual pipeline failed")
-                Common.showToast(R.string.string_ai_manga_translate_failed)
+                if (cancelledByUser) {
+                    Timber.d(e, "ImageTranslationVM: manual error after user cancelled, ignored")
+                } else {
+                    Timber.e(e, "ImageTranslationVM: manual pipeline failed")
+                    Common.showToast(R.string.string_ai_manga_translate_failed)
+                }
             } finally {
                 _status.postValue(null)
                 _running.postValue(false)
+                pipelineJob = null
             }
         }
         return true
@@ -242,7 +302,7 @@ class ImageTranslationViewModel : ViewModel() {
                     .onFailure { Timber.e(it, "manual: loadModel failed") }.isSuccess
             }
             if (!ok) {
-                Common.showToast(R.string.string_ai_ocr_failed)
+                if (!cancelledByUser) Common.showToast(R.string.string_ai_ocr_failed)
                 return
             }
         }
@@ -255,16 +315,22 @@ class ImageTranslationViewModel : ViewModel() {
         // 3. 解码底图 + crop 选区 + 单框 OCR(全在 IO)
         _status.postValue(Status(app.getString(R.string.string_ai_manga_manual_recognizing)))
         val ocr = withContext(Dispatchers.IO) {
-            runCatching { recognizeManualRegion(baseFile, l, t, r, b) }
-                .onFailure { Timber.e(it, "manual: recognize failed") }.getOrNull()
+            try {
+                recognizeManualRegion(baseFile, l, t, r, b)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.e(e, "manual: recognize failed")
+                null
+            }
         }
         if (ocr == null) {
-            Common.showToast(R.string.string_ai_manga_translate_failed)
+            if (!cancelledByUser) Common.showToast(R.string.string_ai_manga_translate_failed)
             return
         }
         try {
             if (ocr.text.isBlank()) {
-                Common.showToast(R.string.string_ai_ocr_empty)
+                if (!cancelledByUser) Common.showToast(R.string.string_ai_ocr_empty)
                 return
             }
 
@@ -275,12 +341,16 @@ class ImageTranslationViewModel : ViewModel() {
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                Timber.e(e, "manual: translate failed")
-                promptTranslateFailedIfPossible(e)
+                if (cancelledByUser) {
+                    Timber.d(e, "ImageTranslationVM: manual translate error after user cancelled, ignored")
+                } else {
+                    Timber.e(e, "manual: translate failed")
+                    promptTranslateFailedIfPossible(e)
+                }
                 return
             }
             if (translated.isBlank()) {
-                promptTranslateFailedIfPossible(null)
+                if (!cancelledByUser) promptTranslateFailedIfPossible(null)
                 return
             }
 
@@ -291,7 +361,7 @@ class ImageTranslationViewModel : ViewModel() {
                     .onFailure { Timber.e(it, "manual: render failed") }.getOrNull()
             }
             if (outFile == null) {
-                Common.showToast(R.string.string_ai_manga_translate_failed)
+                if (!cancelledByUser) Common.showToast(R.string.string_ai_manga_translate_failed)
                 return
             }
             publishTranslated(pageIndex, outFile.absolutePath)
@@ -308,7 +378,7 @@ class ImageTranslationViewModel : ViewModel() {
      * crop 出来喂 manga-ocr。region 直接构造在「底图像素坐标系」下,后续擦/填都在这套坐标里,
      * 不再有 sample 还原那一层。框太小 / 解码失败返回 null。
      */
-    private fun recognizeManualRegion(file: File, l: Float, t: Float, r: Float, b: Float): ManualOcr? {
+    private suspend fun recognizeManualRegion(file: File, l: Float, t: Float, r: Float, b: Float): ManualOcr? {
         val base = decodeSampled(file, MAX_RENDER_SHORT_SIDE) ?: return null
         var keep = false
         try {
@@ -543,6 +613,10 @@ class ImageTranslationViewModel : ViewModel() {
 
     override fun onCleared() {
         super.onCleared()
+        // VM 终结(Activity 销毁)时同样按取消处理:viewModelScope 已 cancel,
+        // 但阻塞调用可能还在跑,晚到的异常不能误报「翻译失败」。
+        cancelledByUser = true
+        pipelineJob?.cancel()
         // VM 终结时把 cacheDir 里这次会话产生的译图全删掉
         val paths = _translatedPaths.value.orEmpty().values.toList()
         if (paths.isNotEmpty()) {

--- a/app/src/main/java/ceui/lisa/activities/ImageTranslationViewModel.kt
+++ b/app/src/main/java/ceui/lisa/activities/ImageTranslationViewModel.kt
@@ -77,6 +77,13 @@ class ImageTranslationViewModel : ViewModel() {
     private var cancelToastShown = false
 
     /**
+     * 是否已向 AI 接口发起请求(POST 即将送出,Token 可能已开始烧)。
+     * 只在 AiTranslator 触发,Google 免费端点不会置位;置位后退出要二次确认。
+     */
+    @Volatile
+    private var aiRequestSent = false
+
+    /**
      * 「圈选翻译」请求事件:Activity 菜单点了之后塞进目标 pageIndex,对应那页的
      * [ceui.lisa.fragments.FragmentImageDetail] 观察到自己 index 命中就进圈选模式,
      * 进完立刻 [consumeManualSelectionRequest] 置空防止旋转/重订阅重复触发。
@@ -113,6 +120,9 @@ class ImageTranslationViewModel : ViewModel() {
         }
     }
 
+    /** AI 翻译已向接口发过 POST(有 Token 成本)且流水线仍在跑:退出前需要二次确认。 */
+    fun shouldConfirmAiExit(): Boolean = _running.value == true && aiRequestSent
+
     /**
      * 启动 pipeline。已在跑就直接 return false,UI 自己决定要不要 toast。
      */
@@ -127,6 +137,7 @@ class ImageTranslationViewModel : ViewModel() {
         _running.value = true
         cancelledByUser = false
         cancelToastShown = false
+        aiRequestSent = false
         val app = context.applicationContext
         pipelineJob = viewModelScope.launch {
             try {
@@ -202,6 +213,7 @@ class ImageTranslationViewModel : ViewModel() {
                 outputLang = appTranslateTargetLang(),
                 onItem = { i, translated -> translations[i] = translated },
                 onPhase = { phase -> postTranslatePhase(app, phase) },
+                onRequestSent = { aiRequestSent = true },
             )
         } catch (e: CancellationException) {
             // 离开页面/重新进入导致协程取消:重抛,别把「Job was cancelled」当真实错误弹给用户
@@ -264,6 +276,7 @@ class ImageTranslationViewModel : ViewModel() {
         _running.value = true
         cancelledByUser = false
         cancelToastShown = false
+        aiRequestSent = false
         val app = context.applicationContext
         pipelineJob = viewModelScope.launch {
             try {
@@ -431,6 +444,7 @@ class ImageTranslationViewModel : ViewModel() {
             outputLang = appTranslateTargetLang(),
             onItem = { _, translated -> out = translated },
             onPhase = { phase -> postTranslatePhase(app, phase) },
+            onRequestSent = { aiRequestSent = true },
         )
         return out
     }

--- a/app/src/main/java/ceui/pixiv/ui/translate/AiTranslator.kt
+++ b/app/src/main/java/ceui/pixiv/ui/translate/AiTranslator.kt
@@ -173,6 +173,7 @@ object AiTranslator : Translator {
         onItem: ((Int, String) -> Unit)?,
         onProgress: ((Int, Int) -> Unit)?,
         onPhase: ((AiTranslatePhase) -> Unit)?,
+        onRequestSent: (() -> Unit)?,
     ): List<String> = withContext(Dispatchers.IO) {
         if (inputs.isEmpty()) return@withContext emptyList()
 
@@ -195,7 +196,11 @@ object AiTranslator : Translator {
                     try {
                         val payload = JSONArray().apply { slice.forEach { put(it) } }
                         val reply = requestSemaphore.withPermit {
-                            callChatCompletion(batchPrompt, payload.toString(), onPhase = phaseAggregator::report)
+                            callChatCompletion(
+                                batchPrompt, payload.toString(),
+                                onPhase = phaseAggregator::report,
+                                onRequestSent = onRequestSent,
+                            )
                         }
                         parseJsonArrayReply(reply)?.takeIf { it.size == slice.size }
                     } catch (e: CancellationException) {
@@ -235,6 +240,7 @@ object AiTranslator : Translator {
                                         systemPromptFor(outputLang),
                                         text,
                                         onPhase = phaseAggregator::report,
+                                        onRequestSent = onRequestSent,
                                     ).trim()
                                 }
                             } catch (e: CancellationException) {
@@ -377,13 +383,14 @@ object AiTranslator : Translator {
         onPhase: ((AiTranslatePhase) -> Unit)? = null,
         client: OkHttpClient? = null,
         forceStreaming: Boolean? = null,
+        onRequestSent: (() -> Unit)? = null,
     ): String {
         var lastError: Exception? = null
         repeat(2) { attempt ->
             try {
                 return doCallChatCompletion(
                     systemPrompt, userContent, overrideBaseUrl, overrideApiKey, overrideModel,
-                    onPhase, client, forceStreaming,
+                    onPhase, client, forceStreaming, onRequestSent,
                 )
             } catch (e: RetryableApiException) {
                 lastError = e
@@ -407,6 +414,7 @@ object AiTranslator : Translator {
         onPhase: ((AiTranslatePhase) -> Unit)?,
         client: OkHttpClient? = null,
         forceStreaming: Boolean? = null,
+        onRequestSent: (() -> Unit)? = null,
     ): String {
         val settings = Shaft.sSettings
         val endpoint = normalizeEndpoint(overrideBaseUrl ?: settings?.aiTranslateBaseUrl ?: "")
@@ -431,6 +439,10 @@ object AiTranslator : Translator {
                 put(JSONObject().put("role", "user").put("content", userContent))
             })
         }
+
+        // 请求体已就绪,马上要向 AI 接口发 POST(可能已烧 Token)。
+        // 此刻通知业务侧:之后用户退出要弹「二次确认」,防止手滑浪费 Token。
+        onRequestSent?.invoke()
 
         if (streaming) {
             return try {

--- a/app/src/main/java/ceui/pixiv/ui/translate/AiTranslator.kt
+++ b/app/src/main/java/ceui/pixiv/ui/translate/AiTranslator.kt
@@ -696,7 +696,12 @@ object AiTranslator : Translator {
         false
     }
 
-    private fun nonStreamChatCompletion(
+    /**
+     * 非流式 chat/completions 调用。走 [awaitOkHttpCall],协程取消时立即掐断连接——
+     * 页面销毁后翻译工作流能及时停,不会阻塞到 readTimeout 才回来
+     * (默认 120s,最坏 600s)再误报「翻译失败」。
+     */
+    private suspend fun nonStreamChatCompletion(
         endpoint: String,
         apiKey: String,
         model: String,
@@ -713,8 +718,9 @@ object AiTranslator : Translator {
         // 请求/响应全文打 Timber(debug 可见);API key 只在 Authorization 头里,不打印。
         Timber.d("AiTranslator: POST %s model=%s body=%s", endpoint, model, requestBody)
         val startNanos = System.nanoTime()
-        (client ?: clientFor(REAL_CONNECT_TIMEOUT_SECONDS, readTimeout, Dns.SYSTEM))
-            .newCall(builder.build()).execute().use { resp ->
+        val call = (client ?: clientFor(REAL_CONNECT_TIMEOUT_SECONDS, readTimeout, Dns.SYSTEM))
+            .newCall(builder.build())
+        return awaitOkHttpCall(call) { resp ->
             val elapsedMs = (System.nanoTime() - startNanos) / 1_000_000
             if (!resp.isSuccessful) {
                 val errorBody = readBodyQuietly(resp, readTimeout)
@@ -737,7 +743,7 @@ object AiTranslator : Translator {
                 throw IOException("empty completion: ${respBody.take(200)}")
             }
             logUsageStats(root, elapsedMs, reasoningContent.length)
-            return content
+            content
         }
     }
 

--- a/app/src/main/java/ceui/pixiv/ui/translate/AwaitCall.kt
+++ b/app/src/main/java/ceui/pixiv/ui/translate/AwaitCall.kt
@@ -1,0 +1,50 @@
+package ceui.pixiv.ui.translate
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.suspendCancellableCoroutine
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.Response
+import java.io.IOException
+
+/**
+ * 把 OkHttp 的 [Call] 转成可取消的 suspend 调用,Google/AI 两条翻译链路共用:
+ * - 协程取消时调 [Call.cancel] 立刻掐断连接,不再阻塞到 connect/read 超时;
+ * - 取消引发的 Canceled 一律以 [CancellationException] 语义返回,绝不让外层把
+ *   「取消」当成真实失败弹给用户;
+ * - [onResponse] 在 OkHttp 回调线程执行,必须自己消费 body;返回后 [Response] 自动关闭。
+ */
+internal suspend fun <T> awaitOkHttpCall(
+    call: Call,
+    onResponse: (Response) -> T,
+): T = suspendCancellableCoroutine { cont ->
+    call.enqueue(object : Callback {
+        override fun onFailure(call: Call, e: IOException) {
+            if (cont.isCancelled) {
+                cont.resumeWith(Result.failure(CancellationException("okhttp call cancelled", e)))
+            } else {
+                cont.resumeWith(Result.failure(e))
+            }
+        }
+
+        override fun onResponse(call: Call, response: Response) {
+            try {
+                response.use { resp ->
+                    val result = onResponse(resp)
+                    if (cont.isCancelled) {
+                        cont.resumeWith(Result.failure(CancellationException("okhttp call cancelled")))
+                    } else {
+                        cont.resumeWith(Result.success(result))
+                    }
+                }
+            } catch (e: Exception) {
+                if (cont.isCancelled) {
+                    cont.resumeWith(Result.failure(CancellationException("okhttp call cancelled", e)))
+                } else {
+                    cont.resumeWith(Result.failure(e))
+                }
+            }
+        }
+    })
+    cont.invokeOnCancellation { call.cancel() }
+}

--- a/app/src/main/java/ceui/pixiv/ui/translate/ComicTextDetector.kt
+++ b/app/src/main/java/ceui/pixiv/ui/translate/ComicTextDetector.kt
@@ -9,9 +9,12 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.Rect
 import android.graphics.RectF
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ensureActive
 import timber.log.Timber
 import java.io.File
 import java.nio.FloatBuffer
+import kotlin.coroutines.coroutineContext
 
 /**
  * comic-text-detector (dmMaze) Android port.
@@ -161,15 +164,17 @@ object ComicTextDetector {
      * @param bitmap 原图(任意尺寸),内部会 letterbox 到 1024x1024
      * @return [DetectionResult],boxes 在原图坐标系;textMask 跟原图同尺寸(没拿到则为 null)
      */
-    fun detect(
+    suspend fun detect(
         bitmap: Bitmap,
         confThreshold: Float = DEFAULT_CONF_THRESHOLD,
         iouThreshold: Float = DEFAULT_IOU_THRESHOLD,
     ): DetectionResult {
+        coroutineContext.ensureActive()
         val sess = session ?: throw IllegalStateException("CTD model not loaded")
         val env = ortEnv ?: throw IllegalStateException("CTD model not loaded")
 
         val (lb, scale, padX, padY) = letterbox(bitmap, INPUT_SIZE)
+        coroutineContext.ensureActive()
         val inputBuf = try {
             bitmapToTensor(lb)
         } finally {
@@ -182,6 +187,7 @@ object ComicTextDetector {
         val candidates = mutableListOf<DetectionBox>()
         var textMask: TextMask? = null
         try {
+            coroutineContext.ensureActive()
             val outputs = sess.run(mapOf(inputName to inputTensor))
             try {
                 val blkTensor = outputs[blkOutputIndex] as OnnxTensor
@@ -195,6 +201,8 @@ object ComicTextDetector {
                 val buf = blkTensor.floatBuffer
                 // YOLOv5: [cx, cy, w, h, obj, cls0, cls1, ...]
                 for (i in 0 until n) {
+                    // 候选框循环里逐条检查取消,大图 N 可到几千,不能让它把取消憋到最后
+                    coroutineContext.ensureActive()
                     val off = i * k
                     val obj = buf.get(off + 4)
                     if (obj < confThreshold) continue
@@ -223,10 +231,15 @@ object ComicTextDetector {
 
                 // mask:解 4D output → 反 letterbox → 二值化 → 跟原图等大 ByteArray
                 if (maskOutputIndex >= 0) {
-                    textMask = runCatching {
+                    textMask = try {
                         val maskTensor = outputs[maskOutputIndex] as OnnxTensor
                         decodeMaskToBitmapCoords(maskTensor, bitmap.width, bitmap.height, scale, padX, padY)
-                    }.onFailure { Timber.w(it, "CTD: mask decode failed, fallback to no-mask") }.getOrNull()
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        Timber.w(e, "CTD: mask decode failed, fallback to no-mask")
+                        null
+                    }
                 }
             } finally {
                 outputs.close()
@@ -236,6 +249,7 @@ object ComicTextDetector {
         }
 
         // class-agnostic NMS:text/balloon 互相覆盖时取高分
+        coroutineContext.ensureActive()
         val kept = nms(candidates, iouThreshold)
         Timber.d(
             "CTD: ${candidates.size} candidates → ${kept.size} after NMS (conf>=$confThreshold, iou<=$iouThreshold)" +
@@ -263,7 +277,7 @@ object ComicTextDetector {
      *  3. 对原图每个像素 (bx, by) → letterbox 坐标 (bx*scale, by*scale) → mask 坐标 nearest sample
      *  4. 阈值 [MASK_THRESHOLD] 二值化(CTD seg head 是 sigmoid'd in [0,1])
      */
-    private fun decodeMaskToBitmapCoords(
+    private suspend fun decodeMaskToBitmapCoords(
         maskTensor: OnnxTensor,
         bmpW: Int, bmpH: Int,
         scale: Float, padX: Float, padY: Float,
@@ -281,6 +295,8 @@ object ComicTextDetector {
         val out = ByteArray(bmpW * bmpH)
         var painted = 0
         for (by in 0 until bmpH) {
+            // 逐行检查取消:mask 解到原图分辨率(几百万像素)也是秒级阻塞段
+            coroutineContext.ensureActive()
             // letterboxY = by * scale + padY,本项目 padY=0 所以化简
             val lbY = by * scale + padY
             val my = (lbY * mScaleY).toInt().coerceIn(0, mh - 1)

--- a/app/src/main/java/ceui/pixiv/ui/translate/GoogleWebTranslator.kt
+++ b/app/src/main/java/ceui/pixiv/ui/translate/GoogleWebTranslator.kt
@@ -54,6 +54,8 @@ object GoogleWebTranslator : Translator {
         onItem: ((Int, String) -> Unit)?,
         onProgress: ((Int, Int) -> Unit)?,
         onPhase: ((AiTranslatePhase) -> Unit)?,
+        // Google 免费端点不烧 Token,不需要「退出二次确认」信号,这里显式忽略。
+        onRequestSent: (() -> Unit)?,
     ): List<String> = withContext(Dispatchers.IO) {
         if (inputs.isEmpty()) return@withContext emptyList()
 

--- a/app/src/main/java/ceui/pixiv/ui/translate/GoogleWebTranslator.kt
+++ b/app/src/main/java/ceui/pixiv/ui/translate/GoogleWebTranslator.kt
@@ -149,7 +149,7 @@ object GoogleWebTranslator : Translator {
         return out
     }
 
-    private fun callGtx(text: String, targetLang: String): String {
+    private suspend fun callGtx(text: String, targetLang: String): String {
         // POST + form body,FormBody 自动 URL 编码 q 值,避免 GET URL 撑爆
         val form = FormBody.Builder()
             .add("client", "gtx")
@@ -163,12 +163,11 @@ object GoogleWebTranslator : Translator {
             .post(form)
             .header("User-Agent", "Mozilla/5.0")
             .build()
-        client.newCall(req).execute().use { resp ->
+        return awaitOkHttpCall(client.newCall(req)) { resp ->
             if (!resp.isSuccessful) {
                 throw RuntimeException("google translate http ${resp.code}")
             }
-            val body = resp.body?.string().orEmpty()
-            return parseResponse(body)
+            parseResponse(resp.body?.string().orEmpty())
         }
     }
 

--- a/app/src/main/java/ceui/pixiv/ui/translate/MangaOcrRecognizer.kt
+++ b/app/src/main/java/ceui/pixiv/ui/translate/MangaOcrRecognizer.kt
@@ -6,6 +6,7 @@ import ai.onnxruntime.OrtSession
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Color
+import kotlinx.coroutines.ensureActive
 import org.json.JSONArray
 import org.json.JSONObject
 import timber.log.Timber
@@ -13,6 +14,7 @@ import java.io.File
 import java.nio.FloatBuffer
 import java.nio.LongBuffer
 import java.text.Normalizer
+import kotlin.coroutines.coroutineContext
 import kotlin.math.exp
 import kotlin.math.ln
 
@@ -131,7 +133,8 @@ object MangaOcrRecognizer {
      * @param bitmap Cropped image of a single text region
      * @return Recognized Japanese text + 模型自身置信度
      */
-    fun recognize(bitmap: Bitmap): OcrResult {
+    suspend fun recognize(bitmap: Bitmap): OcrResult {
+        coroutineContext.ensureActive()
         val encoder = encoderSession ?: throw IllegalStateException("Model not loaded")
         val decoder = decoderSession ?: throw IllegalStateException("Model not loaded")
         val cfg = config ?: throw IllegalStateException("Model not loaded")
@@ -158,6 +161,9 @@ object MangaOcrRecognizer {
 
         try {
             for (step in 0 until cfg.maxLength) {
+                // 自回归解码是逐 token 阻塞的,每步检查一次取消:
+                // 页面销毁后最多再跑一步 decoder,而不是等整页 OCR 全部跑完
+                coroutineContext.ensureActive()
                 val decInputTensor = OnnxTensor.createTensor(
                     env,
                     LongBuffer.wrap(decoderInputIds),

--- a/app/src/main/java/ceui/pixiv/ui/translate/Translator.kt
+++ b/app/src/main/java/ceui/pixiv/ui/translate/Translator.kt
@@ -24,6 +24,8 @@ interface Translator {
      * - onItem: 单条完成后回调,用于 LiveData 增量推送
      * - onProgress: 每完成一段后回调 (done, total),用于按钮进度
      * - onPhase: 流式阶段的实时回调(思考中/生成中),非流式实现可以不回调
+     * - onRequestSent: 请求即将向远端发出(POST 已就绪)时回调。Google 免费端点不需要,
+     *   AI 引擎用于「退出二次确认」——POST 出去后 Token 已经开烧,退出会浪费。
      */
     suspend fun translateBatch(
         inputs: List<String>,
@@ -31,10 +33,12 @@ interface Translator {
         onItem: ((index: Int, translated: String) -> Unit)? = null,
         onProgress: ((done: Int, total: Int) -> Unit)? = null,
         onPhase: ((AiTranslatePhase) -> Unit)? = null,
+        onRequestSent: (() -> Unit)? = null,
     ): List<String> {
         val out = mutableListOf<String>()
         for ((i, text) in inputs.withIndex()) {
             coroutineContext.ensureActive()
+            onRequestSent?.invoke()
             val zh = try {
                 translate(text, outputLang)
             } catch (e: CancellationException) {

--- a/app/src/main/java/ceui/pixiv/ui/upscale/MangaOcr.kt
+++ b/app/src/main/java/ceui/pixiv/ui/upscale/MangaOcr.kt
@@ -15,11 +15,14 @@ import ceui.pixiv.ui.translate.ComicTextDetector
 import ceui.pixiv.ui.translate.DetectionBox
 import ceui.pixiv.ui.translate.MangaOcrRecognizer
 import ceui.pixiv.ui.translate.TextMask
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.io.File
 import java.io.FileOutputStream
+import kotlin.coroutines.coroutineContext
 
 /**
  * OCR 文本框,**坐标系契约:统一在"原图"分辨率下**。
@@ -126,6 +129,9 @@ object MangaOcr {
         inputFile: File,
         onProgress: ((stage: String, fraction: Float) -> Unit)? = null
     ): MangaOcrResult? = withContext(Dispatchers.IO) {
+        // 整段 OCR 是秒级阻塞工作,必须在这里逐段检查取消,否则页面销毁后
+        // 气泡检测 + 逐框识别会整段跑完才返回,「工作流无法中断」就出在这一层
+        coroutineContext.ensureActive()
         if (!MangaOcrRecognizer.isLoaded) {
             Timber.e("MangaOcr: manga-ocr model not loaded")
             return@withContext null
@@ -152,12 +158,15 @@ object MangaOcr {
                 Timber.e("MangaOcr: failed to decode input")
                 return@withContext null
             }
+            coroutineContext.ensureActive()
             Timber.d("MangaOcr: orig ${bounds.outWidth}x${bounds.outHeight} sample=$sample → ${bitmap!!.width}x${bitmap!!.height}")
 
             // 检测阶段没有可靠百分比 → 用 NaN 通知 caller 切 indeterminate ring
             onProgress?.invoke(context.getString(R.string.string_ai_ocr_detecting), Float.NaN)
 
+            coroutineContext.ensureActive()
             val detResult = ComicTextDetector.detect(bitmap!!)
+            coroutineContext.ensureActive()
             val rawRegions = detResult.boxes.map { it.toOcrTextRegion() }
             Timber.d("MangaOcr: CTD returned ${rawRegions.size} regions, mask=${detResult.textMask?.let { "${it.width}x${it.height}" } ?: "null"}")
 
@@ -178,6 +187,8 @@ object MangaOcr {
 
             val total = viableRegions.size
             val enhanced = viableRegions.mapIndexedNotNull { idx, region ->
+                // 逐 region 检查取消:一页常有几十个气泡,不能让取消憋到全部识别完
+                coroutineContext.ensureActive()
                 onProgress?.invoke(
                     context.getString(R.string.string_ai_ocr_recognizing, idx + 1, total),
                     idx.toFloat() / total.coerceAtLeast(1)
@@ -194,6 +205,9 @@ object MangaOcr {
                     )
                     if (trimmed.isBlank()) null
                     else region.copy(text = trimmed, recogConfidence = result.confidence)
+                } catch (e: CancellationException) {
+                    // 页面销毁取消:必须重抛,不能被当成「该 region 识别失败」吞掉继续跑
+                    throw e
                 } catch (e: Exception) {
                     Timber.e(e, "MangaOcr: manga-ocr failed for region, dropping")
                     null
@@ -201,6 +215,7 @@ object MangaOcr {
                     cropped?.recycle()
                 }
             }
+            coroutineContext.ensureActive()
             onProgress?.invoke(context.getString(R.string.string_ai_ocr_done), 1f)
 
             val confident = enhanced.filter { it.recogConfidence >= MIN_RECOG_CONFIDENCE }
@@ -220,6 +235,9 @@ object MangaOcr {
                 )
             }
             MangaOcrResult(regions = finalRegions, textMask = detResult.textMask, ocrSample = sample)
+        } catch (e: CancellationException) {
+            // 取消不是 OCR 失败:重抛给上层按「翻译取消」处理,别记成 error 日志
+            throw e
         } catch (e: Exception) {
             Timber.e(e, "MangaOcr error")
             null

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -764,6 +764,7 @@
     <string name="string_ai_manga_translate">Manga translation</string>
     <string name="string_ai_manga_translating">Translating manga...</string>
     <string name="string_ai_manga_translate_failed">Manga translation failed</string>
+    <string name="string_ai_manga_translate_cancelled">Manga translation cancelled</string>
     <string name="string_ai_manga_translate_no_text">No text detected</string>
     <string name="string_manga_translate_original">Original</string>
     <string name="string_manga_translate_translated">Translated</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -2215,6 +2215,10 @@
     <string name="ai_translate_unsaved_message">AI translation settings have been modified. Save before leaving?</string>
     <string name="ai_translate_unsaved_save">Save and exit</string>
     <string name="ai_translate_unsaved_discard">Discard</string>
+    <string name="ai_translate_exit_confirm_title">AI is translating</string>
+    <string name="ai_translate_exit_confirm_message">Exiting now will discard the AI translation result\nand waste token costs</string>
+    <string name="ai_translate_exit_confirm_stay">Keep translating</string>
+    <string name="ai_translate_exit_confirm_exit">Exit</string>
     <string name="synonym_dict_title">Synonym Dictionary</string>
     <string name="synonym_dict_enable">Enable synonym dictionary</string>
     <string name="keep_status_bar_when_view_image">Keep status bar area when viewing images</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -2215,6 +2215,10 @@
     <string name="ai_translate_unsaved_message">AI 翻訳の設定が変更されています。終了前に保存しますか？</string>
     <string name="ai_translate_unsaved_save">保存して終了</string>
     <string name="ai_translate_unsaved_discard">保存しない</string>
+    <string name="ai_translate_exit_confirm_title">AIが翻訳中です</string>
+    <string name="ai_translate_exit_confirm_message">今すぐ終了するとAI翻訳の結果が破棄され\nトークン費用を無駄にします</string>
+    <string name="ai_translate_exit_confirm_stay">翻訳を続ける</string>
+    <string name="ai_translate_exit_confirm_exit">終了する</string>
     <string name="synonym_dict_title">同義語辞書</string>
     <string name="synonym_dict_enable">同義語辞書を有効化</string>
     <string name="keep_status_bar_when_view_image">画像表示時にステータスバー領域を残す</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -764,6 +764,7 @@
     <string name="string_ai_manga_translate">漫画翻訳</string>
     <string name="string_ai_manga_translating">漫画を翻訳中…</string>
     <string name="string_ai_manga_translate_failed">漫画翻訳に失敗しました</string>
+    <string name="string_ai_manga_translate_cancelled">漫画翻訳をキャンセルしました</string>
     <string name="string_ai_manga_translate_no_text">文字が検出されませんでした</string>
     <string name="string_manga_translate_original">元画像</string>
     <string name="string_manga_translate_translated">翻訳画像</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -764,6 +764,7 @@
     <string name="string_ai_manga_translate">만화 번역</string>
     <string name="string_ai_manga_translating">만화 번역 중…</string>
     <string name="string_ai_manga_translate_failed">만화 번역 실패</string>
+    <string name="string_ai_manga_translate_cancelled">만화 번역이 취소되었습니다</string>
     <string name="string_ai_manga_translate_no_text">텍스트를 감지하지 못했습니다</string>
     <string name="string_manga_translate_original">원본</string>
     <string name="string_manga_translate_translated">번역본</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2215,6 +2215,10 @@
     <string name="ai_translate_unsaved_message">AI 번역 설정이 변경되었습니다. 종료 전에 저장하시겠습니까?</string>
     <string name="ai_translate_unsaved_save">저장하고 종료</string>
     <string name="ai_translate_unsaved_discard">저장 안 함</string>
+    <string name="ai_translate_exit_confirm_title">AI 번역 중입니다</string>
+    <string name="ai_translate_exit_confirm_message">지금 종료하면 AI 번역 결과가 사라지고\n토큰 비용이 낭비됩니다</string>
+    <string name="ai_translate_exit_confirm_stay">계속 번역</string>
+    <string name="ai_translate_exit_confirm_exit">종료</string>
     <string name="synonym_dict_title">동의어 사전</string>
     <string name="synonym_dict_enable">동의어 사전 사용</string>
     <string name="keep_status_bar_when_view_image">이미지 볼 때 상태 표시줄 영역 유지</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2215,6 +2215,10 @@
     <string name="ai_translate_unsaved_message">Настройки ИИ-перевода изменены. Сохранить перед выходом?</string>
     <string name="ai_translate_unsaved_save">Сохранить и выйти</string>
     <string name="ai_translate_unsaved_discard">Не сохранять</string>
+    <string name="ai_translate_exit_confirm_title">ИИ переводит</string>
+    <string name="ai_translate_exit_confirm_message">Если выйти сейчас, результат перевода ИИ будет потерян,\nа токены будут потрачены впустую</string>
+    <string name="ai_translate_exit_confirm_stay">Продолжить перевод</string>
+    <string name="ai_translate_exit_confirm_exit">Выйти</string>
     <string name="synonym_dict_title">Словарь синонимов</string>
     <string name="synonym_dict_enable">Включить словарь синонимов</string>
     <string name="keep_status_bar_when_view_image">Оставлять область статус-бара при просмотре изображений</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -764,6 +764,7 @@
     <string name="string_ai_manga_translate">Перевод манги</string>
     <string name="string_ai_manga_translating">Перевод манги…</string>
     <string name="string_ai_manga_translate_failed">Не удалось перевести мангу</string>
+    <string name="string_ai_manga_translate_cancelled">Перевод манги отменён</string>
     <string name="string_ai_manga_translate_no_text">Текст не найден</string>
     <string name="string_manga_translate_original">Оригинал</string>
     <string name="string_manga_translate_translated">Перевод</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -2215,6 +2215,10 @@
     <string name="ai_translate_unsaved_message">AI çeviri ayarları değiştirildi. Çıkmadan önce kaydedilsin mi?</string>
     <string name="ai_translate_unsaved_save">Kaydet ve çık</string>
     <string name="ai_translate_unsaved_discard">Kaydetme</string>
+    <string name="ai_translate_exit_confirm_title">AI çeviriyor</string>
+    <string name="ai_translate_exit_confirm_message">Şimdi çıkarsanız AI çevirisi sonucu kaybolur\nve token ücreti boşa gider</string>
+    <string name="ai_translate_exit_confirm_stay">Çeviriye devam et</string>
+    <string name="ai_translate_exit_confirm_exit">Çık</string>
     <string name="synonym_dict_title">Eş Anlamlılar Sözlüğü</string>
     <string name="synonym_dict_enable">Eş anlamlılar sözlüğünü etkinleştir</string>
     <string name="keep_status_bar_when_view_image">Resimleri görüntülerken durum çubuğu alanını koru</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -764,6 +764,7 @@
     <string name="string_ai_manga_translate">Manga çevirisi</string>
     <string name="string_ai_manga_translating">Manga çevriliyor…</string>
     <string name="string_ai_manga_translate_failed">Manga çevirisi başarısız oldu</string>
+    <string name="string_ai_manga_translate_cancelled">Manga çevirisi iptal edildi</string>
     <string name="string_ai_manga_translate_no_text">Metin algılanmadı</string>
     <string name="string_manga_translate_original">Orijinal</string>
     <string name="string_manga_translate_translated">Çevrilmiş</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -2217,6 +2217,10 @@
     <string name="ai_translate_unsaved_message">AI 翻譯設定已修改，結束前是否儲存？</string>
     <string name="ai_translate_unsaved_save">儲存並結束</string>
     <string name="ai_translate_unsaved_discard">不儲存</string>
+    <string name="ai_translate_exit_confirm_title">AI 已在翻譯中</string>
+    <string name="ai_translate_exit_confirm_message">現在退出會丟棄AI翻譯的結果\n並損失Token費用</string>
+    <string name="ai_translate_exit_confirm_stay">繼續翻譯</string>
+    <string name="ai_translate_exit_confirm_exit">退出</string>
     <string name="synonym_dict_title">同義詞詞典</string>
     <string name="synonym_dict_enable">啟用同義詞詞典</string>
     <string name="keep_status_bar_when_view_image">看圖時保留狀態列區域</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -766,6 +766,7 @@
     <string name="string_ai_manga_translate">漫畫翻譯</string>
     <string name="string_ai_manga_translating">漫畫翻譯中…</string>
     <string name="string_ai_manga_translate_failed">漫畫翻譯失敗</string>
+    <string name="string_ai_manga_translate_cancelled">翻譯已取消</string>
     <string name="string_ai_manga_translate_no_text">未偵測到文字</string>
     <string name="string_manga_translate_original">原圖</string>
     <string name="string_manga_translate_translated">譯圖</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -793,6 +793,7 @@
     <string name="string_ai_manga_translate">漫画翻译</string>
     <string name="string_ai_manga_translating">漫画翻译中…</string>
     <string name="string_ai_manga_translate_failed">漫画翻译失败</string>
+    <string name="string_ai_manga_translate_cancelled">翻译已取消</string>
     <string name="string_ai_manga_translate_no_text">未检测到文字</string>
     <string name="string_manga_translate_original">原图</string>
     <string name="string_manga_translate_translated">译图</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2437,6 +2437,10 @@
     <string name="ai_translate_unsaved_message">AI 翻译配置已修改，退出前是否保存？</string>
     <string name="ai_translate_unsaved_save">保存并退出</string>
     <string name="ai_translate_unsaved_discard">不保存</string>
+    <string name="ai_translate_exit_confirm_title">AI已在翻译中</string>
+    <string name="ai_translate_exit_confirm_message">现在退出会丢弃AI翻译的结果\n并损失Token费用</string>
+    <string name="ai_translate_exit_confirm_stay">继续翻译</string>
+    <string name="ai_translate_exit_confirm_exit">退出</string>
     <string-array name="ai_translate_thinking_modes">
         <item>@string/ai_translate_thinking_mode_default</item>
         <item>@string/ai_translate_thinking_mode_deepseek</item>


### PR DESCRIPTION
# 漫画翻译工作流改进：退出及时取消 + AI 翻译 Token 保护

> 分支：`patch-8-13-2`（wangwang-code fork；本地 remote 名为 `my`）
> 提交：`60cf8678b` fix(translate) + `4235709e8` feat(translate)

## 背景

漫画翻译在页面销毁后工作流仍在后台继续跑：

- Google/AI 的 HTTP 请求是阻塞式调用，退出页面后要等 connect/read 超时才返回，
  晚到的异常被当成「翻译失败」误报给已离开的用户；
- CTD 气泡检测与 OCR 整段没有挂起点，协程取消要等整页识别跑完才生效；
- AI 引擎的 POST 发出后 Token 无法保证能停止，手滑按返回就会白烧 Token。

## 改动内容

### 1. 页面销毁及时取消工作流，不再误报「翻译失败」

- 页面销毁（onDestroy isFinishing）时 `cancelActiveWorkflow()` 立即取消流水线并弹「翻译已取消」，
  协程收尾兜底再弹一次（覆盖系统销毁路径），只弹一次；
- Google/AI 阻塞 HTTP 改走共享 `awaitOkHttpCall`：协程取消即 `Call.cancel()` 掐断连接，
  取消引发的 Canceled 一律按取消语义返回，不再被当成真实失败；
- CTD/OCR 加协作式取消检查：候选框循环、mask 逐行、逐 region、自回归解码逐 token，
  退出后约 1~3 秒内停下（ONNX 单次推理无法中途掐断）；
- 取消后的晚到异常统一按取消处理，不再弹「翻译失败」/「需要代理」；
- `awaitLoadedFile` 重抛取消，退出页面时不再误报「识别失败」。

### 2. AI 翻译退出二次确认，防止手滑浪费 Token

- `Translator.translateBatch` 新增 `onRequestSent` 回调，仅 AiTranslator 在请求体就绪、
  马上发 POST 时触发；Google 免费端点显式忽略；
- `ImageTranslationViewModel` 记录 `aiRequestSent`（@Volatile，IO 线程写、主线程读），
  暴露 `shouldConfirmAiExit()`，自动/圈选两条路径都接上；
- `ImageDetailActivity` 返回回调先过 `maybeConfirmAiExit()`：AI 已发请求后按返回/手势
  弹确认框——标题「AI已在翻译中」，正文「现在退出会丢弃AI翻译的结果\n并损失Token费用」；
  选「退出」才取消流水线并离开，「继续翻译」留在页面；
- 修复弹窗崩溃：QMUI `addAction` 首参是图标资源 ID，传 1 会去加载 `Resource #0x1`
  直接 Resources$NotFoundException 崩整个 app，改为 0。

## 涉及文件

- `app/src/main/java/ceui/lisa/activities/ImageDetailActivity.kt`
- `app/src/main/java/ceui/lisa/activities/ImageTranslationViewModel.kt`
- `app/src/main/java/ceui/pixiv/ui/translate/Translator.kt`
- `app/src/main/java/ceui/pixiv/ui/translate/AiTranslator.kt`
- `app/src/main/java/ceui/pixiv/ui/translate/GoogleWebTranslator.kt`
- `app/src/main/java/ceui/pixiv/ui/translate/AwaitCall.kt`（新增）
- `app/src/main/java/ceui/pixiv/ui/translate/ComicTextDetector.kt`
- `app/src/main/java/ceui/pixiv/ui/translate/MangaOcrRecognizer.kt`
- `app/src/main/java/ceui/pixiv/ui/upscale/MangaOcr.kt`
- `app/src/main/res/values*/strings.xml`（7 个语言包：「翻译已取消」+ AI 退出确认 4 条文案）

## 测试情况

- 真机实测：
  - AI 翻译中按返回 → 弹「AI已在翻译中」确认框，「继续翻译」/「退出」两条路径；
  - Google 流 / AI 未发请求阶段 → 直接退出并弹「翻译已取消」；
  - 翻译漫画秒退出后 logcat 不再出现 OCR、Google/AI 的 HTTP 请求继续跑的日志。