### PR TITLE
fix(history): 浏览记录超长封面按收藏页规则封顶 2:1 裁剪

### DIFF
--- a/app/src/main/java/ceui/lisa/fragments/HistoryFeed.kt
+++ b/app/src/main/java/ceui/lisa/fragments/HistoryFeed.kt
@@ -34,6 +34,8 @@ import java.util.Locale
 
 /** 历史卡封面高度下限 = 宽的 0.5 倍(对齐改造前 `coerceAtLeast(itemWidth / 2)` 的语义)。 */
 private const val MIN_HISTORY_HEIGHT_RATIO = 0.5f
+/** 历史卡封面高度上限 = 宽的 2.0 倍(对齐收藏页瀑布流 staggerIllustRenderer 的钳制区间)。 */
+private const val MAX_HISTORY_HEIGHT_RATIO = 2.0f
 
 // ── FeedItem 模型（原 HistoryIllustHolder / HistoryNovelHolder 的数据部分）─────────────
 // isSelectionMode / isSelected 由 FragmentHistoryList.syncSelection 通过 updateItems 回灌。
@@ -365,7 +367,8 @@ fun FragmentHistoryList.historyIllustRenderer(): FeedRenderer<HistoryIllustFeedI
         // 卡整体高 1.5~2 倍。默认值是 2 列,所以只在非默认档露馅。
         // 顺带治了绝对像素的老毛病:复用的卡片横竖屏切换后会揣着旧方向的尺寸。
         val ratio = if (illust.width > 0 && illust.height > 0) {
-            (illust.height.toFloat() / illust.width).coerceAtLeast(MIN_HISTORY_HEIGHT_RATIO)
+            (illust.height.toFloat() / illust.width)
+                .coerceIn(MIN_HISTORY_HEIGHT_RATIO, MAX_HISTORY_HEIGHT_RATIO)
         } else {
             1f
         }


### PR DESCRIPTION
# 浏览记录超长封面与收藏页对齐：高度封顶 2:1 居中裁剪

> 分支：`patch-8-14`（wangwang-code fork；本地 remote 名为 `my`）
> 提交：`2decf398b` fix(history): 浏览记录超长封面按收藏页规则封顶 2:1 裁剪

## 背景

浏览记录页与收藏页共用同一张瀑布流卡片布局和 `DynamicHeightImageView`，但封面高度策略不一致：

- 收藏页（feeds 框架 `staggerIllustRenderer` / legacy `IAdapter`）：高宽比钳制在 0.6~2.0，极高竖图封顶为列宽的 2 倍，Glide 按 2:1 解码居中裁剪；
- 浏览记录页（`historyIllustRenderer`）：只钳下限 0.5，没有上限，极高竖图按真实比例撑高整张显示。

结果就是浏览记录里遇到比例 >2 的超长图时，卡片会被撑成很高的长条，视觉上与收藏页不一致。

## 改动内容

- 新增 `MAX_HISTORY_HEIGHT_RATIO = 2.0f`，封面高宽比从 `coerceAtLeast(0.5f)` 改为 `coerceIn(0.5f, 2.0f)`；
- Glide 请求尺寸与展示盒同源（列宽 × 钳制后比例），解码阶段即按 2:1 居中裁剪，回收重绑、横竖屏切换行为与收藏页一致；
- 下限保持 0.5（历史页刻意保留的旧语义，未动）。

## 涉及文件

- `app/src/main/java/ceui/lisa/fragments/HistoryFeed.kt`
