### PR TITLE
fix(embedding): 调整可折叠设备的比例

### DIFF
--- a/app/src/main/java/ceui/pixiv/ui/embedding/SplitPlaceholderActivity.kt
+++ b/app/src/main/java/ceui/pixiv/ui/embedding/SplitPlaceholderActivity.kt
@@ -5,7 +5,7 @@ import androidx.appcompat.app.AppCompatActivity
 import ceui.lisa.R
 
 /**
- * 平板双栏右侧 2/3 的占位页：大屏上首页没打开详情时由系统按
+ * 平板双栏右侧 4/7 的占位页：大屏上首页没打开详情时由系统按
  * [TabletActivityEmbedding] 里的 SplitPlaceholderRule 自动拉起/收起，
  * 手机上永远不会出现。纯装饰，无交互、无文案。
  */

--- a/app/src/main/java/ceui/pixiv/ui/embedding/TabletActivityEmbedding.kt
+++ b/app/src/main/java/ceui/pixiv/ui/embedding/TabletActivityEmbedding.kt
@@ -14,6 +14,7 @@ import androidx.window.embedding.SplitRule
 import ceui.lisa.activities.ImageDetailActivity
 import ceui.lisa.activities.MainActivity
 import ceui.lisa.activities.VPActivity
+import ceui.pixiv.ui.embedding.TabletActivityEmbedding.install
 import ceui.pixiv.ui.slideshow.SlideshowActivity
 
 /**
@@ -32,7 +33,7 @@ object TabletActivityEmbedding {
 
     /** 主栏（信息流）占 1/3，详情占 2/3，跟随 RTL。 */
     private val splitAttributes = SplitAttributes.Builder()
-        .setSplitType(SplitAttributes.SplitType.ratio(1f / 3f))
+        .setSplitType(SplitAttributes.SplitType.ratio(3f / 7f))
         .setLayoutDirection(SplitAttributes.LayoutDirection.LOCALE)
         .build()
 

--- a/app/src/main/java/ceui/pixiv/ui/embedding/TabletActivityEmbedding.kt
+++ b/app/src/main/java/ceui/pixiv/ui/embedding/TabletActivityEmbedding.kt
@@ -14,7 +14,6 @@ import androidx.window.embedding.SplitRule
 import ceui.lisa.activities.ImageDetailActivity
 import ceui.lisa.activities.MainActivity
 import ceui.lisa.activities.VPActivity
-import ceui.pixiv.ui.embedding.TabletActivityEmbedding.install
 import ceui.pixiv.ui.slideshow.SlideshowActivity
 
 /**
@@ -22,7 +21,7 @@ import ceui.pixiv.ui.slideshow.SlideshowActivity
  *
  * 本仓是多 Activity 架构（首页 MainActivity 之上叠 VActivity / UActivity /
  * SearchActivity / TemplateActivity …），所以不重写任何导航，只声明分栏规则，
- * 由 WindowManager 把同一个 task 里的 Activity 摆成左 1/3 列表 + 右 2/3 详情。
+ * 由 WindowManager 把同一个 task 里的 Activity 摆成左 3/7 列表 + 右 4/7 详情。
  * 规则只在平板（sw >= 600dp）上注册；手机完全不注册（原因见 [install]，issue #1002）。
  * 已注册的设备上，窗口宽度 < 600dp（平板分屏后的窄窗）时规则不激活；
  * 无 WM Extensions 的老设备上 RuleController 是 no-op。
@@ -31,7 +30,7 @@ object TabletActivityEmbedding {
 
     private const val SPLIT_MIN_WIDTH_DP = 600
 
-    /** 主栏（信息流）占 1/3，详情占 2/3，跟随 RTL。 */
+    /** 主栏（信息流）占 3/7，详情占 4/7，跟随 RTL；折叠屏近方形展开屏上 1/3 太窄（#1022）。 */
     private val splitAttributes = SplitAttributes.Builder()
         .setSplitType(SplitAttributes.SplitType.ratio(3f / 7f))
         .setLayoutDirection(SplitAttributes.LayoutDirection.LOCALE)
@@ -69,7 +68,7 @@ object TabletActivityEmbedding {
             .setFinishSecondaryWithPrimary(SplitRule.FinishBehavior.ALWAYS)
             .build()
 
-        // 首页没打开任何内容时右栏放占位页，保持 1/3 + 2/3 的稳定布局。
+        // 首页没打开任何内容时右栏放占位页，保持 3/7 + 4/7 的稳定布局。
         val placeholder = SplitPlaceholderRule.Builder(
             setOf(ActivityFilter(ComponentName(context, MainActivity::class.java), null)),
             Intent(context, SplitPlaceholderActivity::class.java)
@@ -79,7 +78,7 @@ object TabletActivityEmbedding {
             .setFinishPrimaryWithPlaceholder(SplitRule.FinishBehavior.ADJACENT)
             .build()
 
-        // 沉浸式查看器始终铺满整窗，不塞进 2/3 的格子里。
+        // 沉浸式查看器始终铺满整窗，不塞进 4/7 的格子里。
         val fullscreenViewers = ActivityRule.Builder(
             setOf(
                 ImageDetailActivity::class.java,


### PR DESCRIPTION
在我的设备上发现1:3有点问题，于是我修改一下。
修改前：
<img width="2312" height="2504" alt="Screenshot_20260815_141138" src="https://github.com/user-attachments/assets/652dd45f-cc4b-4e65-86d7-3c2066006720" />
修改后：
<img width="2312" height="2504" alt="Screenshot_20260815_204445" src="https://github.com/user-attachments/assets/6a61b630-04c3-4aa1-8075-425e21709fd2" />

但平板未测试。