### PR TITLE
feat(detail): 详情页新增标题+简介一键翻译

### DIFF
--- a/app/src/main/java/ceui/pixiv/ui/comments/CommentTranslate.kt
+++ b/app/src/main/java/ceui/pixiv/ui/comments/CommentTranslate.kt
@@ -2,15 +2,13 @@ package ceui.pixiv.ui.comments
 
 import androidx.fragment.app.Fragment
 import ceui.lisa.R
-import ceui.lisa.utils.ClipBoardUtils
 import ceui.lisa.utils.Common
 import ceui.loxia.launchSuspend
-import ceui.pixiv.ui.translate.AiTranslatePhase
 import ceui.pixiv.ui.translate.appTranslateTargetLang
 import ceui.pixiv.ui.translate.currentTranslator
+import ceui.pixiv.ui.translate.onThinkingPhase
 import ceui.pixiv.ui.translate.promptTranslateFailedIfPossible
-import com.qmuiteam.qmui.skin.QMUISkinManager
-import com.qmuiteam.qmui.widget.dialog.QMUIDialog
+import ceui.pixiv.ui.translate.showTranslatedDialog
 import kotlinx.coroutines.CancellationException
 import timber.log.Timber
 
@@ -27,11 +25,7 @@ fun Fragment.translateComment(text: String?) {
     Common.showToast(R.string.string_translating)
     launchSuspend {
         val translated = try {
-            currentTranslator().translate(src, appTranslateTargetLang()) { phase ->
-                if (phase == AiTranslatePhase.THINKING) {
-                    Common.showToast(R.string.ai_translate_thinking)
-                }
-            }
+            currentTranslator().translate(src, appTranslateTargetLang(), onPhase = onThinkingPhase)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -43,15 +37,6 @@ fun Fragment.translateComment(text: String?) {
             promptTranslateFailedIfPossible(null)
             return@launchSuspend
         }
-        QMUIDialog.MessageDialogBuilder(ctx)
-            .setTitle(ctx.getString(R.string.string_translate_caption))
-            .setMessage(translated)
-            .setSkinManager(QMUISkinManager.defaultInstance(ctx))
-            .addAction(ctx.getString(R.string.string_120)) { dialog, _ ->
-                ClipBoardUtils.putTextIntoClipboard(ctx, translated)
-                dialog.dismiss()
-            }
-            .addAction(ctx.getString(R.string.sure)) { dialog, _ -> dialog.dismiss() }
-            .show()
+        showTranslatedDialog(ctx, translated)
     }
 }

--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkSectionRenderers.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkSectionRenderers.kt
@@ -97,7 +97,7 @@ class ArtworkSeriesItem(val illust: IllustsBean) : FeedItem {
     override fun hashCode() = System.identityHashCode(illust)
 }
 
-data class ArtworkDescItem(val caption: String) : FeedItem {
+data class ArtworkDescItem(val caption: String, val title: String = "") : FeedItem {
     override val feedKey: Any get() = "artwork_desc"
 }
 
@@ -298,7 +298,7 @@ internal fun ArtworkV3Fragment.descRenderer() =
             val plain = HtmlCompat.fromHtml(
                 cell.item.caption, HtmlCompat.FROM_HTML_MODE_COMPACT
             ).toString().trim()
-            translateComment(plain)
+            translateTitleAndCaption(cell.item.title, plain)
         }
     }
 

--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkSectionRenderers.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkSectionRenderers.kt
@@ -294,7 +294,7 @@ internal fun ArtworkV3Fragment.descRenderer() =
             applyDescCollapseState(b)
             if (!descExpanded) scrollDescBackIntoView(b.root)
         }
-        b.root.findViewById<View>(R.id.desc_translate).setOnClickListener {
+        b.descTranslate.setOnClickListener {
             val plain = (descFullCaption ?: HtmlCompat.fromHtml(
                 cell.item.caption, HtmlCompat.FROM_HTML_MODE_COMPACT
             )).toString().trim()

--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkSectionRenderers.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkSectionRenderers.kt
@@ -294,6 +294,12 @@ internal fun ArtworkV3Fragment.descRenderer() =
             applyDescCollapseState(b)
             if (!descExpanded) scrollDescBackIntoView(b.root)
         }
+        b.root.findViewById<View>(R.id.desc_translate).setOnClickListener {
+            val plain = HtmlCompat.fromHtml(
+                cell.item.caption, HtmlCompat.FROM_HTML_MODE_COMPACT
+            ).toString().trim()
+            translateComment(plain)
+        }
     }
 
 /** 简介折叠阈值(#965):超过这个行数才折,issue 建议 3~5 行,取上限。 */

--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkSectionRenderers.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkSectionRenderers.kt
@@ -295,9 +295,9 @@ internal fun ArtworkV3Fragment.descRenderer() =
             if (!descExpanded) scrollDescBackIntoView(b.root)
         }
         b.root.findViewById<View>(R.id.desc_translate).setOnClickListener {
-            val plain = HtmlCompat.fromHtml(
+            val plain = (descFullCaption ?: HtmlCompat.fromHtml(
                 cell.item.caption, HtmlCompat.FROM_HTML_MODE_COMPACT
-            ).toString().trim()
+            )).toString().trim()
             translateTitleAndCaption(cell.item.title, plain)
         }
     }

--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3FeedSource.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3FeedSource.kt
@@ -121,7 +121,7 @@ class ArtworkV3FeedSource(
             }
             list.add(ArtworkArtistItem(illust))
             if (!TextUtils.isEmpty(illust.caption)) {
-                list.add(ArtworkDescItem(illust.caption))
+                list.add(ArtworkDescItem(illust.caption, illust.title.orEmpty()))
             }
             list.add(ArtworkTagsItem(illust))
             list.add(ArtworkStatsItem(illust))

--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3FeedSource.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3FeedSource.kt
@@ -120,8 +120,8 @@ class ArtworkV3FeedSource(
                 list.add(ArtworkSeriesItem(illust))
             }
             list.add(ArtworkArtistItem(illust))
-            if (!TextUtils.isEmpty(illust.caption)) {
-                list.add(ArtworkDescItem(illust.caption, illust.title.orEmpty()))
+            if (!TextUtils.isEmpty(illust.caption) || !TextUtils.isEmpty(illust.title)) {
+                list.add(ArtworkDescItem(illust.caption.orEmpty(), illust.title.orEmpty()))
             }
             list.add(ArtworkTagsItem(illust))
             list.add(ArtworkStatsItem(illust))

--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3FeedSource.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3FeedSource.kt
@@ -120,7 +120,10 @@ class ArtworkV3FeedSource(
                 list.add(ArtworkSeriesItem(illust))
             }
             list.add(ArtworkArtistItem(illust))
-            if (!TextUtils.isEmpty(illust.caption) || !TextUtils.isEmpty(illust.title)) {
+            // 产出条件仍然只看 caption:没有简介的作品(pixiv 上是多数)一旦也产出这块,
+            // 详情页就会多出「简介表头 + 翻译按钮 + 一个空正文」约 120dp 的空区块。
+            // 标题跟着一起带下去,只是为了让简介块的翻译按钮能连标题一起翻。
+            if (!TextUtils.isEmpty(illust.caption)) {
                 list.add(ArtworkDescItem(illust.caption.orEmpty(), illust.title.orEmpty()))
             }
             list.add(ArtworkTagsItem(illust))

--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3Fragment.kt
@@ -554,17 +554,18 @@ class ArtworkV3Fragment : IllustFeedFragment(R.layout.fragment_artwork_v3) {
      * AOSP 越界。谁要把动画开回来,先想清楚这里。
      */
     private fun syncDescSection(caption: String?, title: String?) {
-        if (caption.isNullOrEmpty()) return
+        if (caption.isNullOrEmpty() && title.isNullOrEmpty()) return
+        val descCaption = caption.orEmpty()
         val descTitle = title.orEmpty()
         feedViewModel.mutateItems { items ->
             val at = items.indexOfFirst { it is ArtworkDescItem }
             if (at >= 0) {
-                if ((items[at] as ArtworkDescItem).caption == caption &&
+                if ((items[at] as ArtworkDescItem).caption == descCaption &&
                     (items[at] as ArtworkDescItem).title == descTitle
                 ) {
                     items
                 } else {
-                    items.toMutableList().apply { this[at] = ArtworkDescItem(caption, descTitle) }
+                    items.toMutableList().apply { this[at] = ArtworkDescItem(descCaption, descTitle) }
                 }
             } else {
                 val anchor = items.indexOfFirst { it is ArtworkTagsItem }
@@ -572,8 +573,8 @@ class ArtworkV3Fragment : IllustFeedFragment(R.layout.fragment_artwork_v3) {
                     items // header 还没建出来(首屏仍在飞),等下一次 fire
                 } else {
                     Timber.tag(ARTWORK_LAZY_TAG)
-                        .d("简介块后台补入 illustId=%d len=%d", illustId, caption.length)
-                    items.subList(0, anchor) + ArtworkDescItem(caption, descTitle) +
+                        .d("简介块后台补入 illustId=%d len=%d", illustId, descCaption.length)
+                    items.subList(0, anchor) + ArtworkDescItem(descCaption, descTitle) +
                             items.subList(anchor, items.size)
                 }
             }

--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3Fragment.kt
@@ -275,7 +275,7 @@ class ArtworkV3Fragment : IllustFeedFragment(R.layout.fragment_artwork_v3) {
         // 顺带接住 caption 后台补拉的落地(见 ArtworkV3ViewModel.ensureTrustedCaption)。
         ObjectPool.get<IllustsBean>(illustId).observe(viewLifecycleOwner) { illust ->
             illust ?: return@observe
-            syncDescSection(illust.caption)
+            syncDescSection(illust.caption, illust.title)
             attachMuteObserver(illust)
             val authorId = illust.user?.id?.toLong() ?: return@observe
             attachArtistFollowObserver(authorId)
@@ -553,15 +553,18 @@ class ArtworkV3Fragment : IllustFeedFragment(R.layout.fragment_artwork_v3) {
      * 预布局,也就绕开了 [ceui.lisa.helper.StaggeredManager] 注释里那个「fling + 插入同帧」的
      * AOSP 越界。谁要把动画开回来,先想清楚这里。
      */
-    private fun syncDescSection(caption: String?) {
+    private fun syncDescSection(caption: String?, title: String?) {
         if (caption.isNullOrEmpty()) return
+        val descTitle = title.orEmpty()
         feedViewModel.mutateItems { items ->
             val at = items.indexOfFirst { it is ArtworkDescItem }
             if (at >= 0) {
-                if ((items[at] as ArtworkDescItem).caption == caption) {
+                if ((items[at] as ArtworkDescItem).caption == caption &&
+                    (items[at] as ArtworkDescItem).title == descTitle
+                ) {
                     items
                 } else {
-                    items.toMutableList().apply { this[at] = ArtworkDescItem(caption) }
+                    items.toMutableList().apply { this[at] = ArtworkDescItem(caption, descTitle) }
                 }
             } else {
                 val anchor = items.indexOfFirst { it is ArtworkTagsItem }
@@ -570,7 +573,7 @@ class ArtworkV3Fragment : IllustFeedFragment(R.layout.fragment_artwork_v3) {
                 } else {
                     Timber.tag(ARTWORK_LAZY_TAG)
                         .d("简介块后台补入 illustId=%d len=%d", illustId, caption.length)
-                    items.subList(0, anchor) + ArtworkDescItem(caption) +
+                    items.subList(0, anchor) + ArtworkDescItem(caption, descTitle) +
                             items.subList(anchor, items.size)
                 }
             }

--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3Fragment.kt
@@ -554,8 +554,10 @@ class ArtworkV3Fragment : IllustFeedFragment(R.layout.fragment_artwork_v3) {
      * AOSP 越界。谁要把动画开回来,先想清楚这里。
      */
     private fun syncDescSection(caption: String?, title: String?) {
-        if (caption.isNullOrEmpty() && title.isNullOrEmpty()) return
-        val descCaption = caption.orEmpty()
+        // 门槛只看 caption,和 [ArtworkV3FeedSource.buildArtworkHeaderItems] 的产出条件一致:
+        // 放宽成「标题非空也补入」的话,无简介的作品会从这条后台补入的路径长出一个空简介块。
+        if (caption.isNullOrEmpty()) return
+        val descCaption = caption
         val descTitle = title.orEmpty()
         feedViewModel.mutateItems { items ->
             val at = items.indexOfFirst { it is ArtworkDescItem }

--- a/app/src/main/java/ceui/pixiv/ui/detail/CaptionTranslate.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/CaptionTranslate.kt
@@ -1,0 +1,70 @@
+package ceui.pixiv.ui.detail
+
+import androidx.fragment.app.Fragment
+import ceui.lisa.R
+import ceui.lisa.utils.ClipBoardUtils
+import ceui.lisa.utils.Common
+import ceui.loxia.launchSuspend
+import ceui.pixiv.ui.translate.AiTranslatePhase
+import ceui.pixiv.ui.translate.appTranslateTargetLang
+import ceui.pixiv.ui.translate.currentTranslator
+import ceui.pixiv.ui.translate.promptTranslateFailedIfPossible
+import com.qmuiteam.qmui.skin.QMUISkinManager
+import com.qmuiteam.qmui.widget.dialog.QMUIDialog
+import kotlinx.coroutines.CancellationException
+import timber.log.Timber
+
+/**
+ * 简介标题栏「翻译」:同时翻译标题与简介,译成 app 内语言(见 [appTranslateTargetLang])。
+ * 复用 [currentTranslator](自定义 AI 优先,否则内置 Google)与 [promptTranslateFailedIfPossible]
+ * 的失败提示;译文按「标题：… \n\n 简介：…」弹 QMUIDialog 展示、可一键复制,交互与评论翻译
+ * [ceui.pixiv.ui.comments.translateComment] 保持一致。标题/简介为空时显示占位 [no_info],不触发翻译。
+ */
+fun Fragment.translateTitleAndCaption(title: String?, caption: String?) {
+    val t = title?.trim().orEmpty()
+    val c = caption?.trim().orEmpty()
+    if (t.isEmpty() && c.isEmpty()) return
+    val ctx = requireContext()
+    Common.showToast(R.string.string_translating)
+    launchSuspend {
+        val translated = try {
+            val translatedTitle = if (t.isEmpty()) null else currentTranslator().translate(
+                t, appTranslateTargetLang()
+            ) { phase ->
+                if (phase == AiTranslatePhase.THINKING) {
+                    Common.showToast(R.string.ai_translate_thinking)
+                }
+            }
+            val translatedCaption = if (c.isEmpty()) null else currentTranslator().translate(
+                c, appTranslateTargetLang()
+            ) { phase ->
+                if (phase == AiTranslatePhase.THINKING) {
+                    Common.showToast(R.string.ai_translate_thinking)
+                }
+            }
+            translatedTitle to translatedCaption
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "translate title/caption failed")
+            promptTranslateFailedIfPossible(e)
+            return@launchSuspend
+        }
+        val (translatedTitle, translatedCaption) = translated
+        val placeholder = ctx.getString(R.string.no_info)
+        val titleText = translatedTitle?.takeIf { it.isNotBlank() } ?: placeholder
+        val captionText = translatedCaption?.takeIf { it.isNotBlank() } ?: placeholder
+        val message = ctx.getString(R.string.string_182) + titleText + "\n\n" +
+            ctx.getString(R.string.v3_translate_caption_label) + captionText
+        QMUIDialog.MessageDialogBuilder(ctx)
+            .setTitle(ctx.getString(R.string.string_translate_caption))
+            .setMessage(message)
+            .setSkinManager(QMUISkinManager.defaultInstance(ctx))
+            .addAction(ctx.getString(R.string.string_120)) { dialog, _ ->
+                ClipBoardUtils.putTextIntoClipboard(ctx, message)
+                dialog.dismiss()
+            }
+            .addAction(ctx.getString(R.string.sure)) { dialog, _ -> dialog.dismiss() }
+            .show()
+    }
+}

--- a/app/src/main/java/ceui/pixiv/ui/detail/CaptionTranslate.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/CaptionTranslate.kt
@@ -2,17 +2,18 @@ package ceui.pixiv.ui.detail
 
 import androidx.fragment.app.Fragment
 import ceui.lisa.R
-import ceui.lisa.utils.ClipBoardUtils
 import ceui.lisa.utils.Common
 import ceui.loxia.launchSuspend
-import ceui.pixiv.ui.translate.AiTranslatePhase
 import ceui.pixiv.ui.translate.appTranslateTargetLang
 import ceui.pixiv.ui.translate.currentTranslator
+import ceui.pixiv.ui.translate.onThinkingPhase
 import ceui.pixiv.ui.translate.promptTranslateFailedIfPossible
-import com.qmuiteam.qmui.skin.QMUISkinManager
-import com.qmuiteam.qmui.widget.dialog.QMUIDialog
+import ceui.pixiv.ui.translate.showTranslatedDialog
 import kotlinx.coroutines.CancellationException
 import timber.log.Timber
+
+/** 标题译文与简介译文之间的分隔符。 */
+private const val TRANSLATED_MESSAGE_SEPARATOR = "\n\n"
 
 /**
  * 简介标题栏「翻译」:同时翻译标题与简介,译成 app 内语言(见 [appTranslateTargetLang])。
@@ -27,22 +28,15 @@ fun Fragment.translateTitleAndCaption(title: String?, caption: String?) {
     val ctx = requireContext()
     Common.showToast(R.string.string_translating)
     launchSuspend {
-        val translated = try {
-            val translatedTitle = if (t.isEmpty()) null else currentTranslator().translate(
-                t, appTranslateTargetLang()
-            ) { phase ->
-                if (phase == AiTranslatePhase.THINKING) {
-                    Common.showToast(R.string.ai_translate_thinking)
-                }
-            }
-            val translatedCaption = if (c.isEmpty()) null else currentTranslator().translate(
-                c, appTranslateTargetLang()
-            ) { phase ->
-                if (phase == AiTranslatePhase.THINKING) {
-                    Common.showToast(R.string.ai_translate_thinking)
-                }
-            }
-            translatedTitle to translatedCaption
+        // 只对非空字段发起批量翻译,一次取回两条(复用 translateBatch,避免两条顺序 translate)。
+        val inputs = listOfNotNull(
+            t.takeIf { it.isNotEmpty() },
+            c.takeIf { it.isNotEmpty() },
+        )
+        val results = try {
+            currentTranslator().translateBatch(
+                inputs, appTranslateTargetLang(), onPhase = onThinkingPhase
+            )
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -50,21 +44,19 @@ fun Fragment.translateTitleAndCaption(title: String?, caption: String?) {
             promptTranslateFailedIfPossible(e)
             return@launchSuspend
         }
-        val (translatedTitle, translatedCaption) = translated
+        // 输入非空但译文空白 = 翻译失败:全部失败则不弹窗(与评论翻译一致);部分失败则失败字段用占位。
+        if (results.all { it.isBlank() }) {
+            promptTranslateFailedIfPossible(null)
+            return@launchSuspend
+        }
         val placeholder = ctx.getString(R.string.no_info)
-        val titleText = translatedTitle?.takeIf { it.isNotBlank() } ?: placeholder
-        val captionText = translatedCaption?.takeIf { it.isNotBlank() } ?: placeholder
-        val message = ctx.getString(R.string.string_182) + titleText + "\n\n" +
+        var idx = 0
+        val titleText = if (t.isEmpty()) placeholder
+            else results[idx++].takeIf { it.isNotBlank() } ?: placeholder
+        val captionText = if (c.isEmpty()) placeholder
+            else results[idx].takeIf { it.isNotBlank() } ?: placeholder
+        val message = ctx.getString(R.string.string_182) + titleText + TRANSLATED_MESSAGE_SEPARATOR +
             ctx.getString(R.string.v3_translate_caption_label) + captionText
-        QMUIDialog.MessageDialogBuilder(ctx)
-            .setTitle(ctx.getString(R.string.string_translate_caption))
-            .setMessage(message)
-            .setSkinManager(QMUISkinManager.defaultInstance(ctx))
-            .addAction(ctx.getString(R.string.string_120)) { dialog, _ ->
-                ClipBoardUtils.putTextIntoClipboard(ctx, message)
-                dialog.dismiss()
-            }
-            .addAction(ctx.getString(R.string.sure)) { dialog, _ -> dialog.dismiss() }
-            .show()
+        showTranslatedDialog(ctx, message)
     }
 }

--- a/app/src/main/java/ceui/pixiv/ui/detail/CaptionTranslate.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/CaptionTranslate.kt
@@ -6,11 +6,14 @@ import ceui.lisa.utils.Common
 import ceui.loxia.launchSuspend
 import ceui.pixiv.ui.translate.appTranslateTargetLang
 import ceui.pixiv.ui.translate.currentTranslator
-import ceui.pixiv.ui.translate.onThinkingPhase
+import ceui.pixiv.ui.translate.onceThinkingPhase
 import ceui.pixiv.ui.translate.promptTranslateFailedIfPossible
 import ceui.pixiv.ui.translate.showTranslatedDialog
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import timber.log.Timber
+import java.util.concurrent.atomic.AtomicReference
 
 /** 标题译文与简介译文之间的分隔符。 */
 private const val TRANSLATED_MESSAGE_SEPARATOR = "\n\n"
@@ -19,7 +22,14 @@ private const val TRANSLATED_MESSAGE_SEPARATOR = "\n\n"
  * 简介标题栏「翻译」:同时翻译标题与简介,译成 app 内语言(见 [appTranslateTargetLang])。
  * 复用 [currentTranslator](自定义 AI 优先,否则内置 Google)与 [promptTranslateFailedIfPossible]
  * 的失败提示;译文按「标题：… \n\n 简介：…」弹 QMUIDialog 展示、可一键复制,交互与评论翻译
- * [ceui.pixiv.ui.comments.translateComment] 保持一致。标题/简介为空时显示占位 [no_info],不触发翻译。
+ * [ceui.pixiv.ui.comments.translateComment] 保持一致。某一条为空或翻译失败时,那一行显示占位
+ * [R.string.no_info];两条都没译出来才算整体失败,走统一的失败提示、不弹译文窗。
+ *
+ * ⚠️ 这里刻意**不走** `translateBatch`:那个批量接口是给 OCR 的短行设计的,Google 实现把多条
+ * 用 `\n` join 成一次 POST、再按 `\n` 切回。简介是含换行的自由文本(pixiv 的 `<br>` 经
+ * HtmlCompat 变成 `\n`),切分数量必然对不上——先白发一次带全文的 POST,再退化成逐条**串行**
+ * 请求,反而更慢;万一换行被 Google 归并到恰好两行,标题和简介的译文还会错位拼在一起。
+ * 只有两条,直接各翻各的、并发发出即可。
  */
 fun Fragment.translateTitleAndCaption(title: String?, caption: String?) {
     val t = title?.trim().orEmpty()
@@ -28,35 +38,39 @@ fun Fragment.translateTitleAndCaption(title: String?, caption: String?) {
     val ctx = requireContext()
     Common.showToast(R.string.string_translating)
     launchSuspend {
-        // 只对非空字段发起批量翻译,一次取回两条(复用 translateBatch,避免两条顺序 translate)。
-        val inputs = listOfNotNull(
-            t.takeIf { it.isNotEmpty() },
-            c.takeIf { it.isNotEmpty() },
-        )
-        val results = try {
-            currentTranslator().translateBatch(
-                inputs, appTranslateTargetLang(), onPhase = onThinkingPhase
-            )
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            Timber.e(e, "translate title/caption failed")
-            promptTranslateFailedIfPossible(e)
-            return@launchSuspend
+        val translator = currentTranslator()
+        val targetLang = appTranslateTargetLang()
+        val onPhase = onceThinkingPhase()
+        // 单条失败不连累另一条:失败的那条留空串,留到最后统一判定。
+        val failure = AtomicReference<Exception?>(null)
+        suspend fun translateOne(text: String): String {
+            if (text.isEmpty()) return ""
+            return try {
+                translator.translate(text, targetLang, onPhase = onPhase)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.e(e, "translate title/caption failed")
+                failure.compareAndSet(null, e)
+                ""
+            }
         }
-        // 输入非空但译文空白 = 翻译失败:全部失败则不弹窗(与评论翻译一致);部分失败则失败字段用占位。
-        if (results.all { it.isBlank() }) {
-            promptTranslateFailedIfPossible(null)
+        val (translatedTitle, translatedCaption) = coroutineScope {
+            val titleTask = async { translateOne(t) }
+            val captionTask = async { translateOne(c) }
+            titleTask.await() to captionTask.await()
+        }
+        // 两条都没译出来 = 整体失败:不弹译文窗,交给统一的失败提示(与评论翻译一致)。
+        if (translatedTitle.isBlank() && translatedCaption.isBlank()) {
+            promptTranslateFailedIfPossible(failure.get())
             return@launchSuspend
         }
         val placeholder = ctx.getString(R.string.no_info)
-        var idx = 0
-        val titleText = if (t.isEmpty()) placeholder
-            else results[idx++].takeIf { it.isNotBlank() } ?: placeholder
-        val captionText = if (c.isEmpty()) placeholder
-            else results[idx].takeIf { it.isNotBlank() } ?: placeholder
-        val message = ctx.getString(R.string.string_182) + titleText + TRANSLATED_MESSAGE_SEPARATOR +
-            ctx.getString(R.string.v3_translate_caption_label) + captionText
+        val message = ctx.getString(R.string.string_182) +
+            (translatedTitle.takeIf { it.isNotBlank() } ?: placeholder) +
+            TRANSLATED_MESSAGE_SEPARATOR +
+            ctx.getString(R.string.v3_translate_caption_label) +
+            (translatedCaption.takeIf { it.isNotBlank() } ?: placeholder)
         showTranslatedDialog(ctx, message)
     }
 }

--- a/app/src/main/java/ceui/pixiv/ui/translate/TranslateDialog.kt
+++ b/app/src/main/java/ceui/pixiv/ui/translate/TranslateDialog.kt
@@ -6,6 +6,7 @@ import ceui.lisa.utils.ClipBoardUtils
 import ceui.lisa.utils.Common
 import com.qmuiteam.qmui.skin.QMUISkinManager
 import com.qmuiteam.qmui.widget.dialog.QMUIDialog
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * 详情页标题/简介翻译与评论翻译共享的「思考中」阶段提示与译文弹窗。
@@ -17,6 +18,19 @@ import com.qmuiteam.qmui.widget.dialog.QMUIDialog
 internal val onThinkingPhase: (AiTranslatePhase) -> Unit = { phase ->
     if (phase == AiTranslatePhase.THINKING) {
         Common.showToast(R.string.ai_translate_thinking)
+    }
+}
+
+/**
+ * 同一次操作里并发跑多条翻译时用这个:THINKING 只提示一次,不会几条请求各弹一个「思考中」。
+ * 回调来自 IO 线程(见 [AiTranslator] 的流式解析),所以用 [AtomicBoolean] 而不是裸 var。
+ */
+internal fun onceThinkingPhase(): (AiTranslatePhase) -> Unit {
+    val shown = AtomicBoolean(false)
+    return { phase ->
+        if (phase == AiTranslatePhase.THINKING && shown.compareAndSet(false, true)) {
+            Common.showToast(R.string.ai_translate_thinking)
+        }
     }
 }
 

--- a/app/src/main/java/ceui/pixiv/ui/translate/TranslateDialog.kt
+++ b/app/src/main/java/ceui/pixiv/ui/translate/TranslateDialog.kt
@@ -1,0 +1,35 @@
+package ceui.pixiv.ui.translate
+
+import android.content.Context
+import ceui.lisa.R
+import ceui.lisa.utils.ClipBoardUtils
+import ceui.lisa.utils.Common
+import com.qmuiteam.qmui.skin.QMUISkinManager
+import com.qmuiteam.qmui.widget.dialog.QMUIDialog
+
+/**
+ * 详情页标题/简介翻译与评论翻译共享的「思考中」阶段提示与译文弹窗。
+ *
+ * 两处翻译入口(见 [ceui.pixiv.ui.detail.translateTitleAndCaption] 与
+ * [ceui.pixiv.ui.comments.translateComment])此前各自复制了一份几乎相同的 QMUIDialog 装配
+ * 与 THINKING 阶段 toast,这里收拢成共享成员,避免后续改一处漏一处。
+ */
+internal val onThinkingPhase: (AiTranslatePhase) -> Unit = { phase ->
+    if (phase == AiTranslatePhase.THINKING) {
+        Common.showToast(R.string.ai_translate_thinking)
+    }
+}
+
+/** 弹出译文弹窗(挂 SkinManager 跟随日夜皮肤),复制按钮把整段译文写进剪贴板。 */
+internal fun showTranslatedDialog(context: Context, message: String) {
+    QMUIDialog.MessageDialogBuilder(context)
+        .setTitle(context.getString(R.string.string_translate_caption))
+        .setMessage(message)
+        .setSkinManager(QMUISkinManager.defaultInstance(context))
+        .addAction(context.getString(R.string.string_120)) { dialog, _ ->
+            ClipBoardUtils.putTextIntoClipboard(context, message)
+            dialog.dismiss()
+        }
+        .addAction(context.getString(R.string.sure)) { dialog, _ -> dialog.dismiss() }
+        .show()
+}

--- a/app/src/main/res/layout/section_v3_description.xml
+++ b/app/src/main/res/layout/section_v3_description.xml
@@ -30,8 +30,10 @@
 
         <ImageView
             android:id="@+id/desc_translate"
-            android:layout_width="16dp"
-            android:layout_height="16dp"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:padding="16dp"
             android:contentDescription="@string/string_translate_caption"
             android:src="@drawable/ic_baseline_translate_24"
             android:tint="@color/v3_text_3" />

--- a/app/src/main/res/layout/section_v3_description.xml
+++ b/app/src/main/res/layout/section_v3_description.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical"
@@ -36,7 +37,7 @@
             android:padding="16dp"
             android:contentDescription="@string/string_translate_caption"
             android:src="@drawable/ic_baseline_translate_24"
-            android:tint="@color/v3_text_3" />
+            app:tint="@color/v3_text_3" />
     </LinearLayout>
 
     <org.sufficientlysecure.htmltextview.HtmlTextView

--- a/app/src/main/res/layout/section_v3_description.xml
+++ b/app/src/main/res/layout/section_v3_description.xml
@@ -6,16 +6,36 @@
     android:paddingHorizontal="12dp"
     android:paddingBottom="18dp">
 
-    <TextView
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="10dp"
-        android:letterSpacing="0.12"
-        android:text="@string/novel_desc_label"
-        android:textAllCaps="true"
-        android:textColor="@color/v3_text_3"
-        android:textSize="12sp"
-        android:textStyle="bold" />
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:letterSpacing="0.12"
+            android:text="@string/novel_desc_label"
+            android:textAllCaps="true"
+            android:textColor="@color/v3_text_3"
+            android:textSize="12sp"
+            android:textStyle="bold" />
+
+        <View
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+        <ImageView
+            android:id="@+id/desc_translate"
+            android:layout_width="16dp"
+            android:layout_height="16dp"
+            android:contentDescription="@string/string_translate_caption"
+            android:src="@drawable/ic_baseline_translate_24"
+            android:tint="@color/v3_text_3" />
+    </LinearLayout>
 
     <org.sufficientlysecure.htmltextview.HtmlTextView
         android:id="@+id/description"
@@ -42,4 +62,3 @@
         android:textStyle="bold"
         android:visibility="gone" />
 </LinearLayout>
-

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -732,6 +732,7 @@
     <string name="string_translation_model_download_subtitle">%1$s must be downloaded before offline translation can be used</string>
     <string name="string_translation_model_download_done">Translation model downloaded</string>
     <string name="string_translate_caption">Translate</string>
+    <string name="v3_translate_caption_label">Description:</string>
     <string name="string_translating">Translating...</string>
     <string name="string_translate_failed">Translation failed</string>
     <string name="string_translate_model_loading">Loading translation model...</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -732,7 +732,7 @@
     <string name="string_translation_model_download_subtitle">%1$s must be downloaded before offline translation can be used</string>
     <string name="string_translation_model_download_done">Translation model downloaded</string>
     <string name="string_translate_caption">Translate</string>
-    <string name="v3_translate_caption_label">Description:</string>
+    <string name="v3_translate_caption_label">description:</string>
     <string name="string_translating">Translating...</string>
     <string name="string_translate_failed">Translation failed</string>
     <string name="string_translate_model_loading">Loading translation model...</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -732,6 +732,7 @@
     <string name="string_translation_model_download_subtitle">%1$s は追加ダウンロード後にオフライン翻訳で使用できます</string>
     <string name="string_translation_model_download_done">翻訳モデルのダウンロードが完了しました</string>
     <string name="string_translate_caption">翻訳</string>
+    <string name="v3_translate_caption_label">あらすじ：</string>
     <string name="string_translating">翻訳中…</string>
     <string name="string_translate_failed">翻訳に失敗しました</string>
     <string name="string_translate_model_loading">翻訳モデルを読み込み中…</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -732,6 +732,7 @@
     <string name="string_translation_model_download_subtitle">%1$s 를 추가 다운로드해야 오프라인 번역을 사용할 수 있습니다</string>
     <string name="string_translation_model_download_done">번역 모델 다운로드 완료</string>
     <string name="string_translate_caption">번역</string>
+    <string name="v3_translate_caption_label">소개:</string>
     <string name="string_translating">번역 중…</string>
     <string name="string_translate_failed">번역 실패</string>
     <string name="string_translate_model_loading">번역 모델 불러오는 중…</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -732,6 +732,7 @@
     <string name="string_translation_model_download_subtitle">Чтобы использовать офлайн-перевод, нужно дополнительно скачать %1$s</string>
     <string name="string_translation_model_download_done">Модель перевода загружена</string>
     <string name="string_translate_caption">Перевести</string>
+    <string name="v3_translate_caption_label">Описание:</string>
     <string name="string_translating">Перевод…</string>
     <string name="string_translate_failed">Не удалось перевести</string>
     <string name="string_translate_model_loading">Загрузка модели перевода…</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -732,6 +732,7 @@
     <string name="string_translation_model_download_subtitle">Çevrimdışı çeviri için %1$s modelini ayrıca indirmeniz gerekir</string>
     <string name="string_translation_model_download_done">Çeviri modeli indirildi</string>
     <string name="string_translate_caption">Çevir</string>
+    <string name="v3_translate_caption_label">Açıklama:</string>
     <string name="string_translating">Çevriliyor…</string>
     <string name="string_translate_failed">Çeviri başarısız oldu</string>
     <string name="string_translate_model_loading">Çeviri modeli yükleniyor…</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -734,6 +734,7 @@
     <string name="string_translation_model_download_subtitle">%1$s 需額外下載後才能使用離線翻譯</string>
     <string name="string_translation_model_download_done">翻譯模型下載完成</string>
     <string name="string_translate_caption">翻譯</string>
+    <string name="v3_translate_caption_label">簡介：</string>
     <string name="string_translating">翻譯中…</string>
     <string name="string_translate_failed">翻譯失敗</string>
     <string name="string_translate_model_loading">正在載入翻譯模型…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -761,6 +761,7 @@
     <string name="string_translation_model_download_subtitle">%1$s 需要额外下载才能使用离线翻译</string>
     <string name="string_translation_model_download_done">翻译模型下载完成</string>
     <string name="string_translate_caption">翻译</string>
+    <string name="v3_translate_caption_label">简介：</string>
     <string name="string_translating">翻译中…</string>
     <string name="string_translate_failed">翻译失败</string>
     <string name="string_translate_model_loading">正在加载翻译模型…</string>


### PR DESCRIPTION
## 概述
为作品详情页新增「标题 + 简介」一键翻译能力，共 3 个提交。

## 新增内容

### 1. 简介标题栏新增翻译按钮（9cfc560）
在详情页「简介」区块标题栏最右侧新增翻译按钮，点击即可翻译简介正文。

### 2. 标题与简介一起翻译（7882704）
点击翻译按钮时，同时翻译作品标题与简介，译成 App 内当前语言；
译文按「标题：… / 简介：…」的固定格式弹窗展示，并支持一键复制。
复用现有翻译链路（自定义 AI 翻译优先，否则内置 Google）；
标题或简介为空时显示「暂无信息」占位。

### 3. 纯标题作品也可翻译标题（9d35ee7）
放宽简介区块的产出条件：即使作品没有简介，只要存在标题，也会渲染简介区块，
让用户仍能点击翻译按钮翻译标题。

## 已知说明
对于只有标题、没有简介的作品，放宽产出条件后会渲染一个「简介」表头 + 翻译按钮、
但正文为空的区块（用于提供翻标题入口）。这是当前的取舍，后续可考虑隐藏空表头，
或将翻译入口移到标题区。
