### PR TITLE
feat: 无简介作品在信息区显示翻译按钮

### DIFF
--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkSectionRenderers.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkSectionRenderers.kt
@@ -254,6 +254,13 @@ internal fun ArtworkV3Fragment.heroRenderer() =
         b.metaDate.text = Common.getLocalYYYYMMDDHHMMString(illust.create_date)
         b.metaPages.text = if (illust.page_count == 1) ctx.getString(R.string.v3_page_count_one)
         else ctx.getString(R.string.v3_page_count_many, illust.page_count)
+        // 信息区翻译按钮：仅当作品无简介时显示。有简介的作品简介区已提供翻译按钮
+        //（见 descRenderer），而简介区整体只在 caption 非空时才产出（见
+        // ArtworkV3FeedSource.buildArtworkHeaderItems），无简介时这里补一个翻译标题的入口。
+        b.metaTranslate.isVisible = illust.caption.isNullOrEmpty()
+        b.metaTranslate.setOnClickListener {
+            translateTitleAndCaption(illust.title, null)
+        }
     }
 
 internal fun ArtworkV3Fragment.seriesRenderer() =

--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkSectionRenderers.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkSectionRenderers.kt
@@ -85,10 +85,21 @@ import java.text.NumberFormat
 
 // ── 区块条目 ────────────────────────────────────────────────────────────────
 
-class ArtworkHeroItem(val illust: IllustsBean) : FeedItem {
+class ArtworkHeroItem(
+    val illust: IllustsBean,
+    /**
+     * 信息区那个补位的翻译按钮是否显示:只在整页**没有**简介区块时显示,否则和简介区自带的
+     * 翻译按钮重复。初值按 bean 的 caption 判(与 [ArtworkV3FeedSource.buildArtworkHeaderItems]
+     * 产出简介块的条件一致);简介后台补入时由 ArtworkV3Fragment.syncDescSection 翻成 false ——
+     * 那条路径换的是**另一个** bean 实例,光看 [illust] 永远还是空 caption,收不起来。
+     */
+    val showTranslate: Boolean = illust.caption.isNullOrEmpty(),
+) : FeedItem {
     override val feedKey: Any get() = "artwork_hero"
-    override fun equals(other: Any?) = other is ArtworkHeroItem && other.illust === illust
-    override fun hashCode() = System.identityHashCode(illust)
+    override fun equals(other: Any?) =
+        other is ArtworkHeroItem && other.illust === illust && other.showTranslate == showTranslate
+
+    override fun hashCode() = System.identityHashCode(illust) * 31 + showTranslate.hashCode()
 }
 
 class ArtworkSeriesItem(val illust: IllustsBean) : FeedItem {
@@ -257,7 +268,7 @@ internal fun ArtworkV3Fragment.heroRenderer() =
         // 信息区翻译按钮：仅当作品无简介时显示。有简介的作品简介区已提供翻译按钮
         //（见 descRenderer），而简介区整体只在 caption 非空时才产出（见
         // ArtworkV3FeedSource.buildArtworkHeaderItems），无简介时这里补一个翻译标题的入口。
-        b.metaTranslate.isVisible = illust.caption.isNullOrEmpty()
+        b.metaTranslate.isVisible = cell.item.showTranslate
         b.metaTranslate.setOnClickListener {
             translateTitleAndCaption(illust.title, null)
         }

--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3Fragment.kt
@@ -549,6 +549,8 @@ class ArtworkV3Fragment : IllustFeedFragment(R.layout.fragment_artwork_v3) {
      * 只做「补上 / 换内容」,不做「抹掉」:池会被各种精简来源覆盖(作者其他作品、相关作品列表都会
      * 合池),拿一次空 caption 去删已经显示出来的简介,就成了简介闪一下又没了。
      *
+     * 简介块一旦在页面里,信息区那个补位的翻译按钮必须同时收起,见 [hideHeroTranslate]。
+     *
      * 位置锚在 [ArtworkTagsItem] 之前——对齐 [ArtworkV3FeedSource.buildArtworkHeaderItems] 的
      * 区块顺序(Hero /(Series)/ Artist / Desc / Tags / ...)。tags 块是无条件产出的,锚点稳定。
      * 没变化时原样返回同一个 list,[FeedViewModel.mutateItems] 据此判定 no-op,所以这个观察者
@@ -566,26 +568,51 @@ class ArtworkV3Fragment : IllustFeedFragment(R.layout.fragment_artwork_v3) {
         val descCaption = caption
         val descTitle = title.orEmpty()
         feedViewModel.mutateItems { items ->
-            val at = items.indexOfFirst { it is ArtworkDescItem }
-            if (at >= 0) {
-                if ((items[at] as ArtworkDescItem).caption == descCaption &&
-                    (items[at] as ArtworkDescItem).title == descTitle
-                ) {
-                    items
+            val withDesc = run {
+                val at = items.indexOfFirst { it is ArtworkDescItem }
+                if (at >= 0) {
+                    if ((items[at] as ArtworkDescItem).caption == descCaption &&
+                        (items[at] as ArtworkDescItem).title == descTitle
+                    ) {
+                        items
+                    } else {
+                        items.toMutableList()
+                            .apply { this[at] = ArtworkDescItem(descCaption, descTitle) }
+                    }
                 } else {
-                    items.toMutableList().apply { this[at] = ArtworkDescItem(descCaption, descTitle) }
-                }
-            } else {
-                val anchor = items.indexOfFirst { it is ArtworkTagsItem }
-                if (anchor < 0) {
-                    items // header 还没建出来(首屏仍在飞),等下一次 fire
-                } else {
-                    Timber.tag(ARTWORK_LAZY_TAG)
-                        .d("简介块后台补入 illustId=%d len=%d", illustId, descCaption.length)
-                    items.subList(0, anchor) + ArtworkDescItem(descCaption, descTitle) +
-                            items.subList(anchor, items.size)
+                    val anchor = items.indexOfFirst { it is ArtworkTagsItem }
+                    if (anchor < 0) {
+                        items // header 还没建出来(首屏仍在飞),等下一次 fire
+                    } else {
+                        Timber.tag(ARTWORK_LAZY_TAG)
+                            .d("简介块后台补入 illustId=%d len=%d", illustId, descCaption.length)
+                        items.subList(0, anchor) + ArtworkDescItem(descCaption, descTitle) +
+                                items.subList(anchor, items.size)
+                    }
                 }
             }
+            hideHeroTranslate(withDesc)
+        }
+    }
+
+    /**
+     * 简介块已经在页面里 → 收起信息区那个补位的翻译按钮([ArtworkHeroItem.showTranslate]),
+     * 否则同屏两个翻译入口。
+     *
+     * 必须在这里收:hero 条目建出来时用的是**列表页那条**空 caption 的 bean,而简介是
+     * [ceui.pixiv.ui.detail.ArtworkV3ViewModel.ensureTrustedCaption] 回源拿**另一个** bean
+     * 实例补回来的;hero 条目自己既没被替换、[ArtworkHeroItem.equals] 又只比实例身份,
+     * 不主动翻这一下的话它永远重绑不了(#960 的补拉在动态流里约一半会命中)。
+     *
+     * 没得可收时原样返回同一个 list,守住 [ceui.pixiv.feeds.FeedViewModel.mutateItems] 的
+     * 「同一个 list == no-op」约定 —— 这个观察者每次收藏 / 关注变更都会 fire。
+     */
+    private fun hideHeroTranslate(items: List<FeedItem>): List<FeedItem> {
+        val at = items.indexOfFirst { it is ArtworkHeroItem && it.showTranslate }
+        if (at < 0) return items
+        val hero = items[at] as ArtworkHeroItem
+        return items.toMutableList().apply {
+            this[at] = ArtworkHeroItem(hero.illust, showTranslate = false)
         }
     }
 

--- a/app/src/main/res/layout/section_v3_description.xml
+++ b/app/src/main/res/layout/section_v3_description.xml
@@ -31,9 +31,10 @@
 
         <ImageView
             android:id="@+id/desc_translate"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
             android:background="?attr/selectableItemBackgroundBorderless"
+            android:padding="12dp"
             android:contentDescription="@string/string_translate_caption"
             android:src="@drawable/ic_baseline_translate_24"
             app:tint="@color/v3_text_3" />

--- a/app/src/main/res/layout/section_v3_description.xml
+++ b/app/src/main/res/layout/section_v3_description.xml
@@ -31,10 +31,9 @@
 
         <ImageView
             android:id="@+id/desc_translate"
-            android:layout_width="48dp"
-            android:layout_height="48dp"
+            android:layout_width="25dp"
+            android:layout_height="25dp"
             android:background="?attr/selectableItemBackgroundBorderless"
-            android:padding="16dp"
             android:contentDescription="@string/string_translate_caption"
             android:src="@drawable/ic_baseline_translate_24"
             app:tint="@color/v3_text_3" />

--- a/app/src/main/res/layout/section_v3_hero.xml
+++ b/app/src/main/res/layout/section_v3_hero.xml
@@ -33,63 +33,70 @@
             android:gravity="center_vertical"
             android:orientation="horizontal">
 
-            <TextView
-                android:id="@+id/meta_type"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textColor="@color/v3_text_2"
-                android:textSize="12sp"
-                android:textStyle="bold"
-                tools:text="Illustration" />
-
-            <View
-                android:id="@+id/meta_ext_sep"
-                android:layout_width="3dp"
-                android:layout_height="3dp"
-                android:layout_marginHorizontal="8dp"
-                android:background="@drawable/v3_nav_btn_bg" />
-
-            <TextView
-                android:id="@+id/meta_ext"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textColor="@color/v3_text_2"
-                android:textSize="12sp"
-                android:textStyle="bold"
-                tools:text="PNG" />
-
-            <View
-                android:layout_width="3dp"
-                android:layout_height="3dp"
-                android:layout_marginHorizontal="8dp"
-                android:background="@drawable/v3_nav_btn_bg" />
-
-            <TextView
-                android:id="@+id/meta_date"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textColor="@color/v3_text_3"
-                android:textSize="11sp"
-                tools:text="2026-04-15 18:00" />
-
-            <View
-                android:layout_width="3dp"
-                android:layout_height="3dp"
-                android:layout_marginHorizontal="8dp"
-                android:background="@drawable/v3_nav_btn_bg" />
-
-            <TextView
-                android:id="@+id/meta_pages"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textColor="@color/v3_text_3"
-                android:textSize="11sp"
-                tools:text="1 page" />
-
-            <View
+            <!--
+                元信息独占剩余宽度（0dp + weight）：大字号 / 窄屏下这一行会排不下，
+                挤压落在这层里先把文字裁掉，右侧翻译按钮不会被推出屏幕点不到。
+            -->
+            <LinearLayout
                 android:layout_width="0dp"
-                android:layout_height="0dp"
-                android:layout_weight="1" />
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:gravity="center_vertical"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/meta_type"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/v3_text_2"
+                    android:textSize="12sp"
+                    android:textStyle="bold"
+                    tools:text="Illustration" />
+
+                <View
+                    android:id="@+id/meta_ext_sep"
+                    android:layout_width="3dp"
+                    android:layout_height="3dp"
+                    android:layout_marginHorizontal="8dp"
+                    android:background="@drawable/v3_nav_btn_bg" />
+
+                <TextView
+                    android:id="@+id/meta_ext"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/v3_text_2"
+                    android:textSize="12sp"
+                    android:textStyle="bold"
+                    tools:text="PNG" />
+
+                <View
+                    android:layout_width="3dp"
+                    android:layout_height="3dp"
+                    android:layout_marginHorizontal="8dp"
+                    android:background="@drawable/v3_nav_btn_bg" />
+
+                <TextView
+                    android:id="@+id/meta_date"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/v3_text_3"
+                    android:textSize="11sp"
+                    tools:text="2026-04-15 18:00" />
+
+                <View
+                    android:layout_width="3dp"
+                    android:layout_height="3dp"
+                    android:layout_marginHorizontal="8dp"
+                    android:background="@drawable/v3_nav_btn_bg" />
+
+                <TextView
+                    android:id="@+id/meta_pages"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textColor="@color/v3_text_3"
+                    android:textSize="11sp"
+                    tools:text="1 page" />
+            </LinearLayout>
 
             <ImageView
                 android:id="@+id/meta_translate"

--- a/app/src/main/res/layout/section_v3_hero.xml
+++ b/app/src/main/res/layout/section_v3_hero.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -26,7 +27,7 @@
             tools:text="アナイクス" />
 
         <LinearLayout
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:gravity="center_vertical"
@@ -84,6 +85,20 @@
                 android:textColor="@color/v3_text_3"
                 android:textSize="11sp"
                 tools:text="1 page" />
+
+            <View
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+            <ImageView
+                android:id="@+id/meta_translate"
+                android:layout_width="25dp"
+                android:layout_height="25dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/string_translate_caption"
+                android:src="@drawable/ic_baseline_translate_24"
+                app:tint="@color/v3_text_3" />
         </LinearLayout>
     </LinearLayout>
 </LinearLayout>


### PR DESCRIPTION
信息区(格式/发布时间/页数行)最右侧新增翻译按钮,复用简介区图标与样式;仅当作品无简介时显示;两个翻译按钮触发范围 48dp 调整为 25dp,水波纹同步调整