### PR TITLE
网络测试页回补 PxveAPI 支持：替换 app-api 目标、转发路径验证、Debug http 代理、地址脱敏

### DIFF
--- a/app/src/main/java/ceui/lisa/fragments/FragmentSettingsNetwork.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSettingsNetwork.java
@@ -20,6 +20,7 @@ import com.qmuiteam.qmui.skin.QMUISkinManager;
 import com.qmuiteam.qmui.widget.dialog.QMUIDialog;
 import com.qmuiteam.qmui.widget.dialog.QMUIDialogView;
 
+import ceui.lisa.BuildConfig;
 import ceui.lisa.R;
 import ceui.lisa.activities.Shaft;
 import ceui.lisa.activities.TemplateActivity;
@@ -276,7 +277,7 @@ public class FragmentSettingsNetwork extends SettingsPageFragment<FragmentSettin
                     // 这里不再自己判 startsWith("https://")——那比 normalizeBase 严格，
                     // 会把合法的裸域名（pxve.example.com）误拦掉。
                     if (!TextUtils.isEmpty(proxy)
-                            && AppApiProxyInterceptor.normalizeBase(proxy) == null) {
+                            && AppApiProxyInterceptor.normalizeBase(proxy) == null && !BuildConfig.IS_DEBUG_MODE) {
                         Common.showToast(getString(R.string.app_api_proxy_https_required), 2);
                         return;
                     }

--- a/app/src/main/java/ceui/lisa/fragments/FragmentSettingsNetwork.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSettingsNetwork.java
@@ -20,7 +20,6 @@ import com.qmuiteam.qmui.skin.QMUISkinManager;
 import com.qmuiteam.qmui.widget.dialog.QMUIDialog;
 import com.qmuiteam.qmui.widget.dialog.QMUIDialogView;
 
-import ceui.lisa.BuildConfig;
 import ceui.lisa.R;
 import ceui.lisa.activities.Shaft;
 import ceui.lisa.activities.TemplateActivity;
@@ -273,11 +272,12 @@ public class FragmentSettingsNetwork extends SettingsPageFragment<FragmentSettin
                     CharSequence text = builder.getEditText().getText();
                     String proxy = text == null ? "" : text.toString().trim();
                     // 校验交给拦截器的 normalizeBase（唯一事实源）：它接受裸域名并自动补 https，
-                    // 只拒绝显式 http:// 等非 https scheme、带 query/fragment、以及解析失败。
+                    // 只拒绝非法 scheme（debug 下显式 http:// 是放行的）、带 query/fragment、以及解析失败。
                     // 这里不再自己判 startsWith("https://")——那比 normalizeBase 严格，
-                    // 会把合法的裸域名（pxve.example.com）误拦掉。
+                    // 会把合法的裸域名（pxve.example.com）误拦掉；也不按 buildType 再开第二个口子，
+                    // 否则 debug 下填了真正非法的地址会被静默存下，用户以为代理生效了其实全程直连。
                     if (!TextUtils.isEmpty(proxy)
-                            && AppApiProxyInterceptor.normalizeBase(proxy) == null && !BuildConfig.IS_DEBUG_MODE) {
+                            && AppApiProxyInterceptor.normalizeBase(proxy) == null) {
                         Common.showToast(getString(R.string.app_api_proxy_https_required), 2);
                         return;
                     }

--- a/app/src/main/java/ceui/lisa/http/AppApiProxyInterceptor.java
+++ b/app/src/main/java/ceui/lisa/http/AppApiProxyInterceptor.java
@@ -2,6 +2,7 @@ package ceui.lisa.http;
 
 import java.io.IOException;
 
+import ceui.lisa.BuildConfig;
 import ceui.lisa.activities.Shaft;
 import okhttp3.HttpUrl;
 import okhttp3.Interceptor;
@@ -130,12 +131,21 @@ public class AppApiProxyInterceptor implements Interceptor {
         if (p.isEmpty()) return null;
 
         if (p.contains("://")) {
-            // 显式带 scheme：只接受 https
-            if (!p.startsWith("https://") && !p.startsWith("HTTPS://")) {
-                return null;
+            // Debug 模式下允许 http，Release 强制 https
+            if (!BuildConfig.IS_DEBUG_MODE) {
+                if (!p.startsWith("https://") && !p.startsWith("HTTPS://")) {
+                    return null;
+                }
             }
+            // Debug 模式下 http/https 都放行
+            // 但如果是 http，保留原样
         } else {
-            p = "https://" + p;
+            // 裸域名：Debug 用 http，Release 用 https（保持安全默认）
+            if (BuildConfig.IS_DEBUG_MODE) {
+                p = "http://" + p;  // Debug 默认 http，方便本地代理
+            } else {
+                p = "https://" + p;
+            }
         }
 
         final HttpUrl url;
@@ -148,7 +158,6 @@ public class AppApiProxyInterceptor implements Interceptor {
             return null;
         }
 
-        // 去末尾全部斜杠（HttpUrl.toString 对根路径恒带 "/"，需一并去掉）
         String s = url.toString();
         while (s.endsWith("/")) {
             s = s.substring(0, s.length() - 1);

--- a/app/src/main/java/ceui/lisa/http/AppApiProxyInterceptor.java
+++ b/app/src/main/java/ceui/lisa/http/AppApiProxyInterceptor.java
@@ -50,8 +50,8 @@ public class AppApiProxyInterceptor implements Interceptor {
 
         final HttpUrl newUrl = rewrite(url, proxy);
         if (newUrl == null) {
-            // 地址非法（非 https / 带 query / 解析失败）：不静默裸连，明确告警
-            Timber.w("AppApiProxyInterceptor: 代理地址非法已忽略（仅支持 https:// 且不含 query）: %s", proxy);
+            // 地址非法（scheme 不允许 / 带 query / 解析失败）：不静默裸连，明确告警
+            Timber.w("AppApiProxyInterceptor: 代理地址非法已忽略（需 https://，debug 另可显式 http://，且不含 query）: %s", proxy);
             return chain.proceed(request);
         }
 
@@ -90,8 +90,10 @@ public class AppApiProxyInterceptor implements Interceptor {
         // 只用 base 的 scheme://host[:port] 作为根，路径部分单独规范化：
         // 用户可能误填完整 PxveAPI 地址（如 https://proxy/pixiv-app-api），
         // 去掉路径里已存在的同名前缀，避免拼出 /pixiv-app-api/pixiv-app-api 双前缀 404。
+        // 默认端口按 base 自身的 scheme 取：debug 下允许 http 代理后，恒用 https 的 443
+        // 会给 80 端口的 http 代理拼出多余的 ":80"，和网络测试页展示/探测的 URL 对不上。
         final String root = base.scheme() + "://" + base.host()
-                + (base.port() != HttpUrl.defaultPort("https") ? ":" + base.port() : "");
+                + (base.port() != HttpUrl.defaultPort(base.scheme()) ? ":" + base.port() : "");
         String basePath = base.encodedPath();
         while (basePath.endsWith("/")) {
             basePath = basePath.substring(0, basePath.length() - 1);
@@ -117,8 +119,11 @@ public class AppApiProxyInterceptor implements Interceptor {
      * （返回 null 即提示用户），避免 UI 侧另写一套判断跟这里的规则漂移。</p>
      *
      * <ul>
-     *   <li>强制 {@code https://}：显式写 {@code http://} 或其它 scheme 直接视为非法（返回 null），
-     *       避免 Authorization 令牌走明文；裸域名自动补 {@code https://} 前缀。</li>
+     *   <li>scheme：只接受 {@code https://}；其它 scheme 视为非法（返回 null），避免 Authorization
+     *       令牌走明文。Debug 构建额外放行**显式**写出的 {@code http://}（本地起代理调试用），
+     *       Release 一律拒绝。</li>
+     *   <li>裸域名（不带 scheme）**任何 buildType 下都补 {@code https://}**：明文只能是用户
+     *       显式写出来的选择，不由 buildType 替他决定。</li>
      *   <li>去掉末尾全部斜杠（含根路径 "/"，不止 1 个）。</li>
      *   <li>带 query / fragment 视为非法（代理根地址不应携带），避免拼出非法 URL。</li>
      *   <li>解析失败（非法字符等）返回 null。</li>
@@ -131,21 +136,16 @@ public class AppApiProxyInterceptor implements Interceptor {
         if (p.isEmpty()) return null;
 
         if (p.contains("://")) {
-            // Debug 模式下允许 http，Release 强制 https
-            if (!BuildConfig.IS_DEBUG_MODE) {
-                if (!p.startsWith("https://") && !p.startsWith("HTTPS://")) {
-                    return null;
-                }
+            final boolean https = p.regionMatches(true, 0, "https://", 0, 8);
+            // Debug 构建额外放行**显式**写出的 http://（本地起代理调试用）；Release 只收 https。
+            final boolean debugHttp = BuildConfig.IS_DEBUG_MODE && p.regionMatches(true, 0, "http://", 0, 7);
+            if (!https && !debugHttp) {
+                return null;
             }
-            // Debug 模式下 http/https 都放行
-            // 但如果是 http，保留原样
         } else {
-            // 裸域名：Debug 用 http，Release 用 https（保持安全默认）
-            if (BuildConfig.IS_DEBUG_MODE) {
-                p = "http://" + p;  // Debug 默认 http，方便本地代理
-            } else {
-                p = "https://" + p;
-            }
+            // 裸域名一律补 https：这是绝大多数人填写代理的方式，明文只能是用户显式写出来的选择，
+            // 不能由 buildType 悄悄替他决定（否则 debug 包里 Authorization / refresh_token 走明文）。
+            p = "https://" + p;
         }
 
         final HttpUrl url;
@@ -158,6 +158,7 @@ public class AppApiProxyInterceptor implements Interceptor {
             return null;
         }
 
+        // 去末尾全部斜杠（HttpUrl.toString 对根路径恒带 "/"，需一并去掉）
         String s = url.toString();
         while (s.endsWith("/")) {
             s = s.substring(0, s.length() - 1);

--- a/app/src/main/java/ceui/lisa/http/AppApiProxyInterceptor.java
+++ b/app/src/main/java/ceui/lisa/http/AppApiProxyInterceptor.java
@@ -62,11 +62,15 @@ public class AppApiProxyInterceptor implements Interceptor {
     /**
      * 将 app-api / oauth 请求改写为代理路径。纯函数，不依赖 Android 环境，便于单元测试。
      *
+     * <p>公开给网络测试页（NetworkTestViewModel）复用：探测转发路径时必须发**生产会发的那个
+     * URL**，自己手拼 {@code root + "/pixiv-app-api"} 会绕开下面的双前缀去重，把用户按
+     * 「误填完整 PxveAPI 地址」形态配好的、实际能用的代理误报成 404。</p>
+     *
      * @param original 原始请求 URL（app-api.pixiv.net 或 oauth.secure.pixiv.net）
      * @param proxy    用户配置的代理根地址（原始字符串）
      * @return 改写后的 URL；代理地址非法或为空时返回 null（调用方决定放行原请求）
      */
-    static HttpUrl rewrite(HttpUrl original, String proxy) {
+    public static HttpUrl rewrite(HttpUrl original, String proxy) {
         if (proxy == null || proxy.trim().isEmpty()) return null;
 
         final String prefix;

--- a/app/src/main/java/ceui/pixiv/ui/debug/NetworkTestFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/debug/NetworkTestFragment.kt
@@ -42,6 +42,7 @@ class NetworkTestFragment : Fragment(R.layout.fragment_network_perf_test) {
 
     private lateinit var chipDoh: TextView
     private lateinit var chipDirect: TextView
+    private lateinit var chipProxy: TextView
     private lateinit var chipHost: TextView
     private lateinit var summaryCard: View
     private lateinit var summaryPill: TextView
@@ -86,6 +87,7 @@ class NetworkTestFragment : Fragment(R.layout.fragment_network_perf_test) {
 
         chipDoh = view.findViewById(R.id.chip_doh)
         chipDirect = view.findViewById(R.id.chip_direct)
+        chipProxy = view.findViewById(R.id.chip_proxy)
         chipHost = view.findViewById(R.id.chip_host)
         summaryCard = view.findViewById(R.id.summary_card)
         summaryPill = view.findViewById(R.id.summary_pill)
@@ -193,6 +195,12 @@ class NetworkTestFragment : Fragment(R.layout.fragment_network_perf_test) {
         } else {
             applyPill(chipDirect, getString(R.string.network_test_env_direct_off), R.color.v3_text_3)
         }
+        val proxyRoot = viewModel.proxyRoot
+        if (proxyRoot != null) {
+            applyPill(chipProxy, getString(R.string.network_test_env_proxy_on, maskProxyUrl(proxyRoot)), R.color.v3_green)
+        } else {
+            applyPill(chipProxy, getString(R.string.network_test_env_proxy_off), R.color.v3_text_3)
+        }
         applyPill(chipHost, getString(R.string.network_test_env_host_prefix) + imageHostLabel(), R.color.v3_blue)
     }
 
@@ -203,7 +211,7 @@ class NetworkTestFragment : Fragment(R.layout.fragment_network_perf_test) {
         ImageHostManager.Mode.PIXIV_NL -> getString(R.string.image_host_pixiv_nl)
         ImageHostManager.Mode.CUSTOM -> {
             val host = ImageHostManager.getCustomHost()
-            if (host.isEmpty()) getString(R.string.image_host_custom) else host
+            if (host.isEmpty()) getString(R.string.image_host_custom) else maskProxyUrl(host)
         }
     }
 

--- a/app/src/main/java/ceui/pixiv/ui/debug/NetworkTestViewModel.kt
+++ b/app/src/main/java/ceui/pixiv/ui/debug/NetworkTestViewModel.kt
@@ -526,7 +526,11 @@ class NetworkTestViewModel : ViewModel() {
         }
     }
 
-    /** @return (该目标本机 DNS 是否被判定为污染, 污染时握手是否成功——决定绕过是否生效)。 */
+    /**
+     * @return (该目标本机 DNS 是否被判定为污染, 握手是否成功)。
+     *   第二元素在污染时决定「绕过是否生效」，同时也是 PxveAPI 转发路径探测的前置条件，
+     *   所以每条 return 都要给出**真实**的握手结果，不能因为该分支不关心污染就恒填 false。
+     */
     private fun testTarget(idx: Int, cfg: TargetConfig, doh: Boolean, direct: Boolean): Pair<Boolean, Boolean> {
         log("========== ${cfg.displayName ?: cfg.host} ==========")
 
@@ -608,7 +612,9 @@ class NetworkTestViewModel : ViewModel() {
                 }
             }
             log("")
-            return false to false
+            // fake-ip 下不判污染（isPolluted=false，bypassOk 不消费第二元素），但握手结果要如实返回：
+            // Clash 等 fake-ip 环境正是自建 PxveAPI 的典型场景，恒填 false 会让转发路径探测整段不跑。
+            return false to hs.ok
         }
         log("DNS: " + sysAddrs.joinToString(", ") { it.hostAddress ?: "?" })
 

--- a/app/src/main/java/ceui/pixiv/ui/debug/NetworkTestViewModel.kt
+++ b/app/src/main/java/ceui/pixiv/ui/debug/NetworkTestViewModel.kt
@@ -3,8 +3,10 @@ package ceui.pixiv.ui.debug
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import ceui.lisa.BuildConfig
 import ceui.lisa.R
 import ceui.lisa.activities.Shaft
+import ceui.lisa.http.AppApiProxyInterceptor
 import ceui.lisa.http.CronetInterceptor
 import ceui.lisa.http.HttpDns
 import ceui.lisa.http.ImageHostManager
@@ -27,7 +29,10 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import okhttp3.ConnectionPool
 import okhttp3.Dns
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Protocol
 import okhttp3.Request
 import timber.log.Timber
@@ -41,6 +46,25 @@ import java.net.UnknownHostException
 import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
+
+/**
+ * 代理地址脱敏：保留 scheme 和地址开头少量字符，后面统一替换为 ***。
+ * 用于 PxveAPI 地址与自定义图片反代在 UI / 原始日志中的展示，避免泄露他人私有地址。
+ * 例：https://your-proxy.domain → https://your***；https://192.168.10.109:3021 → https://192.168***
+ */
+internal fun maskProxyUrl(url: String): String {
+    val trimmed = url.trim()
+    val scheme = when {
+        trimmed.startsWith("https://", ignoreCase = true) -> "https://"
+        trimmed.startsWith("http://", ignoreCase = true) -> "http://"
+        else -> ""
+    }
+    val rest = if (scheme.isEmpty()) trimmed else trimmed.substring(scheme.length)
+    // IP 地址多留一点（保留前两段 192.168），域名保留前 4 个字符。
+    val visibleLen = if (rest.firstOrNull()?.isDigit() == true) 7 else 4
+    val visible = rest.take(visibleLen)
+    return "$scheme$visible***"
+}
 
 /** 单条步骤的语义状态，决定圆点 / pill 的颜色（在 Fragment 里按状态染 v3 颜色）。 */
 enum class StepStatus { INFO, OK, WARN, FAIL, RUNNING, HIGH_LATENCY, EXTREME_LATENCY }
@@ -88,6 +112,9 @@ data class NetworkAlert(val titleRes: Int, val message: String)
  *   4. 直连开启时额外做 ICMP/echo 可达性（代理下无意义，故仅直连）
  *   5. HTTPS 握手：持续 5s 多次采样，给 min/avg/max/抖动 + TLS/协议信息
  *   · www.pixiv.net 握手后再发一次真实网页请求（/ajax/illust/{样例}），验证 web 端点可用
+ *   · 开启 PxveAPI 代理时，app-api 目标替换为用户填写的代理根地址，并追加
+ *     /pixiv-app-api 与 /pixiv-oauth 两条转发路径的响应探测（https 在握手成功后测；
+ *     Debug 模式允许 http 代理，跳过 HTTPS 握手直接测转发）
  *
  * 所有目标握手测完后追加「图片下载探测」：对样例作品的插画图 + 画师头像各下一张真图，
  * URL 先经 [ImageHostManager.rewrite] 重写 —— 与 Glide / Manager / Ugoira 同源，
@@ -121,6 +148,8 @@ class NetworkTestViewModel : ViewModel() {
 
     val dohEnabled: Boolean get() = Shaft.sSettings?.isUseSecureDns == true
     val directConnect: Boolean get() = Shaft.sSettings?.isDirectConnect == true
+    val proxyEnabled: Boolean get() = Shaft.sSettings?.isUseAppApiProxy == true
+    val proxyRoot: String? get() = Shaft.sSettings?.getAppApiProxy()?.let { AppApiProxyInterceptor.normalizeBase(it) }
 
     /** 一次性事件：检测到 DNS 污染 / fake-ip 时弹窗提醒（PR #894 的核心诉求）。 */
     private val _pollutionAlert = MutableSharedFlow<NetworkAlert>(extraBufferCapacity = 1)
@@ -142,7 +171,7 @@ class NetworkTestViewModel : ViewModel() {
     /** http 反代等跳过连通性的图片目标：卡片判定以图片下载探测为准（探测结束回写该卡状态）。 */
     private var imageCardRelyOnDownload = false
 
-    /** 本轮图片目标卡的标题（imageCfg.host），供下载阶段定位并回写该卡。 */
+    /** 本轮图片目标卡的标题（imageCfg.displayName ?: imageCfg.host），供下载阶段定位并回写该卡。 */
     private var imageTargetTitle: String? = null
 
     /** 本轮在途的 OkHttp 客户端；onCleared 时 cancelAll 中断阻塞中的 execute()，让测试尽快收尾。 */
@@ -154,6 +183,37 @@ class NetworkTestViewModel : ViewModel() {
         // 避免 VM 重建 / 重进页面时旧一轮还在跑、又并发开第二轮。
         activeClients.forEach { it.dispatcher.cancelAll() }
         super.onCleared()
+    }
+
+    /** PxveAPI 开启且地址合法时，用代理根地址替换 app-api.pixiv.net 目标；否则保持官方域名。 */
+    private fun buildAppApiConfig(): TargetConfig {
+        val ctx = Shaft.getContext()
+        val root = proxyRoot
+        if (root != null) {
+            val url = try {
+                root.toHttpUrl()
+            } catch (e: Exception) {
+                null
+            }
+            if (url != null) {
+                val defaultPort = if (url.scheme == "http") 80 else 443
+                val host = url.host + if (url.port != defaultPort) ":${url.port}" else ""
+                return TargetConfig(
+                    host = host,
+                    subtitle = ctx.getString(R.string.network_test_target_sub_app_api_proxy, maskProxyUrl(root)),
+                    cidrs = null,
+                    kind = TargetKind.APP_API,
+                    rootUrl = root,
+                    displayName = maskProxyUrl(root),
+                )
+            }
+        }
+        return TargetConfig(
+            host = APP_API_HOST,
+            subtitle = ctx.getString(R.string.network_test_target_sub_app_api),
+            cidrs = PIXIV_CIDRS,
+            kind = TargetKind.APP_API,
+        )
     }
 
     /** fake-ip 提示弹窗每轮测试只弹一次。 */
@@ -176,6 +236,10 @@ class NetworkTestViewModel : ViewModel() {
         val kind: TargetKind,
         /** 自定义反代为 http://（明文，非 https）：https 握手无法代表它，跳过连通性，以图片下载探测为准。 */
         val plainHttp: Boolean = false,
+        /** PxveAPI 代理根地址（https://host[/path]；Debug 下可为 http://host[/path]，无尾斜杠）；仅 APP_API 走代理时非空。 */
+        val rootUrl: String? = null,
+        /** 卡片标题展示名；缺省用 [host]。PxveAPI 场景展示完整根地址。 */
+        val displayName: String? = null,
     )
 
     private data class HandshakeResult(val ok: Boolean, val avgMs: Int, val maxMs: Int)
@@ -205,10 +269,15 @@ class NetworkTestViewModel : ViewModel() {
 
         val doh = dohEnabled
         val direct = directConnect
+        val appApiCfg = buildAppApiConfig()
+        val appApiTitle = appApiCfg.displayName ?: appApiCfg.host
 
         viewModelScope.launch(Dispatchers.IO) {
             try {
-                log("环境: 安全 DNS(DoH) ${onOff(doh)} · 直连 ${onOff(direct)}")
+                log(
+                    "环境: 安全 DNS(DoH) ${onOff(doh)} · 直连 ${onOff(direct)} · " +
+                        "App API 代理 ${appApiCfg.rootUrl?.let { maskProxyUrl(it) } ?: onOff(proxyEnabled)}",
+                )
                 log("")
 
                 // 图片目标联动当前图片代理：反代模式下直接把目标域名换成反代域名来测。
@@ -219,12 +288,18 @@ class NetworkTestViewModel : ViewModel() {
                     ImageHostManager.getCustomHost().trim().startsWith("http://", ignoreCase = true)
                 imageCardRelyOnDownload = imagePlainHttp
                 val imageCfg = if (imageProxy != null) {
+                    val imageDisplay = if (ImageHostManager.getMode() == ImageHostManager.Mode.CUSTOM) {
+                        maskProxyUrl(imageProxy)
+                    } else {
+                        imageProxy
+                    }
                     TargetConfig(
                         imageProxy,
-                        Shaft.getContext().getString(R.string.network_test_target_sub_image_proxy, imageProxy),
+                        Shaft.getContext().getString(R.string.network_test_target_sub_image_proxy, imageDisplay),
                         null,
                         TargetKind.IMAGE,
                         plainHttp = imagePlainHttp,
+                        displayName = imageDisplay,
                     )
                 } else {
                     TargetConfig(
@@ -234,14 +309,10 @@ class NetworkTestViewModel : ViewModel() {
                         TargetKind.IMAGE,
                     )
                 }
-                imageTargetTitle = imageCfg.host
+                imageTargetTitle = imageCfg.displayName ?: imageCfg.host
+                val imageTitle = imageCfg.displayName ?: imageCfg.host
                 val configs = listOf(
-                    TargetConfig(
-                        APP_API_HOST,
-                        Shaft.getContext().getString(R.string.network_test_target_sub_app_api),
-                        PIXIV_CIDRS,
-                        TargetKind.APP_API,
-                    ),
+                    appApiCfg,
                     TargetConfig(
                         "www.pixiv.net",
                         Shaft.getContext().getString(R.string.network_test_target_sub_web),
@@ -259,11 +330,37 @@ class NetworkTestViewModel : ViewModel() {
                 val polluted = mutableListOf<String>()
                 val bypassOk = mutableListOf<Boolean>()
                 for (cfg in configs) {
-                    val idx = addTarget(TargetReport(cfg.host, cfg.subtitle))
-                    val (isPolluted, hsOk) = testTarget(idx, cfg, doh, direct)
-                    if (isPolluted) {
-                        polluted.add(cfg.host)
-                        bypassOk.add(hsOk)
+                    val idx = addTarget(TargetReport(cfg.displayName ?: cfg.host, cfg.subtitle))
+                    // Debug 模式允许 http PxveAPI：不测 HTTPS 握手，直接验证两条转发路径。
+                    val plainHttpProxy = cfg.kind == TargetKind.APP_API &&
+                        BuildConfig.IS_DEBUG_MODE &&
+                        cfg.rootUrl?.startsWith("http://", ignoreCase = true) == true
+                    if (plainHttpProxy) {
+                        log("PxveAPI 为 http（Debug），跳过 HTTPS 握手，只测转发路径")
+                        addStep(
+                            idx,
+                            TestStep(
+                                strRes(R.string.network_test_pxve_http_skip),
+                                strRes(R.string.network_test_pxve_http_skip_detail),
+                                StepStatus.INFO,
+                            ),
+                        )
+                        probePxveEndpoints(idx, cfg, direct)
+                        // http 代理没有握手步骤可判定状态；两条转发路径都通过时置为 OK。
+                        if (work[idx].status == TargetStatus.RUNNING) {
+                            setStatus(idx, TargetStatus.OK)
+                        }
+                    } else {
+                        val (isPolluted, hsOk) = testTarget(idx, cfg, doh, direct)
+                        // PxveAPI 代理开启时，额外验证 /pixiv-app-api 与 /pixiv-oauth 转发路径
+                        // 有正确响应（握手成功后才做；握手失败时卡片已 FAILED，无需重复报错）。
+                        if (cfg.kind == TargetKind.APP_API && cfg.rootUrl != null && hsOk) {
+                            probePxveEndpoints(idx, cfg, direct)
+                        }
+                        if (isPolluted) {
+                            polluted.add(cfg.host)
+                            bypassOk.add(hsOk)
+                        }
                     }
                     // 退出页面：每个目标测完检查一次取消，提前收尾、不再测下一个
                     // （阻塞段内取消不了，段间放行；onCleared 已 cancel 在途 Call 加速中断）。
@@ -287,17 +384,18 @@ class NetworkTestViewModel : ViewModel() {
                 val anyExtremeLatency = work.any { it.status == TargetStatus.EXTREME_LATENCY } ||
                     imageDownloadLatency == TargetStatus.EXTREME_LATENCY
                 val anyDegraded = work.any { it.status == TargetStatus.DEGRADED } || imageDownloadFailed
-                // app-api 是 app 的主 API：它失败（握手失败 / 污染且未绕过）＝网络不可用，
+                // app-api 是 app 的主 API（PxveAPI 开启时即代理目标）：它失败（握手失败 /
+                // 污染且未绕过 / 代理转发路径异常）＝网络不可用，
                 // 总览必须是红底「网络不可用」，且绝不能报「网络勉强可用」。
                 val appApiFailed = work.any {
-                    it.title == APP_API_HOST &&
+                    it.title == appApiTitle &&
                         (it.status == TargetStatus.FAILED || it.status == TargetStatus.POLLUTED)
                 }
                 // 图片服务器（官方 i.pximg.net 或当前反代域名）失败：卡片 pill 覆盖为红底
                 // 「图片无法加载」，顶部总览并列红底 pill，小字追加换图片代理的提示。
                 // 局部变量用 imageFailed，避免与成员属性 imageTargetFailed 重名遮蔽。
                 val imageFailed = work.any {
-                    it.title == imageCfg.host &&
+                    it.title == imageTitle &&
                         (it.status == TargetStatus.FAILED || it.status == TargetStatus.POLLUTED)
                 }
                 imageTargetFailed.postValue(imageFailed)
@@ -316,8 +414,8 @@ class NetworkTestViewModel : ViewModel() {
                     it.status == TargetStatus.HIGH_LATENCY || it.status == TargetStatus.EXTREME_LATENCY
                 }.map { it.title }
                 // 图片下载卡的延迟同样归到「图片代理慢」，小字给换图片代理的建议。
-                val imageHighLatency = latencyHosts.contains(imageCfg.host) || imageDownloadLatency != null
-                val otherHighLatency = latencyHosts.any { it != imageCfg.host }
+                val imageHighLatency = latencyHosts.contains(imageTitle) || imageDownloadLatency != null
+                val otherHighLatency = latencyHosts.any { it != imageTitle }
                 val ov = when {
                     appApiFailed -> OverallStatus.NETWORK_DOWN
                     polluted.isNotEmpty() -> OverallStatus.POLLUTED
@@ -331,8 +429,13 @@ class NetworkTestViewModel : ViewModel() {
                 val imageHint = ctx.getString(R.string.network_test_high_latency_sub_image)
                 val subText: String? = when {
                     ov == OverallStatus.NETWORK_DOWN -> {
-                        // 主 API 失败：小字说明主 API 不可达；图片服务器也失败时再追加换代理提示。
-                        var base = ctx.getString(R.string.network_test_overall_unavailable_sub)
+                        // 主 API 失败：小字说明主 API 不可达；PxveAPI 开启时指向代理地址；
+                        // 图片服务器也失败时再追加换代理提示。
+                        var base = if (appApiCfg.rootUrl != null) {
+                            ctx.getString(R.string.network_test_overall_unavailable_sub_proxy, maskProxyUrl(appApiCfg.rootUrl))
+                        } else {
+                            ctx.getString(R.string.network_test_overall_unavailable_sub)
+                        }
                         if (imageFailed) base += "\n$imageHint"
                         base
                     }
@@ -386,7 +489,7 @@ class NetworkTestViewModel : ViewModel() {
                 }
                 overallSub.postValue(subText)
                 // 图片服务器失败：卡片 pill 覆盖为红底「图片无法加载」（颜色仍按 FAILED/POLLUTED 取红）。
-                val imageIdx = work.indexOfFirst { it.title == imageCfg.host }
+                val imageIdx = work.indexOfFirst { it.title == imageTitle }
                 if (imageIdx >= 0 && imageFailed) {
                     work[imageIdx] = work[imageIdx].copy(
                         statusPillOverride = ctx.getString(R.string.network_test_image_unavailable),
@@ -425,7 +528,7 @@ class NetworkTestViewModel : ViewModel() {
 
     /** @return (该目标本机 DNS 是否被判定为污染, 污染时握手是否成功——决定绕过是否生效)。 */
     private fun testTarget(idx: Int, cfg: TargetConfig, doh: Boolean, direct: Boolean): Pair<Boolean, Boolean> {
-        log("========== ${cfg.host} ==========")
+        log("========== ${cfg.displayName ?: cfg.host} ==========")
 
         // http 反代：握手客户端只走 HTTPS，无法代表明文反代（且 host 常带非 443 端口），
         // 直接跳过连通性 / 握手，卡片判定由 runImageDownloadPhase 以真实下载结果回写。
@@ -969,6 +1072,109 @@ class NetworkTestViewModel : ViewModel() {
         return ok
     }
 
+    // ---- PxveAPI 代理转发路径探测（仅开启代理时） ----
+
+    /**
+     * PxveAPI 代理开启时，验证代理的 /pixiv-app-api 与 /pixiv-oauth 两条转发路径有正确响应。
+     * 路径约定来自 [AppApiProxyInterceptor]：app-api → /pixiv-app-api，oauth → /pixiv-oauth。
+     * 用真实子路径请求（而不是只打前缀）避免 Hono 通配路由对裸前缀返回 404 的误报。
+     * 判定：200..499 且非 404 视为链路通（400/401/403 是无凭证时 Pixiv 的预期响应）；
+     * 404 / 5xx / 连接失败视为代理异常，并把该目标置为失败。
+     * Debug 模式允许 http 代理：此时不测 HTTPS 握手，客户端也退回标准 HTTP，不走 Cronet。
+     */
+    private fun probePxveEndpoints(idx: Int, cfg: TargetConfig, direct: Boolean) {
+        val root = cfg.rootUrl ?: return
+        val plainHttp = root.startsWith("http://", ignoreCase = true)
+        val appStepIdx = work[idx].steps.size
+        addStep(
+            idx,
+            TestStep(strRes(R.string.network_test_pxve_app_api_step), strRes(R.string.network_test_requesting), StepStatus.RUNNING),
+        )
+        val oauthStepIdx = work[idx].steps.size
+        addStep(
+            idx,
+            TestStep(strRes(R.string.network_test_pxve_oauth_step), strRes(R.string.network_test_requesting), StepStatus.RUNNING),
+        )
+
+        var client: OkHttpClient? = null
+        try {
+            // http 代理只做明文请求验证，不套 Cronet/QUIC；https 代理继续复刻真实握手客户端。
+            client = buildHandshakeClient(cfg, null, if (plainHttp) false else direct, pin = false)
+            val appOk = runPxveRequest(
+                idx,
+                appStepIdx,
+                client,
+                "$root/pixiv-app-api/v1/illust/ranking?mode=day",
+                R.string.network_test_pxve_app_api_path,
+            )
+            val oauthOk = runPxveRequest(
+                idx,
+                oauthStepIdx,
+                client,
+                "$root/pixiv-oauth/auth/token",
+                R.string.network_test_pxve_oauth_path,
+                method = "POST",
+            )
+            if (!appOk || !oauthOk) {
+                setStatus(idx, TargetStatus.FAILED)
+            }
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            val msg = e.javaClass.simpleName + (e.message?.let { ": $it" } ?: "")
+            updateStep(idx, appStepIdx, strRes(R.string.network_test_pxve_failed, msg), StepStatus.FAIL)
+            updateStep(idx, oauthStepIdx, strRes(R.string.network_test_pxve_failed, msg), StepStatus.FAIL)
+            log("PxveAPI 转发探测异常终止: $msg")
+            setStatus(idx, TargetStatus.FAILED)
+        } finally {
+            client?.let {
+                activeClients.remove(it)
+                it.connectionPool.evictAll()
+                it.dispatcher.executorService.shutdown()
+            }
+        }
+    }
+
+    private fun runPxveRequest(
+        idx: Int,
+        stepIdx: Int,
+        client: OkHttpClient,
+        url: String,
+        pathLabelRes: Int,
+        method: String = "GET",
+    ): Boolean {
+        val t0 = System.currentTimeMillis()
+        try {
+            val requestBuilder = Request.Builder().url(url)
+            // /pixiv-oauth/auth/token 的真实语义是 POST；用 GET 会被部分后端直接 404，造成误报。
+            if (method == "POST") {
+                requestBuilder.post(ByteArray(0).toRequestBody())
+            } else {
+                requestBuilder.get()
+            }
+            client.newCall(requestBuilder.build()).execute().use { resp ->
+                val ms = System.currentTimeMillis() - t0
+                val code = resp.code
+                val ok = code in 200..499 && code != 404
+                val detail = when {
+                    code == 404 -> strRes(R.string.network_test_pxve_not_found, ms, code, strRes(pathLabelRes))
+                    code in 200..299 -> strRes(R.string.network_test_pxve_ok_2xx, ms, code)
+                    code == 400 || code == 401 || code == 403 -> strRes(R.string.network_test_pxve_ok_auth, ms, code)
+                    ok -> strRes(R.string.network_test_pxve_ok_other, ms, code)
+                    else -> strRes(R.string.network_test_pxve_fail_status, ms, code)
+                }
+                updateStep(idx, stepIdx, detail, if (ok) StepStatus.OK else StepStatus.FAIL)
+                log("PxveAPI ${strRes(pathLabelRes)}: $method HTTP $code · ${ms}ms")
+                return ok
+            }
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            val msg = e.javaClass.simpleName + (e.message?.let { ": $it" } ?: "")
+            updateStep(idx, stepIdx, strRes(R.string.network_test_pxve_failed, msg), StepStatus.FAIL)
+            log("PxveAPI ${strRes(pathLabelRes)} 连接失败: $msg")
+            return false
+        }
+    }
+
     // ---- 图片下载探测（插画 + 头像，联动图片加载代理）----
 
     /**
@@ -1160,6 +1366,8 @@ class NetworkTestViewModel : ViewModel() {
      *  @return (步骤, 是否下载缓慢)。 */
     private fun downloadImageStep(label: String, rawUrl: String, judgeSpeed: Boolean = true): Pair<TestStep, Boolean> {
         val realUrl = ImageHostManager.rewrite(rawUrl)
+        val customImageProxy = ImageHostManager.getMode() == ImageHostManager.Mode.CUSTOM
+        val displayRealUrl = if (customImageProxy) maskProxyUrl(realUrl) else realUrl
         val client = buildImageDownloadClient()
         val t0 = System.currentTimeMillis()
         var result: Pair<TestStep, Boolean>
@@ -1193,6 +1401,7 @@ class NetworkTestViewModel : ViewModel() {
                     val speedKBs = if (transferMs > 0) data.size * 1000L / transferMs / 1024 else -1L
                     val speedTxt = if (speedKBs >= 0) "${speedKBs}KB/s" else "-"
                     val host = realUrl.substringAfter("://").substringBefore('/')
+                    val displayHost = if (customImageProxy) maskProxyUrl(host) else host
                     val ok = code in 200..299 && format != null
 
                     // 「下载缓慢」按吞吐判，不按绝对毫秒：样例插画只有 ~39KB，新建连接的
@@ -1214,7 +1423,7 @@ class NetworkTestViewModel : ViewModel() {
                     val tagTxt = if (tags.isNotEmpty()) " · " + tags.joinToString(" · ") else ""
                     log(
                         "$label: HTTP $code · ${data.size}B · TTFB ${ttfb}ms · 传输 ${transferMs}ms · $speedTxt · $format$tagTxt · " +
-                            "$rawUrl -> $realUrl",
+                            "$rawUrl -> $displayRealUrl",
                     )
                     val st = when {
                         !ok -> StepStatus.FAIL
@@ -1224,13 +1433,13 @@ class NetworkTestViewModel : ViewModel() {
                         else -> StepStatus.OK
                     }
                     val detail = if (ok) {
-                        strRes(R.string.network_test_dl_detail_ok, code, sizeTxt, ttfb, transferMs, speedTxt, format, tagTxt, host)
+                        strRes(R.string.network_test_dl_detail_ok, code, sizeTxt, ttfb, transferMs, speedTxt, format, tagTxt, displayHost)
                     } else {
                         strRes(
                             R.string.network_test_dl_detail_fail,
                             code, sizeTxt, ms,
                             if (format != null) " · $format" else "",
-                            host,
+                            displayHost,
                         )
                     }
                     TestStep(label, detail, st) to slow
@@ -1356,7 +1565,7 @@ class NetworkTestViewModel : ViewModel() {
         ImageHostManager.Mode.PIXIV_NL -> strRes(R.string.network_test_route_nl)
         ImageHostManager.Mode.CUSTOM -> {
             val host = ImageHostManager.getCustomHost()
-            if (host.isEmpty()) strRes(R.string.network_test_route_custom_none) else strRes(R.string.network_test_route_custom, host)
+            if (host.isEmpty()) strRes(R.string.network_test_route_custom_none) else strRes(R.string.network_test_route_custom, maskProxyUrl(host))
         }
     }
 

--- a/app/src/main/java/ceui/pixiv/ui/debug/NetworkTestViewModel.kt
+++ b/app/src/main/java/ceui/pixiv/ui/debug/NetworkTestViewModel.kt
@@ -47,10 +47,16 @@ import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
+/** 点分四段 IPv4 前缀（可后接 :port / 路径），用于把 IP 按「段」而不是按字符数脱敏。 */
+private val IPV4_PREFIX = Regex("""^(\d{1,3})\.(\d{1,3})\.\d{1,3}\.\d{1,3}""")
+
 /**
- * 代理地址脱敏：保留 scheme 和地址开头少量字符，后面统一替换为 ***。
+ * 代理地址脱敏：保留 scheme 和地址开头少量信息，后面统一替换为 ***。
  * 用于 PxveAPI 地址与自定义图片反代在 UI / 原始日志中的展示，避免泄露他人私有地址。
  * 例：https://your-proxy.domain → https://your***；https://192.168.10.109:3021 → https://192.168***
+ *
+ * IPv4 按**段**截断（保留前两段）而不是按字符数：按字符数截会随 IP 变短而越露越多，
+ * 极端情况（https://1.2.3.4:8080）能把整个公网 IP 原样漏出来，正好背离脱敏的目的。
  */
 internal fun maskProxyUrl(url: String): String {
     val trimmed = url.trim()
@@ -60,9 +66,14 @@ internal fun maskProxyUrl(url: String): String {
         else -> ""
     }
     val rest = if (scheme.isEmpty()) trimmed else trimmed.substring(scheme.length)
-    // IP 地址多留一点（保留前两段 192.168），域名保留前 4 个字符。
-    val visibleLen = if (rest.firstOrNull()?.isDigit() == true) 7 else 4
-    val visible = rest.take(visibleLen)
+    val ipv4 = IPV4_PREFIX.find(rest)
+    val visible = if (ipv4 != null) {
+        // IP：保留前两段（192.168 / 10.0），后两段与端口一律隐藏。
+        "${ipv4.groupValues[1]}.${ipv4.groupValues[2]}"
+    } else {
+        // 域名（含 IPv6 字面量）：保留前 4 个字符。
+        rest.take(4)
+    }
     return "$scheme$visible***"
 }
 
@@ -1082,7 +1093,10 @@ class NetworkTestViewModel : ViewModel() {
 
     /**
      * PxveAPI 代理开启时，验证代理的 /pixiv-app-api 与 /pixiv-oauth 两条转发路径有正确响应。
-     * 路径约定来自 [AppApiProxyInterceptor]：app-api → /pixiv-app-api，oauth → /pixiv-oauth。
+     * 探测 URL 一律由 [AppApiProxyInterceptor.rewrite] 生成 —— 和生产请求同一套拼接逻辑，
+     * 自己手拼 `root + "/pixiv-app-api"` 会绕开它的双前缀去重：用户把根地址按
+     * 「误填完整 PxveAPI 地址」的形态填成 https://proxy/pixiv-app-api（拦截器专门兼容、有单测
+     * 覆盖）时，手拼会多出一层前缀打成 404，把一个实际能用的配置诬告成代理异常。
      * 用真实子路径请求（而不是只打前缀）避免 Hono 通配路由对裸前缀返回 404 的误报。
      * 判定：200..499 且非 404 视为链路通（400/401/403 是无凭证时 Pixiv 的预期响应）；
      * 404 / 5xx / 连接失败视为代理异常，并把该目标置为失败。
@@ -1110,14 +1124,14 @@ class NetworkTestViewModel : ViewModel() {
                 idx,
                 appStepIdx,
                 client,
-                "$root/pixiv-app-api/v1/illust/ranking?mode=day",
+                AppApiProxyInterceptor.rewrite(APP_API_PROBE_URL.toHttpUrl(), root),
                 R.string.network_test_pxve_app_api_path,
             )
             val oauthOk = runPxveRequest(
                 idx,
                 oauthStepIdx,
                 client,
-                "$root/pixiv-oauth/auth/token",
+                AppApiProxyInterceptor.rewrite(OAUTH_PROBE_URL.toHttpUrl(), root),
                 R.string.network_test_pxve_oauth_path,
                 method = "POST",
             )
@@ -1144,10 +1158,16 @@ class NetworkTestViewModel : ViewModel() {
         idx: Int,
         stepIdx: Int,
         client: OkHttpClient,
-        url: String,
+        url: HttpUrl?,
         pathLabelRes: Int,
         method: String = "GET",
     ): Boolean {
+        if (url == null) {
+            // root 来自 normalizeBase，正常不可能拼不出来；真拼不出来就是地址非法，如实报错。
+            updateStep(idx, stepIdx, strRes(R.string.network_test_pxve_failed, "invalid proxy url"), StepStatus.FAIL)
+            log("PxveAPI ${strRes(pathLabelRes)}: 代理地址非法，无法拼出探测 URL")
+            return false
+        }
         val t0 = System.currentTimeMillis()
         try {
             val requestBuilder = Request.Builder().url(url)
@@ -1796,6 +1816,10 @@ class NetworkTestViewModel : ViewModel() {
     companion object {
         /** app 主 API 域名：它失败即总览判「网络不可用」，且否决「网络勉强可用」。 */
         private const val APP_API_HOST = "app-api.pixiv.net"
+
+        /** 转发路径探测用的原始 pixiv URL：交给 [AppApiProxyInterceptor.rewrite] 改写成代理地址。 */
+        private const val APP_API_PROBE_URL = "https://app-api.pixiv.net/v1/illust/ranking?mode=day"
+        private const val OAUTH_PROBE_URL = "https://oauth.secure.pixiv.net/auth/token"
 
         // 代理 fake-ip 模式返回的占位段：不可路由，命中即说明 DNS 被代理接管，测连通无意义。
         private val FAKE_IP_CIDRS = listOf(

--- a/app/src/main/res/layout/fragment_network_perf_test.xml
+++ b/app/src/main/res/layout/fragment_network_perf_test.xml
@@ -96,6 +96,18 @@
                     tools:text="直连关" />
 
                 <TextView
+                    android:id="@+id/chip_proxy"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:layout_marginEnd="8dp"
+                    android:paddingHorizontal="12dp"
+                    android:paddingVertical="6dp"
+                    android:textSize="12sp"
+                    android:textStyle="bold"
+                    tools:text="使用PxveAPI · https://pxve.example.com" />
+
+                <TextView
                     android:id="@+id/chip_host"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1999,6 +1999,8 @@
     <string name="network_test_env_doh_off">Secure DNS off</string>
     <string name="network_test_env_direct_on">Direct connection on</string>
     <string name="network_test_env_direct_off">Direct connection off</string>
+    <string name="network_test_env_proxy_on">Use PxveAPI · %1$s</string>
+    <string name="network_test_env_proxy_off">Use PxveAPI · off</string>
     <string name="network_test_empty_hint">Tap &quot;Start test&quot; below to run network diagnostics</string>
     <string name="network_test_section_targets">Connectivity diagnostics</string>
     <string name="network_test_section_illust">Artwork API probe</string>
@@ -2032,8 +2034,10 @@
     <string name="network_test_overall_polluted_bypass_sub">Local DNS is polluted, but bypassed via secure DNS/direct; handshake normal</string>
     <string name="network_test_overall_unavailable">Network unavailable</string>
     <string name="network_test_overall_unavailable_sub">Main API (app-api.pixiv.net) unreachable; core features unavailable</string>
+    <string name="network_test_overall_unavailable_sub_proxy">Main API (PxveAPI proxy %1$s) unreachable; core features unavailable</string>
     <string name="network_test_image_unavailable">Images cannot load</string>
     <string name="network_test_target_sub_app_api">pixiv API · Cloudflare CDN</string>
+    <string name="network_test_target_sub_app_api_proxy">PxveAPI proxy · %1$s</string>
     <string name="network_test_target_sub_web">Web endpoint · Cloudflare CDN</string>
     <string name="network_test_target_sub_image_official">Image server · Pixiv Japan</string>
     <string name="network_test_target_sub_image_proxy">Image server · proxy %1$s</string>
@@ -2095,6 +2099,18 @@
     <string name="network_test_web_ok">HTTP %1$d · %2$dms · artwork #%3$d returned image URL</string>
     <string name="network_test_web_degraded">HTTP %1$d · error=%2$s · no image URL returned</string>
     <string name="network_test_web_failed">Request failed: %1$s</string>
+    <string name="network_test_pxve_app_api_step">PxveAPI forward · /pixiv-app-api</string>
+    <string name="network_test_pxve_oauth_step">PxveAPI forward · /pixiv-oauth</string>
+    <string name="network_test_pxve_http_skip">Skip HTTPS handshake</string>
+    <string name="network_test_pxve_http_skip_detail">Debug builds allow HTTP proxies; only /pixiv-app-api and /pixiv-oauth forwarding responses are checked</string>
+    <string name="network_test_pxve_app_api_path">/pixiv-app-api</string>
+    <string name="network_test_pxve_oauth_path">/pixiv-oauth</string>
+    <string name="network_test_pxve_ok_2xx">Reachable · %1$dms · HTTP %2$d (normal)</string>
+    <string name="network_test_pxve_ok_auth">Reachable · %1$dms · HTTP %2$d (expected without credentials; forwarding path works)</string>
+    <string name="network_test_pxve_ok_other">Reachable · %1$dms · HTTP %2$d</string>
+    <string name="network_test_pxve_fail_status">Abnormal · %1$dms · HTTP %2$d</string>
+    <string name="network_test_pxve_not_found">Unreachable · %1$dms · HTTP %2$d (proxy does not forward %3$s path)</string>
+    <string name="network_test_pxve_failed">Connection failed: %1$s</string>
     <string name="network_test_dl_title">Image download probe</string>
     <string name="network_test_dl_sub">Sample artwork #%1$d · illustration + avatar</string>
     <string name="network_test_fetching">Fetching…</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1999,6 +1999,8 @@
     <string name="network_test_env_doh_off">セキュア DNS オフ</string>
     <string name="network_test_env_direct_on">直接接続オン</string>
     <string name="network_test_env_direct_off">直接接続オフ</string>
+    <string name="network_test_env_proxy_on">PxveAPI 使用中 · %1$s</string>
+    <string name="network_test_env_proxy_off">PxveAPI オフ</string>
     <string name="network_test_empty_hint">下の「テスト開始」をタップしてネットワーク診断を実行</string>
     <string name="network_test_section_targets">接続診断</string>
     <string name="network_test_section_illust">作品 API テスト</string>
@@ -2032,8 +2034,10 @@
     <string name="network_test_overall_polluted_bypass_sub">DNS 汚染を検出しましたが、セキュア DNS/直続で迂回済み、ハンドシェイクは正常です</string>
     <string name="network_test_overall_unavailable">ネットワークが利用できません</string>
     <string name="network_test_overall_unavailable_sub">メイン API（app-api.pixiv.net）に到達できません。主要機能が利用できません</string>
+    <string name="network_test_overall_unavailable_sub_proxy">メイン API（PxveAPI プロキシ %1$s）に到達できません。主要機能が利用できません</string>
     <string name="network_test_image_unavailable">画像を読み込めません</string>
     <string name="network_test_target_sub_app_api">pixiv API · Cloudflare CDN</string>
+    <string name="network_test_target_sub_app_api_proxy">PxveAPI プロキシ · %1$s</string>
     <string name="network_test_target_sub_web">Web エンドポイント · Cloudflare CDN</string>
     <string name="network_test_target_sub_image_official">画像サーバー · Pixiv Japan</string>
     <string name="network_test_target_sub_image_proxy">画像サーバー · プロキシ %1$s</string>
@@ -2095,6 +2099,18 @@
     <string name="network_test_web_ok">HTTP %1$d · %2$dms · 作品 #%3$d の画像 URL を取得</string>
     <string name="network_test_web_degraded">HTTP %1$d · error=%2$s · 画像 URL を取得できませんでした</string>
     <string name="network_test_web_failed">リクエスト失敗: %1$s</string>
+    <string name="network_test_pxve_app_api_step">PxveAPI 転送 · /pixiv-app-api</string>
+    <string name="network_test_pxve_oauth_step">PxveAPI 転送 · /pixiv-oauth</string>
+    <string name="network_test_pxve_http_skip">HTTPS ハンドシェイクをスキップ</string>
+    <string name="network_test_pxve_http_skip_detail">Debug ビルドでは HTTP プロキシを許可します。/pixiv-app-api と /pixiv-oauth の転送応答のみ検証します</string>
+    <string name="network_test_pxve_app_api_path">/pixiv-app-api</string>
+    <string name="network_test_pxve_oauth_path">/pixiv-oauth</string>
+    <string name="network_test_pxve_ok_2xx">到達可能 · %1$dms · HTTP %2$d（正常）</string>
+    <string name="network_test_pxve_ok_auth">到達可能 · %1$dms · HTTP %2$d（認証情報なしの想定応答、転送経路は正常）</string>
+    <string name="network_test_pxve_ok_other">到達可能 · %1$dms · HTTP %2$d</string>
+    <string name="network_test_pxve_fail_status">異常 · %1$dms · HTTP %2$d</string>
+    <string name="network_test_pxve_not_found">到達不可 · %1$dms · HTTP %2$d（プロキシが %3$s パスを転送していません）</string>
+    <string name="network_test_pxve_failed">接続失敗: %1$s</string>
     <string name="network_test_dl_title">画像ダウンロード検証</string>
     <string name="network_test_dl_sub">サンプル作品 #%1$d · イラスト + アバター</string>
     <string name="network_test_fetching">取得中…</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1999,6 +1999,8 @@
     <string name="network_test_env_doh_off">보안 DNS 꺼짐</string>
     <string name="network_test_env_direct_on">직접 연결 켜짐</string>
     <string name="network_test_env_direct_off">직접 연결 꺼짐</string>
+    <string name="network_test_env_proxy_on">PxveAPI 사용 중 · %1$s</string>
+    <string name="network_test_env_proxy_off">PxveAPI 꺼짐</string>
     <string name="network_test_empty_hint">아래의 &quot;테스트 시작&quot;을 눌러 네트워크 진단을 실행하세요</string>
     <string name="network_test_section_targets">연결 진단</string>
     <string name="network_test_section_illust">작품 API 테스트</string>
@@ -2032,8 +2034,10 @@
     <string name="network_test_overall_polluted_bypass_sub">로컬 DNS가 오염되었지만 보안 DNS/직접 연결로 우회되었고, 핸드셰이크는 정상입니다</string>
     <string name="network_test_overall_unavailable">네트워크 사용 불가</string>
     <string name="network_test_overall_unavailable_sub">메인 API(app-api.pixiv.net)에 연결할 수 없어 주요 기능을 사용할 수 없습니다</string>
+    <string name="network_test_overall_unavailable_sub_proxy">메인 API(PxveAPI 프록시 %1$s)에 연결할 수 없어 주요 기능을 사용할 수 없습니다</string>
     <string name="network_test_image_unavailable">이미지를 불러올 수 없음</string>
     <string name="network_test_target_sub_app_api">pixiv API · Cloudflare CDN</string>
+    <string name="network_test_target_sub_app_api_proxy">PxveAPI 프록시 · %1$s</string>
     <string name="network_test_target_sub_web">웹 엔드포인트 · Cloudflare CDN</string>
     <string name="network_test_target_sub_image_official">이미지 서버 · Pixiv Japan</string>
     <string name="network_test_target_sub_image_proxy">이미지 서버 · 프록시 %1$s</string>
@@ -2095,6 +2099,18 @@
     <string name="network_test_web_ok">HTTP %1$d · %2$dms · 작품 #%3$d 이미지 URL 반환</string>
     <string name="network_test_web_degraded">HTTP %1$d · error=%2$s · 이미지 URL을 받지 못함</string>
     <string name="network_test_web_failed">요청 실패: %1$s</string>
+    <string name="network_test_pxve_app_api_step">PxveAPI 전달 · /pixiv-app-api</string>
+    <string name="network_test_pxve_oauth_step">PxveAPI 전달 · /pixiv-oauth</string>
+    <string name="network_test_pxve_http_skip">HTTPS 핸드셰이크 건너뜀</string>
+    <string name="network_test_pxve_http_skip_detail">Debug 빌드에서는 HTTP 프록시를 허용합니다. /pixiv-app-api 및 /pixiv-oauth 전달 응답만 확인합니다</string>
+    <string name="network_test_pxve_app_api_path">/pixiv-app-api</string>
+    <string name="network_test_pxve_oauth_path">/pixiv-oauth</string>
+    <string name="network_test_pxve_ok_2xx">연결 가능 · %1$dms · HTTP %2$d (정상)</string>
+    <string name="network_test_pxve_ok_auth">연결 가능 · %1$dms · HTTP %2$d (자격 증명 없음 시 예상 응답, 전달 경로 정상)</string>
+    <string name="network_test_pxve_ok_other">연결 가능 · %1$dms · HTTP %2$d</string>
+    <string name="network_test_pxve_fail_status">이상 · %1$dms · HTTP %2$d</string>
+    <string name="network_test_pxve_not_found">연결 불가 · %1$dms · HTTP %2$d (프록시가 %3$s 경로를 전달하지 않음)</string>
+    <string name="network_test_pxve_failed">연결 실패: %1$s</string>
     <string name="network_test_dl_title">이미지 다운로드 검사</string>
     <string name="network_test_dl_sub">샘플 작품 #%1$d · 일러스트 + 아바타</string>
     <string name="network_test_fetching">가져오는 중…</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1999,6 +1999,8 @@
     <string name="network_test_env_doh_off">Безопасный DNS выключен</string>
     <string name="network_test_env_direct_on">Прямое соединение включено</string>
     <string name="network_test_env_direct_off">Прямое соединение выключено</string>
+    <string name="network_test_env_proxy_on">Используется PxveAPI · %1$s</string>
+    <string name="network_test_env_proxy_off">PxveAPI выкл</string>
     <string name="network_test_empty_hint">Нажмите ниже «Начать тест», чтобы запустить диагностику сети</string>
     <string name="network_test_section_targets">Диагностика подключения</string>
     <string name="network_test_section_illust">Проверка API работ</string>
@@ -2032,8 +2034,10 @@
     <string name="network_test_overall_polluted_bypass_sub">Локальный DNS подменён, но обход через защищённый DNS/прямое подключение сработал; рукопожатие в норме</string>
     <string name="network_test_overall_unavailable">Сеть недоступна</string>
     <string name="network_test_overall_unavailable_sub">Основной API (app-api.pixiv.net) недоступен; основные функции не работают</string>
+    <string name="network_test_overall_unavailable_sub_proxy">Основной API (прокси PxveAPI %1$s) недоступен; основные функции не работают</string>
     <string name="network_test_image_unavailable">Изображения не загружаются</string>
     <string name="network_test_target_sub_app_api">pixiv API · Cloudflare CDN</string>
+    <string name="network_test_target_sub_app_api_proxy">Прокси PxveAPI · %1$s</string>
     <string name="network_test_target_sub_web">Веб-эндпоинт · Cloudflare CDN</string>
     <string name="network_test_target_sub_image_official">Сервер изображений · Pixiv Japan</string>
     <string name="network_test_target_sub_image_proxy">Сервер изображений · прокси %1$s</string>
@@ -2095,6 +2099,18 @@
     <string name="network_test_web_ok">HTTP %1$d · %2$dms · работа #%3$d вернула URL изображения</string>
     <string name="network_test_web_degraded">HTTP %1$d · error=%2$s · URL изображения не получен</string>
     <string name="network_test_web_failed">Ошибка запроса: %1$s</string>
+    <string name="network_test_pxve_app_api_step">Передача PxveAPI · /pixiv-app-api</string>
+    <string name="network_test_pxve_oauth_step">Передача PxveAPI · /pixiv-oauth</string>
+    <string name="network_test_pxve_http_skip">Пропуск HTTPS-рукопожатия</string>
+    <string name="network_test_pxve_http_skip_detail">В Debug-сборках разрешён HTTP-прокси; проверяются только ответы пересылки /pixiv-app-api и /pixiv-oauth</string>
+    <string name="network_test_pxve_app_api_path">/pixiv-app-api</string>
+    <string name="network_test_pxve_oauth_path">/pixiv-oauth</string>
+    <string name="network_test_pxve_ok_2xx">Доступно · %1$dмс · HTTP %2$d (нормально)</string>
+    <string name="network_test_pxve_ok_auth">Доступно · %1$dмс · HTTP %2$d (ожидаемо без учётных данных, цепочка пересылки работает)</string>
+    <string name="network_test_pxve_ok_other">Доступно · %1$dмс · HTTP %2$d</string>
+    <string name="network_test_pxve_fail_status">Ошибка · %1$dмс · HTTP %2$d</string>
+    <string name="network_test_pxve_not_found">Недоступно · %1$dмс · HTTP %2$d (прокси не пересылает путь %3$s)</string>
+    <string name="network_test_pxve_failed">Ошибка подключения: %1$s</string>
     <string name="network_test_dl_title">Проверка загрузки изображений</string>
     <string name="network_test_dl_sub">Пример работы #%1$d · иллюстрация + аватар</string>
     <string name="network_test_fetching">Получение…</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1999,6 +1999,8 @@
     <string name="network_test_env_doh_off">Güvenli DNS kapalı</string>
     <string name="network_test_env_direct_on">Doğrudan bağlantı açık</string>
     <string name="network_test_env_direct_off">Doğrudan bağlantı kapalı</string>
+    <string name="network_test_env_proxy_on">PxveAPI kullanılıyor · %1$s</string>
+    <string name="network_test_env_proxy_off">PxveAPI kapalı</string>
     <string name="network_test_empty_hint">Ağ tanısını başlatmak için aşağıdaki &quot;Testi başlat&quot;a dokunun</string>
     <string name="network_test_section_targets">Bağlantı tanısı</string>
     <string name="network_test_section_illust">Eser API testi</string>
@@ -2032,8 +2034,10 @@
     <string name="network_test_overall_polluted_bypass_sub">Yerel DNS kirli, ancak güvenli DNS/doğrudan bağlantı ile atlandı; el sıkışma normal</string>
     <string name="network_test_overall_unavailable">Ağ kullanılamıyor</string>
     <string name="network_test_overall_unavailable_sub">Ana API (app-api.pixiv.net) erişilemez; temel özellikler çalışmıyor</string>
+    <string name="network_test_overall_unavailable_sub_proxy">Ana API (PxveAPI proxy %1$s) erişilemez; temel özellikler çalışmıyor</string>
     <string name="network_test_image_unavailable">Görseller yüklenemiyor</string>
     <string name="network_test_target_sub_app_api">pixiv API · Cloudflare CDN</string>
+    <string name="network_test_target_sub_app_api_proxy">PxveAPI proxy · %1$s</string>
     <string name="network_test_target_sub_web">Web uç noktası · Cloudflare CDN</string>
     <string name="network_test_target_sub_image_official">Görsel sunucusu · Pixiv Japan</string>
     <string name="network_test_target_sub_image_proxy">Görsel sunucusu · proxy %1$s</string>
@@ -2095,6 +2099,18 @@
     <string name="network_test_web_ok">HTTP %1$d · %2$dms · #%3$d çalışması görsel URL\'si döndü</string>
     <string name="network_test_web_degraded">HTTP %1$d · error=%2$s · görsel URL alınamadı</string>
     <string name="network_test_web_failed">İstek başarısız: %1$s</string>
+    <string name="network_test_pxve_app_api_step">PxveAPI iletimi · /pixiv-app-api</string>
+    <string name="network_test_pxve_oauth_step">PxveAPI iletimi · /pixiv-oauth</string>
+    <string name="network_test_pxve_http_skip">HTTPS el sıkışması atlanıyor</string>
+    <string name="network_test_pxve_http_skip_detail">Debug derlemeleri HTTP proxy kullanabilir; yalnızca /pixiv-app-api ve /pixiv-oauth iletim yanıtları denetlenir</string>
+    <string name="network_test_pxve_app_api_path">/pixiv-app-api</string>
+    <string name="network_test_pxve_oauth_path">/pixiv-oauth</string>
+    <string name="network_test_pxve_ok_2xx">Ulaşılabilir · %1$dms · HTTP %2$d (normal)</string>
+    <string name="network_test_pxve_ok_auth">Ulaşılabilir · %1$dms · HTTP %2$d (kimlik bilgisi olmadan beklenen yanıt, iletim yolu çalışıyor)</string>
+    <string name="network_test_pxve_ok_other">Ulaşılabilir · %1$dms · HTTP %2$d</string>
+    <string name="network_test_pxve_fail_status">Anormal · %1$dms · HTTP %2$d</string>
+    <string name="network_test_pxve_not_found">Ulaşılamıyor · %1$dms · HTTP %2$d (proxy %3$s yolunu iletmiyor)</string>
+    <string name="network_test_pxve_failed">Bağlantı başarısız: %1$s</string>
     <string name="network_test_dl_title">Görsel indirme testi</string>
     <string name="network_test_dl_sub">Örnek çalışma #%1$d · illüstrasyon + avatar</string>
     <string name="network_test_fetching">Alınıyor…</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -2001,6 +2001,8 @@
     <string name="network_test_env_doh_off">安全 DNS 關</string>
     <string name="network_test_env_direct_on">直連開</string>
     <string name="network_test_env_direct_off">直連關</string>
+    <string name="network_test_env_proxy_on">使用PxveAPI · %1$s</string>
+    <string name="network_test_env_proxy_off">使用PxveAPI · 關</string>
     <string name="network_test_empty_hint">點擊下方「開始測試」以執行網路診斷</string>
     <string name="network_test_section_targets">連通性診斷</string>
     <string name="network_test_section_illust">作品 API 探測</string>
@@ -2034,8 +2036,10 @@
     <string name="network_test_overall_polluted_bypass_sub">本機 DNS 被污染，但已透過安全 DNS/直連繞過，握手正常</string>
     <string name="network_test_overall_unavailable">網路不可用</string>
     <string name="network_test_overall_unavailable_sub">主 API（app-api.pixiv.net）不可達，應用主要功能不可用</string>
+    <string name="network_test_overall_unavailable_sub_proxy">主 API（PxveAPI 代理 %1$s）不可達，應用主要功能不可用</string>
     <string name="network_test_image_unavailable">圖片無法載入</string>
     <string name="network_test_target_sub_app_api">pixiv API · Cloudflare CDN</string>
+    <string name="network_test_target_sub_app_api_proxy">PxveAPI 代理 · %1$s</string>
     <string name="network_test_target_sub_web">網頁端點 · Cloudflare CDN</string>
     <string name="network_test_target_sub_image_official">圖片伺服器 · Pixiv Japan</string>
     <string name="network_test_target_sub_image_proxy">圖片伺服器 · 反代 %1$s</string>
@@ -2097,6 +2101,18 @@
     <string name="network_test_web_ok">HTTP %1$d · %2$dms · 作品 #%3$d 已返回圖片位址</string>
     <string name="network_test_web_degraded">HTTP %1$d · error=%2$s · 未拿到圖片位址</string>
     <string name="network_test_web_failed">請求失敗: %1$s</string>
+    <string name="network_test_pxve_app_api_step">PxveAPI 轉發 · /pixiv-app-api</string>
+    <string name="network_test_pxve_oauth_step">PxveAPI 轉發 · /pixiv-oauth</string>
+    <string name="network_test_pxve_http_skip">跳過 HTTPS 握手</string>
+    <string name="network_test_pxve_http_skip_detail">Debug 模式允許 http 代理，僅驗證 /pixiv-app-api 與 /pixiv-oauth 轉發回應</string>
+    <string name="network_test_pxve_app_api_path">/pixiv-app-api</string>
+    <string name="network_test_pxve_oauth_path">/pixiv-oauth</string>
+    <string name="network_test_pxve_ok_2xx">可達 · %1$dms · HTTP %2$d（正常）</string>
+    <string name="network_test_pxve_ok_auth">可達 · %1$dms · HTTP %2$d（缺憑證的預期回應，轉發鏈路通）</string>
+    <string name="network_test_pxve_ok_other">可達 · %1$dms · HTTP %2$d</string>
+    <string name="network_test_pxve_fail_status">異常 · %1$dms · HTTP %2$d</string>
+    <string name="network_test_pxve_not_found">不可達 · %1$dms · HTTP %2$d（代理未轉發 %3$s 路徑）</string>
+    <string name="network_test_pxve_failed">連線失敗: %1$s</string>
     <string name="network_test_dl_title">圖片下載探測</string>
     <string name="network_test_dl_sub">範例作品 #%1$d · 插畫 + 頭像</string>
     <string name="network_test_fetching">取得中…</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2207,6 +2207,8 @@
     <string name="network_test_env_doh_off">安全 DNS 关</string>
     <string name="network_test_env_direct_on">直连开</string>
     <string name="network_test_env_direct_off">直连关</string>
+    <string name="network_test_env_proxy_on">使用PxveAPI · %1$s</string>
+    <string name="network_test_env_proxy_off">使用PxveAPI · 关</string>
     <string name="network_test_env_host_prefix">图片代理 · </string>
     <string name="network_test_empty_hint">点击下方「开始测试」运行网络诊断</string>
     <string name="network_test_section_targets">连通性诊断</string>
@@ -2236,6 +2238,7 @@
     <string name="network_test_overall_polluted_bypass_sub">本机 DNS 被污染，但已通过安全 DNS/直连绕过，握手正常</string>
     <string name="network_test_overall_unavailable">网络不可用</string>
     <string name="network_test_overall_unavailable_sub">主 API（app-api.pixiv.net）不可达，应用主要功能不可用</string>
+    <string name="network_test_overall_unavailable_sub_proxy">主 API（PxveAPI 代理 %1$s）不可达，应用主要功能不可用</string>
     <string name="network_test_image_unavailable">图片无法加载</string>
     <string name="network_test_pollution_dialog_title">⚠ 检测到 DNS 污染</string>
     <string name="network_test_fakeip_dialog_title">⚠️ 检测到假 IP</string>
@@ -2248,6 +2251,7 @@
 
     <!-- 目标卡副标题 -->
     <string name="network_test_target_sub_app_api">pixiv API · Cloudflare CDN</string>
+    <string name="network_test_target_sub_app_api_proxy">PxveAPI 代理 · %1$s</string>
     <string name="network_test_target_sub_web">网页端点 · Cloudflare CDN</string>
     <string name="network_test_target_sub_image_official">图片服务器 · Pixiv Japan</string>
     <string name="network_test_target_sub_image_proxy">图片服务器 · 反代 %1$s</string>
@@ -2323,6 +2327,20 @@
     <string name="network_test_web_ok">HTTP %1$d · %2$dms · 作品 #%3$d 已返回图片地址</string>
     <string name="network_test_web_degraded">HTTP %1$d · error=%2$s · 未拿到图片地址</string>
     <string name="network_test_web_failed">请求失败: %1$s</string>
+
+    <!-- PxveAPI 代理转发路径探测（仅开启 App API 代理时追加） -->
+    <string name="network_test_pxve_app_api_step">PxveAPI 转发 · /pixiv-app-api</string>
+    <string name="network_test_pxve_oauth_step">PxveAPI 转发 · /pixiv-oauth</string>
+    <string name="network_test_pxve_http_skip">跳过 HTTPS 握手</string>
+    <string name="network_test_pxve_http_skip_detail">Debug 模式允许 http 代理，仅验证 /pixiv-app-api 与 /pixiv-oauth 转发响应</string>
+    <string name="network_test_pxve_app_api_path">/pixiv-app-api</string>
+    <string name="network_test_pxve_oauth_path">/pixiv-oauth</string>
+    <string name="network_test_pxve_ok_2xx">可达 · %1$dms · HTTP %2$d（正常）</string>
+    <string name="network_test_pxve_ok_auth">可达 · %1$dms · HTTP %2$d（缺凭证的预期响应，转发链路通）</string>
+    <string name="network_test_pxve_ok_other">可达 · %1$dms · HTTP %2$d</string>
+    <string name="network_test_pxve_fail_status">异常 · %1$dms · HTTP %2$d</string>
+    <string name="network_test_pxve_not_found">不可达 · %1$dms · HTTP %2$d（代理未转发 %3$s 路径）</string>
+    <string name="network_test_pxve_failed">连接失败: %1$s</string>
 
     <!-- 图片下载探测（runImageDownloadPhase / downloadImageStep） -->
     <string name="network_test_dl_title">图片下载探测</string>

--- a/app/src/test/java/ceui/lisa/http/AppApiProxyInterceptorTest.kt
+++ b/app/src/test/java/ceui/lisa/http/AppApiProxyInterceptorTest.kt
@@ -1,5 +1,6 @@
 package ceui.lisa.http
 
+import ceui.lisa.BuildConfig
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -11,6 +12,10 @@ import org.junit.Test
  * 拦截器的核心逻辑（[AppApiProxyInterceptor.rewrite] / [AppApiProxyInterceptor.normalizeBase]）
  * 不依赖 Android 静态状态，直接对纯函数断言。覆盖审查关注的四类边界：
  * https 强制、尾斜杠/query 边界、误填完整 PxveAPI 地址的双前缀、非法地址回退。
+ *
+ * scheme 相关断言按 [BuildConfig.IS_DEBUG_MODE] 分叉：Debug 构建额外放行**显式**写出的
+ * `http://`（本地起代理调试用），Release 一律拒绝。**裸域名不参与这个分叉**——任何
+ * buildType 下都补 `https://`，明文只能是用户显式写出来的选择。
  */
 class AppApiProxyInterceptorTest {
 
@@ -22,13 +27,39 @@ class AppApiProxyInterceptorTest {
     }
 
     @Test
+    fun `裸域名在 Debug 构建下同样补 https 而不是 http`() {
+        // 回归：曾按 buildType 把裸域名默认成 http://，等于让 debug 包的 Authorization /
+        // refresh_token 静默走明文。明文必须是用户显式写 http:// 才发生。
+        assertEquals("https://pxve.example.com", normalize("pxve.example.com"))
+        assertEquals("https://192.168.10.109:3021", normalize("192.168.10.109:3021"))
+    }
+
+    @Test
     fun `已带 https 前缀原样保留`() {
         assertEquals("https://pxve.example.com", normalize("https://pxve.example.com"))
     }
 
     @Test
-    fun `显式 http 前缀被拒绝`() {
-        assertNull("http:// 明文传输令牌，必须拒绝", normalize("http://pxve.example.com"))
+    fun `显式 http 前缀 Release 拒绝 Debug 放行`() {
+        val actual = normalize("http://pxve.example.com")
+        if (BuildConfig.IS_DEBUG_MODE) {
+            assertEquals("Debug 允许显式 http 代理，方便本地调试", "http://pxve.example.com", actual)
+        } else {
+            assertNull("Release 下 http:// 明文传输令牌，必须拒绝", actual)
+        }
+    }
+
+    @Test
+    fun `Debug 下 http 代理的 80 端口不被写成显式冒号 80`() {
+        // 回归：root 端口曾恒按 https 的 443 比较，http 代理会多拼出 ":80"，
+        // 和网络测试页展示 / 探测的 URL 对不上。
+        if (!BuildConfig.IS_DEBUG_MODE) return
+        assertEquals("http://pxve.example.com", normalize("http://pxve.example.com"))
+        val original = "https://app-api.pixiv.net/v1/illust/detail?illust_id=1".toHttpUrl()
+        assertEquals(
+            "http://pxve.example.com/pixiv-app-api/v1/illust/detail?illust_id=1",
+            AppApiProxyInterceptor.rewrite(original, "http://pxve.example.com").toString(),
+        )
     }
 
     @Test
@@ -151,9 +182,17 @@ class AppApiProxyInterceptorTest {
     }
 
     @Test
-    fun `http 明文代理地址返回 null 而非改写`() {
+    fun `http 明文代理地址 Release 返回 null 而非改写`() {
         val original = "https://app-api.pixiv.net/v1/illust/detail?illust_id=1".toHttpUrl()
-        assertNull("http:// 必须被拒绝，避免令牌走明文", AppApiProxyInterceptor.rewrite(original, "http://pxve.example.com"))
+        val rewritten = AppApiProxyInterceptor.rewrite(original, "http://pxve.example.com")
+        if (BuildConfig.IS_DEBUG_MODE) {
+            assertEquals(
+                "http://pxve.example.com/pixiv-app-api/v1/illust/detail?illust_id=1",
+                rewritten.toString(),
+            )
+        } else {
+            assertNull("http:// 必须被拒绝，避免令牌走明文", rewritten)
+        }
     }
 
     @Test

--- a/app/src/test/java/ceui/pixiv/ui/debug/MaskProxyUrlTest.kt
+++ b/app/src/test/java/ceui/pixiv/ui/debug/MaskProxyUrlTest.kt
@@ -1,0 +1,81 @@
+package ceui.pixiv.ui.debug
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * [maskProxyUrl] 的脱敏边界回归。
+ *
+ * 这个函数的存在意义是：用户把网络测试页截图 / 原始日志贴到 issue 时，不要把自建 PxveAPI
+ * 与图片反代的地址漏出去。所以判据只有一条——**露出来的部分必须不足以还原出原地址**。
+ */
+class MaskProxyUrlTest {
+
+    // ── 域名：保留前 4 个字符 ──────────────────────────────────────────
+
+    @Test
+    fun `域名保留 scheme 与前四个字符`() {
+        assertEquals("https://your***", maskProxyUrl("https://your-proxy.domain"))
+        assertEquals("http://pxve***", maskProxyUrl("http://pxve.example.com"))
+    }
+
+    @Test
+    fun `无 scheme 的裸域名同样脱敏`() {
+        // 图片反代走 imageProxyDomain()，传进来的是剥掉 scheme 的 host[:port]。
+        assertEquals("pxim***", maskProxyUrl("pximg.example.com:8443"))
+    }
+
+    // ── IPv4：按段截断，不按字符数 ────────────────────────────────────
+
+    @Test
+    fun `私网 IP 保留前两段`() {
+        assertEquals("https://192.168***", maskProxyUrl("https://192.168.10.109:3021"))
+        assertEquals("http://10.0***", maskProxyUrl("http://10.0.0.5:3021"))
+    }
+
+    @Test
+    fun `短公网 IP 不会被整段漏出`() {
+        // 回归：曾按固定 7 个字符截断，IP 越短露得越多——1.2.3.4 会被原样打印出来。
+        assertEquals("https://1.2***", maskProxyUrl("https://1.2.3.4:8080"))
+        assertEquals("https://8.8***", maskProxyUrl("https://8.8.8.8"))
+        assertEquals("https://5.9***", maskProxyUrl("https://5.9.12.34:3021"))
+        assertEquals("https://43.154***", maskProxyUrl("https://43.154.66.7"))
+    }
+
+    @Test
+    fun `IP 后面的端口与路径一律不保留`() {
+        assertEquals("https://203.0***", maskProxyUrl("https://203.0.113.9:31337/pxve"))
+    }
+
+    // ── 边界 ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `数字开头但不是 IP 的域名走域名规则`() {
+        assertEquals("https://1pan***", maskProxyUrl("https://1panel.example.com"))
+        // 不完整的点分地址不按 IP 处理，退回更保守的 4 字符规则。
+        assertEquals("https://192.***", maskProxyUrl("https://192.168.1"))
+    }
+
+    @Test
+    fun `IPv6 字面量退回域名规则且不漏出完整地址`() {
+        assertEquals("https://[200***", maskProxyUrl("https://[2001:db8::1]:3021"))
+    }
+
+    @Test
+    fun `空串与纯空白不崩且不产生残留`() {
+        assertEquals("***", maskProxyUrl(""))
+        assertEquals("***", maskProxyUrl("   "))
+        assertEquals("https://***", maskProxyUrl("https://"))
+    }
+
+    @Test
+    fun `scheme 大小写不影响识别`() {
+        assertEquals("https://your***", maskProxyUrl("HTTPS://your-proxy.domain"))
+    }
+
+    @Test
+    fun `比原地址短的域名不会被原样返回`() {
+        // take(4) 对 3 字符域名会返回全部——但这种地址本身没有可辨识价值，仅确认不崩。
+        assertEquals("https://a.b***", maskProxyUrl("https://a.b"))
+    }
+}


### PR DESCRIPTION
# 网络测试页回补 PxveAPI 支持：替换 app-api 目标、转发路径验证、Debug http 代理、地址脱敏

> 分支：`patch-8-17`（wangwang-code fork；本地 remote 名为 `my`）
> 提交：`184c0cc34` feat(network-test): 回补 PxveAPI 网络测试与代理地址脱敏

## 背景

PR #1021 的 PxveAPI 代理功能已合入设置页与请求装配，但当时因网络测试页正在大改，网络测试页的 PxveAPI 联动被回退。本次把这一块补回来，并顺带处理两个实际使用中遇到的问题：

- Debug 构建允许填写 `http://` PxveAPI 地址方便本地调试；
- 网络测试页 UI 与原始日志会完整展示 PxveAPI / 自定义图片反代地址，截图或日志外发时可能泄露他人自用地址。

## 改动内容

### 1. PxveAPI 开启时替换 app-api 目标

- 网络测试目标里原本固定的 `app-api.pixiv.net`，在 PxveAPI 开启且地址合法时替换为用户填写的代理根地址；
- 目标卡标题 / 副标题 / 总览「网络不可用」小字都指向代理地址。

### 2. 追加 /pixiv-app-api 与 /pixiv-oauth 转发路径验证

- PxveAPI 代理握手成功后，额外请求两条真实转发路径：
  - `GET {root}/pixiv-app-api/v1/illust/ranking?mode=day`
  - `POST {root}/pixiv-oauth/auth/token`（OAuth token 接口真实语义是 POST，避免 GET 404 误报）
- 判定：`200..499` 且非 `404` 视为链路通；`400/401/403` 是无凭证时 Pixiv 的预期响应；`404/5xx/连接失败` 视为代理异常并置目标失败。

### 3. Debug 模式下 PxveAPI 豁免HTTPS 握手 与 路径仅为https的限制

- `BuildConfig.IS_DEBUG_MODE` 且 PxveAPI 地址为 `http://` 时，跳过 HTTPS 握手；
- 只测 `/pixiv-app-api` 与 `/pixiv-oauth` 两条转发路径；
- 客户端退回标准 HTTP，不套 Cronet/QUIC；
- 设置页校验同步放行 Debug 下的 http 地址。

### 4. 地址脱敏

- 新增 `maskProxyUrl()`：保留 scheme 和地址开头少量字符，后面用 `***` 代替；
  - `https://your-proxy.domain` → `https://your***`
  - `https://192.168.10.109:3021` → `https://192.168***`
- PxveAPI 地址在顶部胶囊、目标卡、总览小字、原始日志中均使用脱敏后的展示；
- 自定义图片反代在顶部胶囊、目标卡、图片代理路由步骤、图片下载日志/详情中也使用脱敏后的展示；
- 内部实际请求仍使用真实地址，仅展示与日志脱敏。

## 涉及文件

- `app/src/main/java/ceui/lisa/fragments/FragmentSettingsNetwork.java`
- `app/src/main/java/ceui/lisa/http/AppApiProxyInterceptor.java`
- `app/src/main/java/ceui/pixiv/ui/debug/NetworkTestViewModel.kt`
- `app/src/main/java/ceui/pixiv/ui/debug/NetworkTestFragment.kt`
- `app/src/main/res/layout/fragment_network_perf_test.xml`
- `app/src/main/res/values/strings.xml`
- `app/src/main/res/values-en/strings.xml`
- `app/src/main/res/values-zh-rTW/strings.xml`
- `app/src/main/res/values-ja/strings.xml`
- `app/src/main/res/values-ko/strings.xml`
- `app/src/main/res/values-ru/strings.xml`
- `app/src/main/res/values-tr/strings.xml`
