### PR TITLE
收敛 app-api / OAuth / www 网页 ajax 超时，并对 Pixiv 域名启用 IPv4-only DNS

### DIFF
--- a/app/src/main/java/ceui/lisa/http/AppApiTimeouts.kt
+++ b/app/src/main/java/ceui/lisa/http/AppApiTimeouts.kt
@@ -1,0 +1,28 @@
+package ceui.lisa.http
+
+/**
+ * App API / OAuth / PxveAPI 代理的超时统一入口（Java / Kotlin 共用）。
+ *
+ * 只做收敛，不改值：当前各调用点要么显式 10s，要么走 OkHttp 默认 10s，
+ * 因此这里统一取 10s，行为与之前完全一致。
+ *
+ * 这些值覆盖以下调用段：
+ * - [Retro.getLogClient]：老栈 AppApi（app-api.pixiv.net）与 AccountTokenApi
+ *   （oauth.secure.pixiv.net 刷新 token）共用同一个 OkHttp builder；
+ *   该 builder 也用于 web/sign/resource，值为原 OkHttp 默认 10s，未变。
+ * - [ceui.loxia.ClientManager.createAPPAPI]：新栈 app-api。
+ * - [ceui.pixiv.login.PixivLogin.buildClient]：OAuth 登录交换 / refresh_token 刷新。
+ * - 以上 client 开启 PxveAPI 代理时，[AppApiProxyInterceptor] 改写后的代理请求
+ *   仍走这些 client，因此代理路径同样使用这里的超时。
+ */
+object AppApiTimeouts {
+
+    /** 连接超时（秒）。值 = 原 OkHttp 默认 10s / loxia REQUIEST_TIME 10s。 */
+    const val CONNECT_TIMEOUT_SECONDS = 10L
+
+    /** 读超时（秒）。值 = 原 OkHttp 默认 10s / loxia REQUIEST_TIME 10s。 */
+    const val READ_TIMEOUT_SECONDS = 10L
+
+    /** 写超时（秒）。app-api 相关 client 显式/默认均为 10s，一并收敛。 */
+    const val WRITE_TIMEOUT_SECONDS = 10L
+}

--- a/app/src/main/java/ceui/lisa/http/AppApiTimeouts.kt
+++ b/app/src/main/java/ceui/lisa/http/AppApiTimeouts.kt
@@ -3,13 +3,12 @@ package ceui.lisa.http
 /**
  * App API / OAuth / PxveAPI 代理的超时统一入口（Java / Kotlin 共用）。
  *
- * 只做收敛，不改值：当前各调用点要么显式 10s，要么走 OkHttp 默认 10s，
- * 因此这里统一取 10s，行为与之前完全一致。
+ * 只做收敛：连接超时现收敛到 5s，读/写超时仍保持原来的 10s。
+ * 所有调用点统一从这里取值，避免散落硬编码。
  *
  * 这些值覆盖以下调用段：
- * - [Retro.getLogClient]：老栈 AppApi（app-api.pixiv.net）与 AccountTokenApi
- *   （oauth.secure.pixiv.net 刷新 token）共用同一个 OkHttp builder；
- *   该 builder 也用于 web/sign/resource，值为原 OkHttp 默认 10s，未变。
+ * - [Retro.buildRetrofit]：老栈 AppApi（app-api.pixiv.net）、AccountTokenApi
+ *   （oauth.secure.pixiv.net 刷新 token）与 SignApi 共用。
  * - [ceui.loxia.ClientManager.createAPPAPI]：新栈 app-api。
  * - [ceui.pixiv.login.PixivLogin.buildClient]：OAuth 登录交换 / refresh_token 刷新。
  * - 以上 client 开启 PxveAPI 代理时，[AppApiProxyInterceptor] 改写后的代理请求
@@ -17,8 +16,8 @@ package ceui.lisa.http
  */
 object AppApiTimeouts {
 
-    /** 连接超时（秒）。值 = 原 OkHttp 默认 10s / loxia REQUIEST_TIME 10s。 */
-    const val CONNECT_TIMEOUT_SECONDS = 10L
+    /** 连接超时（秒）。现收敛到5s。 */
+    const val CONNECT_TIMEOUT_SECONDS = 5L
 
     /** 读超时（秒）。值 = 原 OkHttp 默认 10s / loxia REQUIEST_TIME 10s。 */
     const val READ_TIMEOUT_SECONDS = 10L

--- a/app/src/main/java/ceui/lisa/http/IPv4OnlyDns.kt
+++ b/app/src/main/java/ceui/lisa/http/IPv4OnlyDns.kt
@@ -1,0 +1,34 @@
+package ceui.lisa.http
+
+import okhttp3.Dns
+import java.net.Inet4Address
+import java.net.InetAddress
+
+/**
+ * 公用的 IPv4-only DNS 工具类（OkHttp [Dns]）。
+ *
+ * Pixiv 的 app-api / oauth / www 网页 ajax / comic 域名在官方 DNS 里以 IPv4 为主，
+ * 系统 DNS 返回 IPv6 时多为污染，会让 OkHttp 多出一条毫无意义的 connect 尝试。
+ * 这里只对已知的 Pixiv API / 网页域名过滤 IPv6，其它域名（尤其是用户自建
+ * PxveAPI 代理域名）原样放行——代理可能有合法 IPv6，不能一刀切。
+ *
+ * 安全回退：如果系统 DNS 只返回 IPv6（例如 IPv6-only/NAT64 环境），保留原结果，
+ * 不让 OkHttp 拿到空地址列表而引入新的“无地址”语义。
+ */
+object IPv4OnlyDns : Dns {
+
+    private val IPV4_ONLY_HOSTS = setOf(
+        "app-api.pixiv.net",
+        "oauth.secure.pixiv.net",
+        "www.pixiv.net",
+        "comic.pixiv.net",
+    )
+
+    override fun lookup(hostname: String): List<InetAddress> {
+        val all = Dns.SYSTEM.lookup(hostname)
+        if (hostname !in IPV4_ONLY_HOSTS) return all
+
+        val ipv4 = all.filterIsInstance<Inet4Address>()
+        return if (ipv4.isNotEmpty()) ipv4 else all
+    }
+}

--- a/app/src/main/java/ceui/lisa/http/IPv4OnlyDns.kt
+++ b/app/src/main/java/ceui/lisa/http/IPv4OnlyDns.kt
@@ -5,30 +5,41 @@ import java.net.Inet4Address
 import java.net.InetAddress
 
 /**
+ * 已知在官方 DNS 里只有 A 记录的 Pixiv 域名。其它域名（尤其是用户自建 PxveAPI
+ * 代理域名）不在此列——代理可能有合法 IPv6，不能一刀切。
+ */
+internal val IPV4_ONLY_HOSTS = setOf(
+    "app-api.pixiv.net",
+    "oauth.secure.pixiv.net",
+    "www.pixiv.net",
+    "comic.pixiv.net",
+)
+
+/**
+ * [IPv4OnlyDns] 的纯过滤部分，抽成顶层函数是为了能被单测钉死——尤其是
+ * 「只解析出 IPv6 时必须原样返回」这条兜底：它一旦被改成返回空列表，
+ * IPv6-only / NAT64 网络上所有 Pixiv 请求都会变成 UnknownHost，而这种网络
+ * 在日常开发和真机验证里都碰不到，退化不会有任何人察觉。
+ */
+internal fun keepIpv4IfPossible(hostname: String, resolved: List<InetAddress>): List<InetAddress> {
+    if (hostname !in IPV4_ONLY_HOSTS) return resolved
+
+    val ipv4 = resolved.filterIsInstance<Inet4Address>()
+    return if (ipv4.isNotEmpty()) ipv4 else resolved
+}
+
+/**
  * 公用的 IPv4-only DNS 工具类（OkHttp [Dns]）。
  *
  * Pixiv 的 app-api / oauth / www 网页 ajax / comic 域名在官方 DNS 里以 IPv4 为主，
  * 系统 DNS 返回 IPv6 时多为污染，会让 OkHttp 多出一条毫无意义的 connect 尝试。
- * 这里只对已知的 Pixiv API / 网页域名过滤 IPv6，其它域名（尤其是用户自建
- * PxveAPI 代理域名）原样放行——代理可能有合法 IPv6，不能一刀切。
+ * 这里只对 [IPV4_ONLY_HOSTS] 过滤 IPv6，其它域名原样放行。
  *
  * 安全回退：如果系统 DNS 只返回 IPv6（例如 IPv6-only/NAT64 环境），保留原结果，
  * 不让 OkHttp 拿到空地址列表而引入新的“无地址”语义。
  */
 object IPv4OnlyDns : Dns {
 
-    private val IPV4_ONLY_HOSTS = setOf(
-        "app-api.pixiv.net",
-        "oauth.secure.pixiv.net",
-        "www.pixiv.net",
-        "comic.pixiv.net",
-    )
-
-    override fun lookup(hostname: String): List<InetAddress> {
-        val all = Dns.SYSTEM.lookup(hostname)
-        if (hostname !in IPV4_ONLY_HOSTS) return all
-
-        val ipv4 = all.filterIsInstance<Inet4Address>()
-        return if (ipv4.isNotEmpty()) ipv4 else all
-    }
+    override fun lookup(hostname: String): List<InetAddress> =
+        keepIpv4IfPossible(hostname, Dns.SYSTEM.lookup(hostname))
 }

--- a/app/src/main/java/ceui/lisa/http/Retro.java
+++ b/app/src/main/java/ceui/lisa/http/Retro.java
@@ -131,6 +131,10 @@ public class Retro {
      */
     private static Retrofit buildRetrofit(String baseUrl, boolean directConnect) {
         OkHttpClient.Builder builder = getLogClient();
+        // AppApi / OAuth 刷新 / PxveAPI 代理共用 AppApiTimeouts。
+        builder.connectTimeout(AppApiTimeouts.CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .readTimeout(AppApiTimeouts.READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .writeTimeout(AppApiTimeouts.WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         try {
             builder.addInterceptor(chain -> {
                 Request original = chain.request();
@@ -175,6 +179,10 @@ public class Retro {
      */
     private static Retrofit buildWebRetrofit() {
         OkHttpClient.Builder builder = getLogClient();
+        // www.pixiv.net 网页 ajax 用独立 WebApiTimeouts，不跟 app-api 混用。
+        builder.connectTimeout(WebApiTimeouts.CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .readTimeout(WebApiTimeouts.READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .writeTimeout(WebApiTimeouts.WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         builder.addInterceptor(new ceui.loxia.WebHeaderInterceptor());
         applyDirectConnect(builder, true);
         HttpLoggingInterceptor l = new HttpLoggingInterceptor(message -> Timber.i(message));
@@ -214,12 +222,11 @@ public class Retro {
     }
 
     public static OkHttpClient.Builder getLogClient() {
-        // AppApi / OAuth 刷新 / PxveAPI 代理共用这套超时（值仍为 10s，统一见 AppApiTimeouts）。
-        // 该 builder 也被 web/sign/resource 复用：它们原本就是 OkHttp 默认 10s，值不变。
+        // 公共 builder：只放公共 DNS 与协议；各业务链路的超时由各自 Timeouts 类设置。
+        // app-api/oauth/www/comic 系统 DNS 只保留 IPv4（官方单 A 记录，IPv6 多为污染）；
+        // 其它 host（含 PxveAPI 代理域名）由 IPv4OnlyDns 原样放行。
         return new OkHttpClient.Builder()
-                .connectTimeout(AppApiTimeouts.CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                .readTimeout(AppApiTimeouts.READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                .writeTimeout(AppApiTimeouts.WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .dns(IPv4OnlyDns.INSTANCE)
                 .protocols(Collections.singletonList(Protocol.HTTP_1_1));
     }
 

--- a/app/src/main/java/ceui/lisa/http/Retro.java
+++ b/app/src/main/java/ceui/lisa/http/Retro.java
@@ -11,6 +11,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
 import ceui.lisa.activities.Shaft;
 import ceui.lisa.helper.LanguageHelper;
@@ -213,7 +214,12 @@ public class Retro {
     }
 
     public static OkHttpClient.Builder getLogClient() {
+        // AppApi / OAuth 刷新 / PxveAPI 代理共用这套超时（值仍为 10s，统一见 AppApiTimeouts）。
+        // 该 builder 也被 web/sign/resource 复用：它们原本就是 OkHttp 默认 10s，值不变。
         return new OkHttpClient.Builder()
+                .connectTimeout(AppApiTimeouts.CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .readTimeout(AppApiTimeouts.READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .writeTimeout(AppApiTimeouts.WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
                 .protocols(Collections.singletonList(Protocol.HTTP_1_1));
     }
 

--- a/app/src/main/java/ceui/lisa/http/WebApiTimeouts.kt
+++ b/app/src/main/java/ceui/lisa/http/WebApiTimeouts.kt
@@ -1,0 +1,19 @@
+package ceui.lisa.http
+
+/**
+ * www.pixiv.net 网页 ajax 的超时统一入口（Java / Kotlin 共用）。
+ *
+ * 与 AppApiTimeouts 分离：网页 ajax 和 app-api 是两条独立链路，
+ * 后续可以各自调整而不互相影响。当前连接收敛到 5s，读/写保持 10s。
+ */
+object WebApiTimeouts {
+
+    /** 连接超时（秒）。当前收敛到 5s。 */
+    const val CONNECT_TIMEOUT_SECONDS = 5L
+
+    /** 读超时（秒）。保持原 10s。 */
+    const val READ_TIMEOUT_SECONDS = 10L
+
+    /** 写超时（秒）。保持原 10s。 */
+    const val WRITE_TIMEOUT_SECONDS = 10L
+}

--- a/app/src/main/java/ceui/loxia/Client.kt
+++ b/app/src/main/java/ceui/loxia/Client.kt
@@ -3,6 +3,7 @@ package ceui.loxia
 import ceui.lisa.BuildConfig
 import ceui.lisa.activities.Shaft
 import ceui.lisa.http.AppApiProxyInterceptor
+import ceui.lisa.http.AppApiTimeouts
 import ceui.lisa.http.CronetInterceptor
 import ceui.pixiv.shaftapi.ShaftHmac
 import okhttp3.Dns
@@ -131,6 +132,8 @@ class ClientManager {
 
         const val HEADER_AUTH = "authorization"
 
+        // 非 app-api 的 loxia 客户端（web / comic / fanbox / moon）仍用这个值；
+        // app-api 已统一收敛到 ceui.lisa.http.AppApiTimeouts，不再从这里取。
         const val REQUIEST_TIME = 10L
 
         const val TOKEN_ERROR_1 = "Error occurred at the OAuth process"
@@ -159,10 +162,12 @@ class ClientManager {
     }
 
     fun <T> createAPPAPI(service: Class<T>): T {
+        // app-api 超时收敛到 AppApiTimeouts（值=10s，与 REQUIEST_TIME 一致）；
+        // PxveAPI 代理开启时，AppApiProxyInterceptor 改写后的请求仍走本 client，同样生效。
         val okhttpClientBuilder = OkHttpClient.Builder()
-            .connectTimeout(REQUIEST_TIME, TimeUnit.SECONDS)
-            .writeTimeout(REQUIEST_TIME, TimeUnit.SECONDS)
-            .readTimeout(REQUIEST_TIME, TimeUnit.SECONDS)
+            .connectTimeout(AppApiTimeouts.CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .writeTimeout(AppApiTimeouts.WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .readTimeout(AppApiTimeouts.READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             .protocols(listOf(Protocol.HTTP_2, Protocol.HTTP_1_1))
 
         okhttpClientBuilder.addInterceptor(HeaderInterceptor())

--- a/app/src/main/java/ceui/loxia/Client.kt
+++ b/app/src/main/java/ceui/loxia/Client.kt
@@ -5,6 +5,8 @@ import ceui.lisa.activities.Shaft
 import ceui.lisa.http.AppApiProxyInterceptor
 import ceui.lisa.http.AppApiTimeouts
 import ceui.lisa.http.CronetInterceptor
+import ceui.lisa.http.IPv4OnlyDns
+import ceui.lisa.http.WebApiTimeouts
 import ceui.pixiv.shaftapi.ShaftHmac
 import okhttp3.Dns
 import okhttp3.OkHttpClient
@@ -132,8 +134,8 @@ class ClientManager {
 
         const val HEADER_AUTH = "authorization"
 
-        // 非 app-api 的 loxia 客户端（web / comic / fanbox / moon）仍用这个值；
-        // app-api 已统一收敛到 ceui.lisa.http.AppApiTimeouts，不再从这里取。
+        // 非 app-api / 非网页 ajax 的 loxia 客户端（comic / fanbox / moon）仍用这个值；
+        // app-api 与 www 网页 ajax 已分别收敛到 AppApiTimeouts / WebApiTimeouts。
         const val REQUIEST_TIME = 10L
 
         const val TOKEN_ERROR_1 = "Error occurred at the OAuth process"
@@ -162,12 +164,13 @@ class ClientManager {
     }
 
     fun <T> createAPPAPI(service: Class<T>): T {
-        // app-api 超时收敛到 AppApiTimeouts（值=10s，与 REQUIEST_TIME 一致）；
+        // app-api 超时收敛到 AppApiTimeouts；
         // PxveAPI 代理开启时，AppApiProxyInterceptor 改写后的请求仍走本 client，同样生效。
         val okhttpClientBuilder = OkHttpClient.Builder()
             .connectTimeout(AppApiTimeouts.CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             .writeTimeout(AppApiTimeouts.WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             .readTimeout(AppApiTimeouts.READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .dns(IPv4OnlyDns)
             .protocols(listOf(Protocol.HTTP_2, Protocol.HTTP_1_1))
 
         okhttpClientBuilder.addInterceptor(HeaderInterceptor())
@@ -187,10 +190,13 @@ class ClientManager {
     }
 
     fun <T> createWebAPIService(service: Class<T>): T {
+        // www.pixiv.net 网页 ajax 用独立 WebApiTimeouts，不跟 app-api 混用；
+        // 直连（Cronet）路径不改动，仍由 CronetInterceptor 自己处理。
         val httpBuilder = OkHttpClient.Builder()
-            .connectTimeout(REQUIEST_TIME, TimeUnit.SECONDS)
-            .writeTimeout(REQUIEST_TIME, TimeUnit.SECONDS)
-            .readTimeout(REQUIEST_TIME, TimeUnit.SECONDS)
+            .connectTimeout(WebApiTimeouts.CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .writeTimeout(WebApiTimeouts.WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .readTimeout(WebApiTimeouts.READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .dns(IPv4OnlyDns)
             .protocols(listOf(Protocol.HTTP_1_1))
 
         httpBuilder.addInterceptor(WebHeaderInterceptor())
@@ -252,10 +258,12 @@ class ClientManager {
      * comic.pixiv.net 和 app-api 一样在墙内不可达,必须跟着走直连。
      */
     fun <T> createComicService(service: Class<T>): T {
+        // comic.pixiv.net 也没有 IPv6 DNS 记录，同样用 IPv4OnlyDns 滤掉污染的 IPv6。
         val httpBuilder = OkHttpClient.Builder()
             .connectTimeout(REQUIEST_TIME, TimeUnit.SECONDS)
             .writeTimeout(REQUIEST_TIME, TimeUnit.SECONDS)
             .readTimeout(REQUIEST_TIME, TimeUnit.SECONDS)
+            .dns(IPv4OnlyDns)
             .protocols(listOf(Protocol.HTTP_2, Protocol.HTTP_1_1))
 
         httpBuilder.addInterceptor(HeaderInterceptor())

--- a/app/src/main/java/ceui/loxia/CsrfTokenProvider.kt
+++ b/app/src/main/java/ceui/loxia/CsrfTokenProvider.kt
@@ -2,11 +2,14 @@ package ceui.loxia
 
 import ceui.lisa.activities.Shaft
 import ceui.lisa.http.CronetInterceptor
+import ceui.lisa.http.IPv4OnlyDns
+import ceui.lisa.http.WebApiTimeouts
 import ceui.pixiv.session.SessionManager
 import com.tencent.mmkv.MMKV
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import timber.log.Timber
+import java.util.concurrent.TimeUnit
 
 /**
  * Fetches and caches the x-csrf-token required by Pixiv web POST APIs.
@@ -35,7 +38,15 @@ object CsrfTokenProvider {
      * Fetch a fresh token from the Pixiv homepage. Call from a background thread.
      */
     private fun buildClient(): OkHttpClient {
-        val builder = OkHttpClient.Builder().followRedirects(true)
+        // 打的是 www.pixiv.net，和 [ClientManager.createWebAPIService] 同一条链路，
+        // 超时与 IPv4-only DNS 也跟着它走：不然非直连下被污染的 IPv6 会让这次
+        // **阻塞式**兜底抓取先干等一轮，把调用它的网页 POST 一起拖住。
+        val builder = OkHttpClient.Builder()
+            .followRedirects(true)
+            .connectTimeout(WebApiTimeouts.CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .readTimeout(WebApiTimeouts.READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .writeTimeout(WebApiTimeouts.WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .dns(IPv4OnlyDns)
         // issue #959: 直连下 www.pixiv.net 同样打不通,token 兜底抓取必须走 Cronet,
         // 否则「拉黑」在没梯子时永远卡在「CSRF token 未就绪」。每次现建:直连开关随时可切。
         if (Shaft.sSettings?.isDirectConnect == true) {

--- a/app/src/main/java/ceui/pixiv/login/PixivLogin.kt
+++ b/app/src/main/java/ceui/pixiv/login/PixivLogin.kt
@@ -3,9 +3,11 @@ package ceui.pixiv.login
 import android.net.Uri
 import ceui.lisa.activities.Shaft
 import ceui.lisa.http.AppApiProxyInterceptor
+import ceui.lisa.http.AppApiTimeouts
 import ceui.lisa.http.CronetInterceptor
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
+import java.util.concurrent.TimeUnit
 
 /**
  * Pixiv OAuth 入口，包了库 [PixivOAuthClient]。
@@ -55,7 +57,12 @@ object PixivLogin {
     }
 
     private fun buildClient(): PixivOAuthClient {
+        // OAuth 登录/刷新是 app-api 同一套超时（值=10s，收敛到 AppApiTimeouts）；
+        // 开启 PxveAPI 代理时改写后的 oauth 请求也走本 client，同样生效。
         val builder = OkHttpClient.Builder()
+            .connectTimeout(AppApiTimeouts.CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .readTimeout(AppApiTimeouts.READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .writeTimeout(AppApiTimeouts.WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             .protocols(listOf(Protocol.HTTP_1_1))
         // App API 代理（PxveAPI 风格）与直连模式**共存**：代理拦截器挂在
         // CronetInterceptor 之前，只改写 oauth 请求到代理域名；改写后的域名不在

--- a/app/src/main/java/ceui/pixiv/login/PixivLogin.kt
+++ b/app/src/main/java/ceui/pixiv/login/PixivLogin.kt
@@ -5,6 +5,7 @@ import ceui.lisa.activities.Shaft
 import ceui.lisa.http.AppApiProxyInterceptor
 import ceui.lisa.http.AppApiTimeouts
 import ceui.lisa.http.CronetInterceptor
+import ceui.lisa.http.IPv4OnlyDns
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import java.util.concurrent.TimeUnit
@@ -57,12 +58,13 @@ object PixivLogin {
     }
 
     private fun buildClient(): PixivOAuthClient {
-        // OAuth 登录/刷新是 app-api 同一套超时（值=10s，收敛到 AppApiTimeouts）；
+        // OAuth 登录/刷新是 app-api 同一套超时（收敛到 AppApiTimeouts）；
         // 开启 PxveAPI 代理时改写后的 oauth 请求也走本 client，同样生效。
         val builder = OkHttpClient.Builder()
             .connectTimeout(AppApiTimeouts.CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             .readTimeout(AppApiTimeouts.READ_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             .writeTimeout(AppApiTimeouts.WRITE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .dns(IPv4OnlyDns)
             .protocols(listOf(Protocol.HTTP_1_1))
         // App API 代理（PxveAPI 风格）与直连模式**共存**：代理拦截器挂在
         // CronetInterceptor 之前，只改写 oauth 请求到代理域名；改写后的域名不在

--- a/app/src/test/java/ceui/lisa/http/IPv4OnlyDnsTest.kt
+++ b/app/src/test/java/ceui/lisa/http/IPv4OnlyDnsTest.kt
@@ -1,0 +1,60 @@
+package ceui.lisa.http
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.net.InetAddress
+
+/**
+ * [keepIpv4IfPossible] 的行为回归。
+ *
+ * 这个过滤器挂在 app-api / oauth / www / comic 四条链路的 OkHttp 客户端上，跑在所有
+ * 用户的所有请求前面，但它的三条分支里有两条平时根本走不到：非白名单域名（自建
+ * PxveAPI 代理）和只解析出 IPv6 的网络（IPv6-only / NAT64）。这两条一旦退化，
+ * 表现分别是「代理用户莫名连不上」和「IPv6-only 网络上整个 App 报 UnknownHost」，
+ * 而日常开发和真机验证都是双栈网络 + 不开代理，谁都不会碰到。所以在这里钉死。
+ */
+class IPv4OnlyDnsTest {
+
+    private fun ip(s: String): InetAddress = InetAddress.getByName(s)
+
+    private val v4 = ip("210.140.92.183")
+    private val v6 = ip("2606:4700::6812:2aef")
+
+    @Test
+    fun `白名单域名同时解析出 v4 v6 时只留 v4`() {
+        assertEquals(
+            listOf(v4),
+            keepIpv4IfPossible("app-api.pixiv.net", listOf(v6, v4)),
+        )
+    }
+
+    @Test
+    fun `白名单域名只解析出 IPv6 时原样返回而不是空列表`() {
+        // IPv6-only / NAT64 网络：合成的 AAAA 是唯一能用的地址，滤掉就等于断网。
+        assertEquals(
+            listOf(v6),
+            keepIpv4IfPossible("www.pixiv.net", listOf(v6)),
+        )
+    }
+
+    @Test
+    fun `非白名单域名一律原样放行`() {
+        // 用户自建 PxveAPI 代理可能只有 IPv6，或 v6 优先，不能替它做选择。
+        val resolved = listOf(v6, v4)
+        assertEquals(resolved, keepIpv4IfPossible("pxve.example.com", resolved))
+        assertEquals(resolved, keepIpv4IfPossible("i.pximg.net", resolved))
+    }
+
+    @Test
+    fun `四个 Pixiv 域名都在白名单里`() {
+        assertEquals(
+            setOf(
+                "app-api.pixiv.net",
+                "oauth.secure.pixiv.net",
+                "www.pixiv.net",
+                "comic.pixiv.net",
+            ),
+            IPV4_ONLY_HOSTS,
+        )
+    }
+}


### PR DESCRIPTION
# 收敛 app-api / OAuth / www 网页 ajax 超时，并对 Pixiv 域名启用 IPv4-only DNS

> 分支：`patch-8-18-1`（wangwang-code fork；本地 remote 名为 `my`）
> 提交：
> - `6af23d2fd` refactor(network): 收敛 app-api/www 超时并加 IPv4-only DNS，comic 接入
> - `32966ff96` refactor(network): 收敛 app-api/OAuth/PxveAPI 代理超时到 AppApiTimeouts，值不变

## 背景

从 #1019 拆出的独立工作。原 PR 里「全项目超时统一钳 3s + 网络错误弹窗」按上游审核意见回滚；本 PR 只做其中的**超时收敛**和**IPv6 污染规避**，不引入模态弹窗、不改 Cronet 直连路径。

## 改动内容

### 1. 超时收敛到统一类

- 新增 `AppApiTimeouts`：AppApi / OAuth 刷新 / PxveAPI 代理共用。
  - 连接超时收敛到 5s
  - 读/写超时保持 10s
- 新增 `WebApiTimeouts`：`www.pixiv.net` 网页 ajax 独立使用，不混用 `AppApiTimeouts`。
- 老栈 `Retro`：
  - `buildRetrofit()` → `AppApiTimeouts`
  - `buildWebRetrofit()` → `WebApiTimeouts`
  - `getLogClient()` 只保留公共 DNS 与协议，不再统一塞超时
- 新栈 `ClientManager`：
  - `createAPPAPI()` → `AppApiTimeouts`
  - `createWebAPIService()` → `WebApiTimeouts`
- `PixivLogin.buildClient()`（OAuth 登录 / refresh_token 刷新）→ `AppApiTimeouts`

### 2. IPv4-only DNS 工具类

- `AppApiDns` 抽取为公用 `IPv4OnlyDns`。
- 对以下已知单 IPv4 的 Pixiv 域名过滤系统 DNS 返回的 IPv6：
  - `app-api.pixiv.net`
  - `oauth.secure.pixiv.net`
  - `www.pixiv.net`
  - `comic.pixiv.net`
  - `api.fanbox.cc` （超出本次工作，日后PR）
- 其它域名（尤其用户自建 PxveAPI 代理域名）原样放行。
- 应用位置：
  - `Retro.getLogClient()`
  - `ClientManager.createAPPAPI()`
  - `ClientManager.createWebAPIService()`
  - `ClientManager.createComicService()`
  - `PixivLogin.buildClient()`

### 3. 不动 Cronet

- `CronetInterceptor` 未改动。
- 直连开启时仍由 Cronet 自行处理请求与 30s 整体上限；OkHttp 的 connect/read/write 超时不会影响 Cronet 路径。

## 动机

- 断网但 DNS 有解析结果时，且被污染时`app-api.pixiv.net` 会返回 IPv4 + IPv6 两条记录，OkHttp 逐个尝试，`5s + 5s ≈ 10s` 才失败。
- 已查询多个国际公用DNS，这些域名没有AAAA记录，出现 IPv6 结果即判断为被污染，应只保留 IPv4，让失败时间回到约 5s。这里需要推广到网络测试页，其超出本次工作，另外起PR
- 网页 ajax 与 app-api 是两条独立链路，超时应分开管理，方便后续单独调整。且REQUIEST_TIME应用3个超时（connect/read/write）、多个不同端点的做法并不好（且okhttp在ipv4栈连接/握手失败后发现有ipv6栈会内部用ipv6重试一次，原有的10秒已经很久了，要是ipv6是被污染出的，用户又要无意义的干等10秒）

## 涉及文件

- `app/src/main/java/ceui/lisa/http/AppApiTimeouts.kt`
- `app/src/main/java/ceui/lisa/http/WebApiTimeouts.kt`（新增）
- `app/src/main/java/ceui/lisa/http/IPv4OnlyDns.kt`（新增）
- `app/src/main/java/ceui/lisa/http/Retro.java`
- `app/src/main/java/ceui/loxia/Client.kt`
- `app/src/main/java/ceui/pixiv/login/PixivLogin.kt`
