### PR TITLE
网络测试页：Pixiv 域名公网 IPv6 判污染，并收敛 DNS 解析

### DIFF
--- a/app/src/main/java/ceui/pixiv/ui/debug/NetworkTestViewModel.kt
+++ b/app/src/main/java/ceui/pixiv/ui/debug/NetworkTestViewModel.kt
@@ -39,6 +39,7 @@ import timber.log.Timber
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.net.Inet4Address
+import java.net.Inet6Address
 import java.net.InetAddress
 import java.net.InetSocketAddress
 import java.net.Socket
@@ -77,6 +78,36 @@ internal fun maskProxyUrl(url: String): String {
     return "$scheme$visible***"
 }
 
+/**
+ * 网络测试页的 IPv4-only DNS（OkHttp [Dns]），做法抄自 PR #1036 的 IPv4OnlyDns。
+ *
+ * 当前测试流程大多会先把选定 IPv4 钉进 [buildHandshakeClient]（pinnedDns），所以这个
+ * DNS 实际未必会走到；保留它作为防守：当未钉 IP（fake-ip / 代理 / Cronet 绕过等）时，
+ * 仍对 app-api.pixiv.net / www.pixiv.net 过滤系统 DNS 返回的 IPv6，避免被污染的 IPv6
+ * 拖出多余的 connect 尝试。
+ *
+ * 只过滤这两个官方 Pixiv 域名，其它域名（用户自建 PxveAPI 代理、图片反代等）原样放行
+ * ——代理可能有合法 IPv6，不能一刀切。
+ *
+ * 安全回退：如果系统 DNS 只返回 IPv6（例如 IPv6-only/NAT64 环境），保留原结果，
+ * 不让 OkHttp 拿到空地址列表而引入新的“无地址”语义。
+ */
+private object PixivIpv4OnlyDns : Dns {
+
+    private val IPV4_ONLY_HOSTS = setOf(
+        "app-api.pixiv.net",
+        "www.pixiv.net",
+    )
+
+    override fun lookup(hostname: String): List<InetAddress> {
+        val all = Dns.SYSTEM.lookup(hostname)
+        if (hostname !in IPV4_ONLY_HOSTS) return all
+
+        val ipv4 = all.filterIsInstance<Inet4Address>()
+        return if (ipv4.isNotEmpty()) ipv4 else all
+    }
+}
+
 /** 单条步骤的语义状态，决定圆点 / pill 的颜色（在 Fragment 里按状态染 v3 颜色）。 */
 enum class StepStatus { INFO, OK, WARN, FAIL, RUNNING, HIGH_LATENCY, EXTREME_LATENCY }
 
@@ -86,6 +117,18 @@ data class TestStep(
     val detail: String? = null,
     val status: StepStatus = StepStatus.INFO,
 )
+
+/** 系统 DNS 的一次解析结果，统一拆好 IPv4 / IPv6 / fake-ip / 公网 IPv6，避免各处重复过滤。 */
+private data class SysDnsResult(
+    val all: List<InetAddress>,
+    val ipv4: List<Inet4Address>,
+    val ipv6: List<Inet6Address>,
+    val fakeIps: List<String>,
+    val publicIpv6: List<Inet6Address>,
+) {
+    val hasFakeIp: Boolean get() = fakeIps.isNotEmpty()
+    val hasPublicIpv6: Boolean get() = publicIpv6.isNotEmpty()
+}
 
 /**
  * 单个目标（域名）的整体判定，决定卡片右上角 pill。
@@ -586,20 +629,20 @@ class NetworkTestViewModel : ViewModel() {
             setStatus(idx, TargetStatus.FAILED)
             return false to false
         }
-        val ipv4 = sysAddrs.filterIsInstance<Inet4Address>()
+        val dns = analyzeSysDns(sysAddrs)
+        val ipv4 = dns.ipv4
         // fake-ip 检测：代理接管 DNS 时返回保留地址。不取消目标——跳过 DNS/ping，仅测握手，
         // 且不再把解析出的 IP 喂给 OkHttp（让代理接管路由）。
-        val fakeIps = ipv4.mapNotNull { it.hostAddress }.filter { isFakeIp(it) }
-        if (fakeIps.isNotEmpty()) {
+        if (dns.hasFakeIp) {
             addStep(
                 idx,
                 TestStep(
                     strRes(R.string.network_test_dns_step),
-                    strRes(R.string.network_test_dns_fakeip, fakeIps.joinToString()),
+                    strRes(R.string.network_test_dns_fakeip, dns.fakeIps.joinToString()),
                     StepStatus.WARN,
                 ),
             )
-            log("检测到 fake-ip: ${fakeIps.joinToString()}，跳过 DNS/ping，仅测握手")
+            log("检测到 fake-ip: ${dns.fakeIps.joinToString()}，跳过 DNS/ping，仅测握手")
             fakeIpDetected = true
             val hs = httpsHandshakeSampled(idx, cfg, null, direct, fakeIp = true)
             // 握手走标准 TLS，成功即证书链有效；max/avg 超阈值判延迟异常。
@@ -627,38 +670,48 @@ class NetworkTestViewModel : ViewModel() {
             // Clash 等 fake-ip 环境正是自建 PxveAPI 的典型场景，恒填 false 会让转发路径探测整段不跑。
             return false to hs.ok
         }
-        log("DNS: " + sysAddrs.joinToString(", ") { it.hostAddress ?: "?" })
+        log("DNS: " + dns.all.joinToString(", ") { it.hostAddress ?: "?" })
 
-        var polluted = false
-        if (cfg.cidrs != null) {
+        // 没开 PxveAPI 时，官方 Pixiv 域名如果被系统 DNS 返回公网 IPv6，直接视为 DNS 污染。
+        // 只认公网 IPv6：fake-ip 给的非公网 IPv6 不走这条判定（仍由上面的 fake-ip / 代理逻辑处理）。
+        val pixivPublicIpv6 = !proxyEnabled && isPixivDomain(dnsHost) && dns.hasPublicIpv6
+        if (pixivPublicIpv6) {
+            log("官方 Pixiv 域名返回公网 IPv6，直接判 DNS 污染")
+        }
+        var polluted = pixivPublicIpv6
+
+        // 一次算好 IPv4 的 CIDR 命中与可用的 cleanV4，后续展示、握手、判定共用，避免重复过滤。
+        val cidrHits = cfg.cidrs?.let { cidrs ->
+            ipv4.map { a -> a to cidrs.firstOrNull { isIpInCidr(a.hostAddress ?: "", it) } }
+        }
+        val cleanV4 = if (cidrHits != null) cidrHits.filter { it.second != null }.map { it.first } else ipv4
+        val cleanCount = cleanV4.size
+
+        if (cidrHits != null) {
             val sb = StringBuilder()
-            var clean = 0
-            for (a in ipv4) {
+            for ((a, hit) in cidrHits) {
                 val ip = a.hostAddress ?: continue
-                val hit = cfg.cidrs.firstOrNull { isIpInCidr(ip, it) }
                 if (hit != null) {
-                    clean++
                     sb.append(strRes(R.string.network_test_dns_hit, ip, hit))
                 } else {
                     sb.append(strRes(R.string.network_test_dns_miss, ip))
                 }
             }
-            sysAddrs.filter { it !is Inet4Address }
-                .forEach { sb.append(strRes(R.string.network_test_dns_ipv6_skip, it.hostAddress)) }
-            polluted = ipv4.isNotEmpty() && clean == 0
+            dns.ipv6.forEach { sb.append(strRes(R.string.network_test_dns_ipv6_skip, it.hostAddress)) }
+            polluted = (ipv4.isNotEmpty() && cleanCount == 0) || polluted
             val st = when {
-                ipv4.isEmpty() -> StepStatus.WARN
                 polluted -> StepStatus.FAIL
-                clean < ipv4.size -> StepStatus.WARN
+                ipv4.isEmpty() -> StepStatus.WARN
+                cleanCount < ipv4.size -> StepStatus.WARN
                 else -> StepStatus.OK
             }
-            addStep(idx, TestStep(strRes(R.string.network_test_dns_step_count, sysAddrs.size), sb.toString().trimEnd(), st))
+            addStep(idx, TestStep(strRes(R.string.network_test_dns_step_count, dns.all.size), sb.toString().trimEnd(), st))
         } else {
             addStep(
                 idx,
                 TestStep(
-                    strRes(R.string.network_test_dns_step_count, sysAddrs.size),
-                    sysAddrs.joinToString("\n") { strRes(R.string.network_test_dns_item, it.hostAddress) },
+                    strRes(R.string.network_test_dns_step_count, dns.all.size),
+                    dns.all.joinToString("\n") { strRes(R.string.network_test_dns_item, it.hostAddress) },
                     StepStatus.OK,
                 ),
             )
@@ -686,7 +739,7 @@ class NetworkTestViewModel : ViewModel() {
                     }
                 }
                 appAddrs.filter { it !is Inet4Address }
-                    .forEach { sb.append(strRes(R.string.network_test_dns_ipv6_skip, it.hostAddress)) }
+                    .forEach { sb.append(strRes(R.string.network_test_dns_ipv6_app_skip, it.hostAddress)) }
 
                 val appPolluted = appV4.isNotEmpty() && appClean == 0
                 val st = when {
@@ -725,11 +778,6 @@ class NetworkTestViewModel : ViewModel() {
         }
 
         // 选用于后续连通性 / 握手的目标 IP：优先干净的系统解析，污染时退到应用内解析路径。
-        val cleanV4 = if (cfg.cidrs != null) {
-            ipv4.filter { a -> cfg.cidrs.any { isIpInCidr(a.hostAddress ?: "", it) } }
-        } else {
-            ipv4
-        }
         val targetIp: Inet4Address? = cleanV4.firstOrNull() ?: appIp
         if (targetIp == null) {
             // 直连 + Cronet 覆盖的域名（APP_API / WEB_API）：真实 app 直连时走
@@ -828,7 +876,7 @@ class NetworkTestViewModel : ViewModel() {
     }
 
     /** 仅直连模式做 —— 代理下测 ICMP 无意义（ICMP 会透过代理）。 */
-    private fun icmpPing(idx: Int, ip: InetAddress) {
+    private fun icmpPing(idx: Int, ip: Inet4Address) {
         val samples = mutableListOf<Long>()
         repeat(3) {
             try {
@@ -853,16 +901,18 @@ class NetworkTestViewModel : ViewModel() {
      * （见 [Client] 的 createAPPAPI / createPixshaftService 与 Shaft 图片 client）：
      *   · APP_API / PIXSHAFT：H2+H1；直连开启时挂 [CronetInterceptor]（请求转 QUIC，绕 SNI 阻断）。
      *   · IMAGE：直连开启时无 SNI（[RubySSLSocketFactory]）+ 信任所有证书 + 关主机名校验 + 强制 HTTP/1.1。
-     * 连接池 0 空闲 → 每次调用都重新握手；默认用 [pinnedDns] 把域名钉到本次选定的 IP（Cronet 路径除外，
-     * 其走自身 host-resolver 规则，固定到 Cloudflare IP）。fake-ip 模式传 pin=false 不钉 IP，
+     * 连接池 0 空闲 → 每次调用都重新握手；默认用 [pinnedDns] 把域名钉到本次选定的 IP；
+     * 未钉 IP（fake-ip / 代理 / Cronet 绕过）时用 [PixivIpv4OnlyDns] 过滤 Pixiv 两个域名的污染 IPv6。
+     * Cronet 路径除外，其走自身 host-resolver 规则，固定到 Cloudflare IP。fake-ip 模式传 pin=false 不钉 IP，
      * 交给系统 DNS + 代理接管路由。
      */
-    private fun buildHandshakeClient(cfg: TargetConfig, ip: InetAddress?, direct: Boolean, pin: Boolean = true): OkHttpClient {
+    private fun buildHandshakeClient(cfg: TargetConfig, ip: Inet4Address?, direct: Boolean, pin: Boolean = true): OkHttpClient {
         val builder = OkHttpClient.Builder()
             .connectionPool(ConnectionPool(0, 1, TimeUnit.SECONDS))
             .connectTimeout(5, TimeUnit.SECONDS)
             .readTimeout(5, TimeUnit.SECONDS)
             .writeTimeout(5, TimeUnit.SECONDS)
+            .dns(PixivIpv4OnlyDns)
         if (pin && ip != null) {
             val pinnedDns = object : Dns {
                 override fun lookup(hostname: String): List<InetAddress> = listOf(ip)
@@ -923,7 +973,7 @@ class NetworkTestViewModel : ViewModel() {
     private fun httpsHandshakeSampled(
         idx: Int,
         cfg: TargetConfig,
-        ip: InetAddress?,
+        ip: Inet4Address?,
         direct: Boolean,
         fakeIp: Boolean = false,
         bypassDns: Boolean = false,
@@ -1040,7 +1090,7 @@ class NetworkTestViewModel : ViewModel() {
      * 校验返回 error=false 且带图片地址；顺带把地址/作者 ID 存下来给图片下载阶段复用。
      * @return 是否成功拿到有效响应（失败只把目标降为 DEGRADED，不算握手失败）。
      */
-    private fun probeWebEndpoint(idx: Int, cfg: TargetConfig, ip: InetAddress, direct: Boolean): Boolean {
+    private fun probeWebEndpoint(idx: Int, cfg: TargetConfig, ip: Inet4Address, direct: Boolean): Boolean {
         val stepIdx = work[idx].steps.size
         addStep(
             idx,
@@ -1381,6 +1431,7 @@ class NetworkTestViewModel : ViewModel() {
         val builder = OkHttpClient.Builder()
             .connectTimeout(3, TimeUnit.SECONDS)
             .readTimeout(15, TimeUnit.SECONDS)
+            .dns(PixivIpv4OnlyDns)
             .protocols(listOf(Protocol.HTTP_1_1))
             .addInterceptor(WebHeaderInterceptor())
         if (directConnect) addCronet(builder)
@@ -1830,6 +1881,43 @@ class NetworkTestViewModel : ViewModel() {
         )
 
         private fun isFakeIp(ip: String): Boolean = FAKE_IP_CIDRS.any { isIpInCidr(ip, it) }
+
+        /** 是否官方 Pixiv 域名：只有这些域名在无代理时不该出现公网 IPv6。 */
+        private fun isPixivDomain(host: String): Boolean =
+            host == APP_API_HOST || host == "www.pixiv.net"
+
+        /**
+         * 是否公网 IPv6。
+         *
+         * 用于「官方 Pixiv 域名出现 IPv6 即视为 DNS 污染」的判断；先排除回环 / 链路本地 /
+         * 站点本地 / 组播 / ULA / 文档段 / NAT64 等非公网地址，避免 fake-ip 给的假 IPv6
+         * 被误判成污染。
+         */
+        private fun isPublicIpv6(addr: InetAddress): Boolean {
+            if (addr !is Inet6Address) return false
+            if (addr.isAnyLocalAddress || addr.isLoopbackAddress ||
+                addr.isLinkLocalAddress || addr.isSiteLocalAddress || addr.isMulticastAddress
+            ) {
+                return false
+            }
+            val host = addr.hostAddress?.lowercase() ?: return false
+            return !host.startsWith("fc") && !host.startsWith("fd") &&
+                !host.startsWith("64:ff9b:") && !host.startsWith("2001:db8:") &&
+                !host.startsWith("::ffff:")
+        }
+
+        /** 一次解析系统 DNS 结果，统一拆出后面各步要用的字段。 */
+        private fun analyzeSysDns(addrs: List<InetAddress>): SysDnsResult {
+            val ipv4 = addrs.filterIsInstance<Inet4Address>()
+            val ipv6 = addrs.filterIsInstance<Inet6Address>()
+            return SysDnsResult(
+                all = addrs,
+                ipv4 = ipv4,
+                ipv6 = ipv6,
+                fakeIps = ipv4.mapNotNull { it.hostAddress }.filter { isFakeIp(it) },
+                publicIpv6 = ipv6.filter { isPublicIpv6(it) },
+            )
+        }
 
         /** 握手 avg 超过该阈值判定为「高延迟」。 */
         private const val HIGH_LATENCY_MS = 500

--- a/app/src/main/java/ceui/pixiv/ui/debug/NetworkTestViewModel.kt
+++ b/app/src/main/java/ceui/pixiv/ui/debug/NetworkTestViewModel.kt
@@ -79,6 +79,29 @@ internal fun maskProxyUrl(url: String): String {
 }
 
 /**
+ * RFC 6052 允许的六种前缀长度（/32 /40 /48 /56 /64 /96）下，被嵌入的 IPv4 各占哪几个字节。
+ * 非 /96 时第 8 字节是保留位，IPv4 被它拆到两侧。
+ */
+private val NAT64_V4_OFFSETS = listOf(
+    intArrayOf(4, 5, 6, 7),
+    intArrayOf(5, 6, 7, 9),
+    intArrayOf(6, 7, 9, 10),
+    intArrayOf(7, 9, 10, 11),
+    intArrayOf(9, 10, 11, 12),
+    intArrayOf(12, 13, 14, 15),
+)
+
+/**
+ * 按 [NAT64_V4_OFFSETS] 从 IPv6 里取出所有可能被嵌入的 IPv4（六种前缀长度各一个）。
+ * 只负责取，不判断合不合法——由调用方拿官方 CIDR 白名单去比对。
+ */
+internal fun nat64EmbeddedIpv4Candidates(addr: Inet6Address): List<String> {
+    val b = addr.address
+    if (b.size != 16) return emptyList()
+    return NAT64_V4_OFFSETS.map { idx -> idx.joinToString(".") { (b[it].toInt() and 0xFF).toString() } }
+}
+
+/**
  * 网络测试页的 IPv4-only DNS（OkHttp [Dns]），做法抄自 PR #1036 的 IPv4OnlyDns。
  *
  * 当前测试流程大多会先把选定 IPv4 钉进 [buildHandshakeClient]（pinnedDns），所以这个
@@ -629,7 +652,7 @@ class NetworkTestViewModel : ViewModel() {
             setStatus(idx, TargetStatus.FAILED)
             return false to false
         }
-        val dns = analyzeSysDns(sysAddrs)
+        val dns = analyzeSysDns(sysAddrs, cfg.cidrs)
         val ipv4 = dns.ipv4
         // fake-ip 检测：代理接管 DNS 时返回保留地址。不取消目标——跳过 DNS/ping，仅测握手，
         // 且不再把解析出的 IP 喂给 OkHttp（让代理接管路由）。
@@ -697,7 +720,16 @@ class NetworkTestViewModel : ViewModel() {
                     sb.append(strRes(R.string.network_test_dns_miss, ip))
                 }
             }
-            dns.ipv6.forEach { sb.append(strRes(R.string.network_test_dns_ipv6_skip, it.hostAddress)) }
+            // 文案跟着判定走：没判污染（开了 PxveAPI / 非官方 Pixiv 域名 / 非公网 IPv6）时仍是「跳过」，
+            // 否则卡片会出现「实锤被污染」配一个绿色 pill 的自相矛盾。
+            dns.ipv6.forEach { addr ->
+                val res = if (pixivPublicIpv6 && addr in dns.publicIpv6) {
+                    R.string.network_test_dns_ipv6_polluted
+                } else {
+                    R.string.network_test_dns_ipv6_skip
+                }
+                sb.append(strRes(res, addr.hostAddress))
+            }
             polluted = (ipv4.isNotEmpty() && cleanCount == 0) || polluted
             val st = when {
                 polluted -> StepStatus.FAIL
@@ -739,7 +771,7 @@ class NetworkTestViewModel : ViewModel() {
                     }
                 }
                 appAddrs.filter { it !is Inet4Address }
-                    .forEach { sb.append(strRes(R.string.network_test_dns_ipv6_app_skip, it.hostAddress)) }
+                    .forEach { sb.append(strRes(R.string.network_test_dns_ipv6_skip, it.hostAddress)) }
 
                 val appPolluted = appV4.isNotEmpty() && appClean == 0
                 val st = when {
@@ -1887,27 +1919,41 @@ class NetworkTestViewModel : ViewModel() {
             host == APP_API_HOST || host == "www.pixiv.net"
 
         /**
+         * 是否 NAT64/DNS64 按该目标的官方 IPv4 合成出来的地址。
+         *
+         * IPv6-only 网络上 Android 解析器（netd）会按 RFC 7050 发现的前缀给只有 A 记录的域名
+         * 合成 AAAA。前缀常常是运营商自有的（NSP），落在全球单播段里，只认 64:ff9b::/96 挡不住。
+         * 改成看嵌入的 IPv4 本身：落在该目标的官方 CIDR 白名单里，就是正常合成而非污染
+         * ——被投毒的 IPv6 几乎不可能在 RFC 6052 的某个偏移上正好嵌一个合法官方 IPv4。
+         */
+        private fun isNat64Synthesized(addr: Inet6Address, cidrs: List<String>?): Boolean {
+            if (cidrs == null) return false
+            return nat64EmbeddedIpv4Candidates(addr).any { v4 -> cidrs.any { isIpInCidr(v4, it) } }
+        }
+
+        /**
          * 是否公网 IPv6。
          *
          * 用于「官方 Pixiv 域名出现 IPv6 即视为 DNS 污染」的判断；先排除回环 / 链路本地 /
          * 站点本地 / 组播 / ULA / 文档段 / NAT64 等非公网地址，避免 fake-ip 给的假 IPv6
-         * 被误判成污染。
+         * 被误判成污染。[cidrs] 为该目标的官方 IPv4 段，用来识别运营商前缀的 NAT64 合成地址。
          */
-        private fun isPublicIpv6(addr: InetAddress): Boolean {
+        private fun isPublicIpv6(addr: InetAddress, cidrs: List<String>?): Boolean {
             if (addr !is Inet6Address) return false
             if (addr.isAnyLocalAddress || addr.isLoopbackAddress ||
                 addr.isLinkLocalAddress || addr.isSiteLocalAddress || addr.isMulticastAddress
             ) {
                 return false
             }
+            if (isNat64Synthesized(addr, cidrs)) return false
             val host = addr.hostAddress?.lowercase() ?: return false
             return !host.startsWith("fc") && !host.startsWith("fd") &&
                 !host.startsWith("64:ff9b:") && !host.startsWith("2001:db8:") &&
                 !host.startsWith("::ffff:")
         }
 
-        /** 一次解析系统 DNS 结果，统一拆出后面各步要用的字段。 */
-        private fun analyzeSysDns(addrs: List<InetAddress>): SysDnsResult {
+        /** 一次解析系统 DNS 结果，统一拆出后面各步要用的字段。[cidrs] 为该目标的官方 IPv4 段。 */
+        private fun analyzeSysDns(addrs: List<InetAddress>, cidrs: List<String>?): SysDnsResult {
             val ipv4 = addrs.filterIsInstance<Inet4Address>()
             val ipv6 = addrs.filterIsInstance<Inet6Address>()
             return SysDnsResult(
@@ -1915,7 +1961,7 @@ class NetworkTestViewModel : ViewModel() {
                 ipv4 = ipv4,
                 ipv6 = ipv6,
                 fakeIps = ipv4.mapNotNull { it.hostAddress }.filter { isFakeIp(it) },
-                publicIpv6 = ipv6.filter { isPublicIpv6(it) },
+                publicIpv6 = ipv6.filter { isPublicIpv6(it, cidrs) },
             )
         }
 

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -2054,7 +2054,8 @@
     <string name="network_test_dns_resolve_failed">Resolution failed: %1$s</string>
     <string name="network_test_dns_hit">✓ %1$s ∈ %2$s\n</string>
     <string name="network_test_dns_miss">✗ %1$s not in any known range\n</string>
-    <string name="network_test_dns_ipv6_skip">· %1$s (IPv6, skipped)\n</string>
+    <string name="network_test_dns_ipv6_skip">· %1$s (IPv6 address found; DNS is confirmed polluted)\n</string>
+    <string name="network_test_dns_ipv6_app_skip">· %1$s (IPv6, skipped)\n</string>
     <string name="network_test_dns_fakeip">Returned reserved address (possible proxy fake-ip): %1$s\nSkipping DNS check and ping; handshake only</string>
     <string name="network_test_dns_app_step">In-app resolution · HttpDns(DoH/direct) · %1$d results</string>
     <string name="network_test_dns_app_step_plain">In-app resolution · HttpDns</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -2054,8 +2054,8 @@
     <string name="network_test_dns_resolve_failed">Resolution failed: %1$s</string>
     <string name="network_test_dns_hit">✓ %1$s ∈ %2$s\n</string>
     <string name="network_test_dns_miss">✗ %1$s not in any known range\n</string>
-    <string name="network_test_dns_ipv6_skip">· %1$s (IPv6 address found; DNS is confirmed polluted)\n</string>
-    <string name="network_test_dns_ipv6_app_skip">· %1$s (IPv6, skipped)\n</string>
+    <string name="network_test_dns_ipv6_skip">· %1$s (IPv6, skipped)\n</string>
+    <string name="network_test_dns_ipv6_polluted">· %1$s (IPv6 address found; DNS is confirmed polluted)\n</string>
     <string name="network_test_dns_fakeip">Returned reserved address (possible proxy fake-ip): %1$s\nSkipping DNS check and ping; handshake only</string>
     <string name="network_test_dns_app_step">In-app resolution · HttpDns(DoH/direct) · %1$d results</string>
     <string name="network_test_dns_app_step_plain">In-app resolution · HttpDns</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -2054,8 +2054,8 @@
     <string name="network_test_dns_resolve_failed">解決失敗: %1$s</string>
     <string name="network_test_dns_hit">✓ %1$s ∈ %2$s\n</string>
     <string name="network_test_dns_miss">✗ %1$s は既知の範囲外\n</string>
-    <string name="network_test_dns_ipv6_skip">· %1$s（IPv6 アドレスを検出、DNS 汚染が確定）\n</string>
-    <string name="network_test_dns_ipv6_app_skip">· %1$s (IPv6, スキップ)\n</string>
+    <string name="network_test_dns_ipv6_skip">· %1$s (IPv6, スキップ)\n</string>
+    <string name="network_test_dns_ipv6_polluted">· %1$s（IPv6 アドレスを検出、DNS 汚染が確定）\n</string>
     <string name="network_test_dns_fakeip">予約アドレスが返されました（プロキシの fake-ip の可能性）: %1$s\nDNS チェックと ping をスキップし、ハンドシェイクのみ実施</string>
     <string name="network_test_dns_app_step">アプリ内解決 · HttpDns(DoH/直続) · %1$d 件</string>
     <string name="network_test_dns_app_step_plain">アプリ内解決 · HttpDns</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -2054,7 +2054,8 @@
     <string name="network_test_dns_resolve_failed">解決失敗: %1$s</string>
     <string name="network_test_dns_hit">✓ %1$s ∈ %2$s\n</string>
     <string name="network_test_dns_miss">✗ %1$s は既知の範囲外\n</string>
-    <string name="network_test_dns_ipv6_skip">· %1$s (IPv6, スキップ)\n</string>
+    <string name="network_test_dns_ipv6_skip">· %1$s（IPv6 アドレスを検出、DNS 汚染が確定）\n</string>
+    <string name="network_test_dns_ipv6_app_skip">· %1$s (IPv6, スキップ)\n</string>
     <string name="network_test_dns_fakeip">予約アドレスが返されました（プロキシの fake-ip の可能性）: %1$s\nDNS チェックと ping をスキップし、ハンドシェイクのみ実施</string>
     <string name="network_test_dns_app_step">アプリ内解決 · HttpDns(DoH/直続) · %1$d 件</string>
     <string name="network_test_dns_app_step_plain">アプリ内解決 · HttpDns</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2054,7 +2054,8 @@
     <string name="network_test_dns_resolve_failed">해석 실패: %1$s</string>
     <string name="network_test_dns_hit">✓ %1$s ∈ %2$s\n</string>
     <string name="network_test_dns_miss">✗ %1$s이(가) 알려진 범위에 없음\n</string>
-    <string name="network_test_dns_ipv6_skip">· %1$s (IPv6, 건너뜀)\n</string>
+    <string name="network_test_dns_ipv6_skip">· %1$s (IPv6 주소 발견, DNS 오염 확정)\n</string>
+    <string name="network_test_dns_ipv6_app_skip">· %1$s (IPv6, 건너뜀)\n</string>
     <string name="network_test_dns_fakeip">예약 주소가 반환됨(프록시 fake-ip 가능성): %1$s\nDNS 검사와 ping을 건너뛰고 핸드셰이크만 수행</string>
     <string name="network_test_dns_app_step">앱 내 해석 · HttpDns(DoH/직접) · %1$d개</string>
     <string name="network_test_dns_app_step_plain">앱 내 해석 · HttpDns</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2054,8 +2054,8 @@
     <string name="network_test_dns_resolve_failed">해석 실패: %1$s</string>
     <string name="network_test_dns_hit">✓ %1$s ∈ %2$s\n</string>
     <string name="network_test_dns_miss">✗ %1$s이(가) 알려진 범위에 없음\n</string>
-    <string name="network_test_dns_ipv6_skip">· %1$s (IPv6 주소 발견, DNS 오염 확정)\n</string>
-    <string name="network_test_dns_ipv6_app_skip">· %1$s (IPv6, 건너뜀)\n</string>
+    <string name="network_test_dns_ipv6_skip">· %1$s (IPv6, 건너뜀)\n</string>
+    <string name="network_test_dns_ipv6_polluted">· %1$s (IPv6 주소 발견, DNS 오염 확정)\n</string>
     <string name="network_test_dns_fakeip">예약 주소가 반환됨(프록시 fake-ip 가능성): %1$s\nDNS 검사와 ping을 건너뛰고 핸드셰이크만 수행</string>
     <string name="network_test_dns_app_step">앱 내 해석 · HttpDns(DoH/직접) · %1$d개</string>
     <string name="network_test_dns_app_step_plain">앱 내 해석 · HttpDns</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2054,8 +2054,8 @@
     <string name="network_test_dns_resolve_failed">Ошибка разрешения: %1$s</string>
     <string name="network_test_dns_hit">✓ %1$s ∈ %2$s\n</string>
     <string name="network_test_dns_miss">✗ %1$s вне известных диапазонов\n</string>
-    <string name="network_test_dns_ipv6_skip">· %1$s (обнаружен IPv6, DNS точно загрязнён)\n</string>
-    <string name="network_test_dns_ipv6_app_skip">· %1$s (IPv6, пропуск)\n</string>
+    <string name="network_test_dns_ipv6_skip">· %1$s (IPv6, пропуск)\n</string>
+    <string name="network_test_dns_ipv6_polluted">· %1$s (обнаружен IPv6, DNS точно загрязнён)\n</string>
     <string name="network_test_dns_fakeip">Возвращён зарезервированный адрес (возможен fake-ip прокси): %1$s\nПроверка DNS и ping пропущены, только рукопожатие</string>
     <string name="network_test_dns_app_step">Разрешение в приложении · HttpDns(DoH/прямое) · %1$d записей</string>
     <string name="network_test_dns_app_step_plain">Разрешение в приложении · HttpDns</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2054,7 +2054,8 @@
     <string name="network_test_dns_resolve_failed">Ошибка разрешения: %1$s</string>
     <string name="network_test_dns_hit">✓ %1$s ∈ %2$s\n</string>
     <string name="network_test_dns_miss">✗ %1$s вне известных диапазонов\n</string>
-    <string name="network_test_dns_ipv6_skip">· %1$s (IPv6, пропуск)\n</string>
+    <string name="network_test_dns_ipv6_skip">· %1$s (обнаружен IPv6, DNS точно загрязнён)\n</string>
+    <string name="network_test_dns_ipv6_app_skip">· %1$s (IPv6, пропуск)\n</string>
     <string name="network_test_dns_fakeip">Возвращён зарезервированный адрес (возможен fake-ip прокси): %1$s\nПроверка DNS и ping пропущены, только рукопожатие</string>
     <string name="network_test_dns_app_step">Разрешение в приложении · HttpDns(DoH/прямое) · %1$d записей</string>
     <string name="network_test_dns_app_step_plain">Разрешение в приложении · HttpDns</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -2054,8 +2054,8 @@
     <string name="network_test_dns_resolve_failed">Çözümleme başarısız: %1$s</string>
     <string name="network_test_dns_hit">✓ %1$s ∈ %2$s\n</string>
     <string name="network_test_dns_miss">✗ %1$s bilinen aralıklarda değil\n</string>
-    <string name="network_test_dns_ipv6_skip">· %1$s (IPv6 adresi bulundu, DNS kesin olarak kirli)\n</string>
-    <string name="network_test_dns_ipv6_app_skip">· %1$s (IPv6, atlandı)\n</string>
+    <string name="network_test_dns_ipv6_skip">· %1$s (IPv6, atlandı)\n</string>
+    <string name="network_test_dns_ipv6_polluted">· %1$s (IPv6 adresi bulundu, DNS kesin olarak kirli)\n</string>
     <string name="network_test_dns_fakeip">Ayrılmış adres döndü (proxy fake-ip olabilir): %1$s\nDNS kontrolü ve ping atlandı, yalnızca el sıkışma</string>
     <string name="network_test_dns_app_step">Uygulama içi çözümleme · HttpDns(DoH/doğrudan) · %1$d sonuç</string>
     <string name="network_test_dns_app_step_plain">Uygulama içi çözümleme · HttpDns</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -2054,7 +2054,8 @@
     <string name="network_test_dns_resolve_failed">Çözümleme başarısız: %1$s</string>
     <string name="network_test_dns_hit">✓ %1$s ∈ %2$s\n</string>
     <string name="network_test_dns_miss">✗ %1$s bilinen aralıklarda değil\n</string>
-    <string name="network_test_dns_ipv6_skip">· %1$s (IPv6, atlandı)\n</string>
+    <string name="network_test_dns_ipv6_skip">· %1$s (IPv6 adresi bulundu, DNS kesin olarak kirli)\n</string>
+    <string name="network_test_dns_ipv6_app_skip">· %1$s (IPv6, atlandı)\n</string>
     <string name="network_test_dns_fakeip">Ayrılmış adres döndü (proxy fake-ip olabilir): %1$s\nDNS kontrolü ve ping atlandı, yalnızca el sıkışma</string>
     <string name="network_test_dns_app_step">Uygulama içi çözümleme · HttpDns(DoH/doğrudan) · %1$d sonuç</string>
     <string name="network_test_dns_app_step_plain">Uygulama içi çözümleme · HttpDns</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -2056,7 +2056,8 @@
     <string name="network_test_dns_resolve_failed">解析失敗: %1$s</string>
     <string name="network_test_dns_hit">✓ %1$s ∈ %2$s\n</string>
     <string name="network_test_dns_miss">✗ %1$s 不在任何已知段\n</string>
-    <string name="network_test_dns_ipv6_skip">· %1$s (IPv6, 跳過)\n</string>
+    <string name="network_test_dns_ipv6_skip">· %1$s（發現 IPv6 位址，實錘 DNS 被污染）\n</string>
+    <string name="network_test_dns_ipv6_app_skip">· %1$s (IPv6, 跳過)\n</string>
     <string name="network_test_dns_fakeip">返回保留位址（疑似代理 fake-ip）: %1$s\n跳過 DNS 校驗與 ping，僅測握手</string>
     <string name="network_test_dns_app_step">應用內解析 · HttpDns(DoH/直連) · %1$d 條</string>
     <string name="network_test_dns_app_step_plain">應用內解析 · HttpDns</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -2056,8 +2056,8 @@
     <string name="network_test_dns_resolve_failed">解析失敗: %1$s</string>
     <string name="network_test_dns_hit">✓ %1$s ∈ %2$s\n</string>
     <string name="network_test_dns_miss">✗ %1$s 不在任何已知段\n</string>
-    <string name="network_test_dns_ipv6_skip">· %1$s（發現 IPv6 位址，實錘 DNS 被污染）\n</string>
-    <string name="network_test_dns_ipv6_app_skip">· %1$s (IPv6, 跳過)\n</string>
+    <string name="network_test_dns_ipv6_skip">· %1$s (IPv6, 跳過)\n</string>
+    <string name="network_test_dns_ipv6_polluted">· %1$s（發現 IPv6 位址，實錘 DNS 被污染）\n</string>
     <string name="network_test_dns_fakeip">返回保留位址（疑似代理 fake-ip）: %1$s\n跳過 DNS 校驗與 ping，僅測握手</string>
     <string name="network_test_dns_app_step">應用內解析 · HttpDns(DoH/直連) · %1$d 條</string>
     <string name="network_test_dns_app_step_plain">應用內解析 · HttpDns</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2279,8 +2279,8 @@
     <string name="network_test_dns_resolve_failed">解析失败: %1$s</string>
     <string name="network_test_dns_hit">✓ %1$s ∈ %2$s\n</string>
     <string name="network_test_dns_miss">✗ %1$s 不在任何已知段\n</string>
-    <string name="network_test_dns_ipv6_skip">· %1$s（发现 IPv6 地址，实锤 DNS 被污染）\n</string>
-    <string name="network_test_dns_ipv6_app_skip">· %1$s (IPv6, 跳过)\n</string>
+    <string name="network_test_dns_ipv6_skip">· %1$s (IPv6, 跳过)\n</string>
+    <string name="network_test_dns_ipv6_polluted">· %1$s（发现 IPv6 地址，实锤 DNS 被污染）\n</string>
     <string name="network_test_dns_fakeip">返回保留地址（疑似代理 fake-ip）: %1$s\n跳过 DNS 校验与 ping，仅测握手</string>
     <string name="network_test_dns_app_step">应用内解析 · HttpDns(DoH/直连) · %1$d 条</string>
     <string name="network_test_dns_app_step_plain">应用内解析 · HttpDns</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2279,7 +2279,8 @@
     <string name="network_test_dns_resolve_failed">解析失败: %1$s</string>
     <string name="network_test_dns_hit">✓ %1$s ∈ %2$s\n</string>
     <string name="network_test_dns_miss">✗ %1$s 不在任何已知段\n</string>
-    <string name="network_test_dns_ipv6_skip">· %1$s (IPv6, 跳过)\n</string>
+    <string name="network_test_dns_ipv6_skip">· %1$s（发现 IPv6 地址，实锤 DNS 被污染）\n</string>
+    <string name="network_test_dns_ipv6_app_skip">· %1$s (IPv6, 跳过)\n</string>
     <string name="network_test_dns_fakeip">返回保留地址（疑似代理 fake-ip）: %1$s\n跳过 DNS 校验与 ping，仅测握手</string>
     <string name="network_test_dns_app_step">应用内解析 · HttpDns(DoH/直连) · %1$d 条</string>
     <string name="network_test_dns_app_step_plain">应用内解析 · HttpDns</string>

--- a/app/src/test/java/ceui/pixiv/ui/debug/Nat64EmbeddedIpv4Test.kt
+++ b/app/src/test/java/ceui/pixiv/ui/debug/Nat64EmbeddedIpv4Test.kt
@@ -1,0 +1,62 @@
+package ceui.pixiv.ui.debug
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.net.Inet6Address
+import java.net.InetAddress
+
+/**
+ * [nat64EmbeddedIpv4Candidates] 的字节偏移回归。
+ *
+ * 网络测试页把「官方 Pixiv 域名解析出公网 IPv6」当作 DNS 污染的实锤。IPv6-only 网络上
+ * DNS64 会给只有 A 记录的域名合成 AAAA，用的往往是运营商自有前缀（NSP）而不是众所周知的
+ * 64:ff9b::/96 —— 那种地址在全球单播段里，光看前缀挡不住，会把一个完全正常的网络误报成污染。
+ * 所以改成把嵌入的 IPv4 抠出来跟官方 CIDR 白名单比对，而这里的字节偏移一旦写错，
+ * 抠出来的就是垃圾，NAT64 豁免会静默失效 —— 用 RFC 6052 §2.4 的官方向量钉死。
+ */
+class Nat64EmbeddedIpv4Test {
+
+    private fun v6(s: String): Inet6Address = InetAddress.getByName(s) as Inet6Address
+
+    // ── RFC 6052 §2.4 的六个官方向量：前缀长度不同，嵌入的都是 192.0.2.33 ──────────
+
+    @Test
+    fun `RFC 6052 六种前缀长度都能抠出 192-0-2-33`() {
+        val vectors = listOf(
+            "2001:db8:c000:221::",          // /32
+            "2001:db8:1c0:2:21::",          // /40
+            "2001:db8:122:c000:2:2100::",   // /48
+            "2001:db8:122:3c0:0:221::",     // /56
+            "2001:db8:122:344:c0:2:2100::", // /64
+            "2001:db8:122:344::192.0.2.33", // /96
+        )
+        for (addr in vectors) {
+            assertTrue(
+                "$addr 应能抠出 192.0.2.33",
+                "192.0.2.33" in nat64EmbeddedIpv4Candidates(v6(addr)),
+            )
+        }
+    }
+
+    // ── 真实场景：运营商自有前缀合成 Cloudflare IP，不该被判成污染 ──────────────────
+
+    @Test
+    fun `运营商自有前缀 96 合成的 Cloudflare 地址能被认出来`() {
+        // 2409:8000::/96 形态的 NSP + 104.16.0.1（落在 PIXIV_CIDRS 的 104.16.0.0/13 里）。
+        assertTrue("104.16.0.1" in nat64EmbeddedIpv4Candidates(v6("2409:8000::104.16.0.1")))
+    }
+
+    @Test
+    fun `众所周知前缀 64-ff9b 同样走通用提取`() {
+        assertTrue("210.140.92.1" in nat64EmbeddedIpv4Candidates(v6("64:ff9b::210.140.92.1")))
+    }
+
+    // ── 反例：真投毒的 IPv6 抠不出白名单里的地址 ─────────────────────────────────
+
+    @Test
+    fun `普通公网 IPv6 抠出来的候选里没有官方 IP`() {
+        // GFW 投毒常见的随意 IPv6：六个候选都是无意义字节，不会撞进官方段。
+        val candidates = nat64EmbeddedIpv4Candidates(v6("2001:4860:4860::8888"))
+        assertTrue("104.16.0.1" !in candidates && "210.140.92.1" !in candidates)
+    }
+}


### PR DESCRIPTION
# 网络测试页：Pixiv 域名公网 IPv6 判污染，并收敛 DNS 解析

> 分支：`patch-8-18-2`（wangwang-code fork；本地 remote 名为 `my`）
> 提交：`8cb906937` refactor(network): 网络测试页收敛 DNS 解析并识别 Pixiv IPv6 污染

## 背景

PR #1036 给线上链路加了 `IPv4OnlyDns`：官方 Pixiv 域名只有 IPv4 记录，系统 DNS 返回 IPv6 基本是污染。当时说明“需要推广到网络测试页，另外起 PR”，本次就是这部分工作。

网络测试页是诊断页，如果它自己也把被污染的 IPv6 当作正常地址展示/尝试，会和线上实际行为不一致；另外 `testTarget()` 里对 `sysAddrs` 有多次重复过滤，顺手收敛。

## 改动内容

### 1. 网络测试页自建防守性 IPv4-only DNS

- 新增 `PixivIpv4OnlyDns`，做法抄自 PR #1036 的 `IPv4OnlyDns`。
- 只过滤 `app-api.pixiv.net` / `www.pixiv.net` 两个官方 Pixiv 域名的 IPv6；其它域名（PxveAPI 代理、图片反代等）原样放行。
- 当前握手大多会先用 `pinnedDns` 钉 IPv4，所以这个 DNS 实际未必会走到；保留它作为防守，覆盖未钉 IP（fake-ip / 代理 / Cronet 绕过）的场景。

### 2. 公网 IPv6 直接判 DNS 污染

- 未开启 PxveAPI 时，官方 Pixiv 域名若被系统 DNS 返回**公网 IPv6**，直接判为 DNS 污染。
- 只认公网 IPv6：排除回环 / 链路本地 / 站点本地 / 组播 / ULA / NAT64 / 文档段 / IPv4-mapped 等，避免 fake-ip 给的假 IPv6 被误判。
- 如果开了直连，仍允许继续尝试 HTTPS 握手（Cronet 绕过路径不受影响）。
- 直连 + 安全 DNS 还能解析出 IPv6 的极端情况不做额外处理。

### 3. 卡片文案

- `network_test_dns_ipv6_skip` 文案改为：发现 IPv6 地址，实锤 DNS 被污染。
- 新增 `network_test_dns_ipv6_app_skip`，HttpDns 应用内解析步骤继续使用原来的“IPv6, 跳过”文案，避免安全 DNS 返回 IPv6 时也误显示“实锤污染”。

### 4. 收敛 `testTarget()` 的 DNS 解析

- 新增 `SysDnsResult` 与 `analyzeSysDns()`，一次解析 `sysAddrs`，统一拆出 IPv4 / IPv6 / fake-ip / 公网 IPv6。
- CIDR 命中、`cleanV4`、`cleanCount` 只算一次，后续展示、握手目标选择、状态判定共用。
- 将 `buildHandshakeClient` / `httpsHandshakeSampled` / `probeWebEndpoint` / `icmpPing` 的 IP 参数收窄为 `Inet4Address`，从类型上保证 `pinnedDns` 不会喂入 IPv6。

## 涉及文件

- `app/src/main/java/ceui/pixiv/ui/debug/NetworkTestViewModel.kt`
- `app/src/main/res/values/strings.xml`
- `app/src/main/res/values-en/strings.xml`
- `app/src/main/res/values-zh-rTW/strings.xml`
- `app/src/main/res/values-ru/strings.xml`
- `app/src/main/res/values-ja/strings.xml`
- `app/src/main/res/values-tr/strings.xml`
- `app/src/main/res/values-ko/strings.xml`
