### PR TITLE
插画/漫画下载时自动导出简介（独立简介桶 + 设置开关 + 最少字数）

### DIFF
--- a/app/src/main/java/ceui/lisa/activities/ImageDetailActivity.kt
+++ b/app/src/main/java/ceui/lisa/activities/ImageDetailActivity.kt
@@ -40,6 +40,7 @@ import ceui.pixiv.ui.detail.DownloadFab
 import ceui.pixiv.ui.detail.V3FabBarController
 import ceui.pixiv.utils.setOnClick
 import ceui.pixiv.download.DownloadsRegistry
+import ceui.pixiv.download.IllustCaptionExporter
 import ceui.pixiv.download.ExifKeywordWriter
 import ceui.pixiv.download.config.DownloadItems
 import ceui.pixiv.imageloader.ImageLoaderV3
@@ -409,6 +410,7 @@ class ImageDetailActivity : BaseActivity<ActivityImageDetailBinding?>() {
                 ?: IllustDownload.getUrl(illust, page, Params.IMAGE_RESOLUTION_LARGE)
                 ?: return@setOnClick
             lifecycleScope.launch {
+                IllustCaptionExporter.export(illust)
                 val ok = saveLoadedIllustPage(illust, page, imageUrl)
                 if (ok) {
                     Common.showToast(R.string.string_181)

--- a/app/src/main/java/ceui/lisa/download/IllustDownload.java
+++ b/app/src/main/java/ceui/lisa/download/IllustDownload.java
@@ -39,6 +39,7 @@ import ceui.lisa.models.ImageUrlsBean;
 import ceui.lisa.models.MetaPagesBean;
 import ceui.loxia.ObjectPool;
 import ceui.pixiv.download.DownloadsRegistry;
+import ceui.pixiv.download.IllustCaptionExporter;
 import ceui.pixiv.download.config.StorageChoice;
 import ceui.pixiv.ui.bulk.UgoiraEngine;
 import io.reactivex.android.schedulers.AndroidSchedulers;
@@ -83,6 +84,7 @@ public class IllustDownload {
                 return;
             }
             if (illust.getPage_count() == 1) {
+                IllustCaptionExporter.export(illust);
                 DownloadItem item = buildDownloadItem(illust, 0, imageResolution);
                 Common.showToast('1' + Shaft.getContext().getString(R.string.has_been_added));
                 Manager.get().addTask(item);
@@ -101,6 +103,7 @@ public class IllustDownload {
             return;
         }
         if (illust.getPage_count() == 1) {
+            IllustCaptionExporter.export(illust);
             DownloadItem item = buildDownloadItem(illust, 0, imageResolution);
             Common.showToast('1' + Shaft.getContext().getString(R.string.has_been_added));
             Manager.get().addTask(item);
@@ -113,6 +116,7 @@ public class IllustDownload {
                 // index!=0 时不合理
                 downloadIllustFirstPage(illust);
             } else {
+                IllustCaptionExporter.export(illust);
                 DownloadItem item = buildDownloadItem(illust, index);
                 Common.showToast('1' + Shaft.getContext().getString(R.string.has_been_added));
                 Manager.get().addTask(item);
@@ -129,6 +133,7 @@ public class IllustDownload {
             if (illust.getPage_count() == 1) {
                 downloadIllustFirstPage(illust, activity);
             } else {
+                IllustCaptionExporter.export(illust);
                 List<DownloadItem> tempList = new ArrayList<>();
                 for (int i = 0; i < illust.getPage_count(); i++) {
                     DownloadItem item = buildDownloadItem(illust, i, imageResolution);
@@ -157,6 +162,7 @@ public class IllustDownload {
         } else if (illust.getPage_count() == 1) {
             downloadIllustFirstPage(illust);
         } else {
+            IllustCaptionExporter.export(illust);
             List<DownloadItem> tempList = new ArrayList<>();
             for (int i = 0; i < illust.getPage_count(); i++) {
                 DownloadItem item = buildDownloadItem(illust, i);

--- a/app/src/main/java/ceui/lisa/fragments/FragmentSettingsDownload.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSettingsDownload.java
@@ -2,6 +2,7 @@ package ceui.lisa.fragments;
 
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.text.InputType;
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.CompoundButton;
@@ -329,6 +330,51 @@ public class FragmentSettingsDownload extends SettingsPageFragment<FragmentSetti
         baseBind.silentDownloadRela.setOnClickListener(v ->
                 baseBind.silentDownload.performClick());
 
+        // 插画/漫画下载时自动导出简介（默认关）
+        baseBind.autoExportCaption.setChecked(Shaft.sSettings.isAutoExportIllustCaption());
+        refreshAutoExportCaptionLengthRow();
+        baseBind.autoExportCaptionLengthRela.setVisibility(
+                Shaft.sSettings.isAutoExportIllustCaption() ? View.VISIBLE : View.GONE);
+        baseBind.autoExportCaption.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                Shaft.sSettings.setAutoExportIllustCaption(isChecked);
+                baseBind.autoExportCaptionLengthRela.setVisibility(isChecked ? View.VISIBLE : View.GONE);
+                if (isChecked) refreshAutoExportCaptionLengthRow();
+                Common.showToast(getString(R.string.string_428));
+                Local.setSettings(Shaft.sSettings);
+            }
+        });
+        baseBind.autoExportCaptionRela.setOnClickListener(v ->
+                baseBind.autoExportCaption.performClick());
+
+        // 简介自动导出需达到的最少字数（最小 1）
+        baseBind.autoExportCaptionLengthRela.setOnClickListener(v -> {
+            WitDialog.EditTextDialogBuilder builder =
+                    new WitDialog.EditTextDialogBuilder(mContext);
+            int current = Math.max(Shaft.sSettings.getAutoExportCaptionMinLength(), 1);
+            builder.setTitle(getString(R.string.setting_auto_export_caption_length_title))
+                    .setDefaultText(String.valueOf(current))
+                    .setInputType(InputType.TYPE_CLASS_NUMBER)
+                    .addAction(android.R.string.cancel, (dialog, index) -> dialog.dismiss())
+                    .addAction(android.R.string.ok, (dialog, index) -> {
+                        CharSequence entered = builder.getEditText().getText();
+                        int parsed = 1;
+                        try {
+                            parsed = Integer.parseInt(entered == null ? "" : entered.toString().trim());
+                        } catch (NumberFormatException ignored) {
+                        }
+                        parsed = Math.max(parsed, 1);
+                        Shaft.sSettings.setAutoExportCaptionMinLength(parsed);
+                        Local.setSettings(Shaft.sSettings);
+                        refreshAutoExportCaptionLengthRow();
+                        Common.showToast(getString(R.string.string_428), 2);
+                        dialog.dismiss();
+                    })
+                    .create()
+                    .show();
+        });
+
         //下载限制类型
         final String[] DOWNLOAD_START_TYPE_NAMES = new String[]{
                 getString(DownloadLimitTypeUtil.DOWNLOAD_START_TYPE_IDS[0]),
@@ -454,6 +500,14 @@ public class FragmentSettingsDownload extends SettingsPageFragment<FragmentSetti
         if (baseBind == null) return;
         baseBind.ugoiraSaveFormat.setText(ugoiraSaveFormatNames()[currentUgoiraSaveFormat()]);
         baseBind.ugoiraSaveFormat.setAlpha(1.0f);
+    }
+
+    /** 简介自动导出最少字数行的值列。 */
+    private void refreshAutoExportCaptionLengthRow() {
+        if (baseBind == null) return;
+        int value = Math.max(Shaft.sSettings.getAutoExportCaptionMinLength(), 1);
+        baseBind.autoExportCaptionLength.setText(
+                getString(R.string.setting_auto_export_caption_length_value, value));
     }
 
     /** aria2 远程下载入口行的状态文字：已启用时显示 RPC 地址，否则显示功能简介。 */

--- a/app/src/main/java/ceui/lisa/utils/Settings.java
+++ b/app/src/main/java/ceui/lisa/utils/Settings.java
@@ -285,6 +285,10 @@ public class Settings {
 
     private boolean toastDownloadResult = true; // 默认提示下载结果
 
+    private boolean autoExportIllustCaption = false; // 插画/漫画下载时自动导出简介，默认关
+
+    private int autoExportCaptionMinLength = 1; // 简介自动导出需达到的最少字数，最小 1
+
     private transient boolean r18FilterTempEnableInitialed = false;
     private transient boolean r18FilterTempEnable = false; // 临时开启R18内容过滤
 
@@ -388,6 +392,22 @@ public class Settings {
 
     public void setToastDownloadResult(boolean toastDownloadResult) {
         this.toastDownloadResult = toastDownloadResult;
+    }
+
+    public boolean isAutoExportIllustCaption() {
+        return autoExportIllustCaption;
+    }
+
+    public void setAutoExportIllustCaption(boolean autoExportIllustCaption) {
+        this.autoExportIllustCaption = autoExportIllustCaption;
+    }
+
+    public int getAutoExportCaptionMinLength() {
+        return autoExportCaptionMinLength;
+    }
+
+    public void setAutoExportCaptionMinLength(int autoExportCaptionMinLength) {
+        this.autoExportCaptionMinLength = autoExportCaptionMinLength;
     }
 
     public int getDownloadWay() {

--- a/app/src/main/java/ceui/pixiv/download/IllustCaptionExporter.kt
+++ b/app/src/main/java/ceui/pixiv/download/IllustCaptionExporter.kt
@@ -1,0 +1,69 @@
+package ceui.pixiv.download
+
+import ceui.lisa.activities.Shaft
+import ceui.lisa.models.IllustsBean
+import ceui.pixiv.download.config.DownloadItems
+import ceui.pixiv.download.model.Bucket
+import ceui.pixiv.ui.task.DownloadNovelTask
+import timber.log.Timber
+
+/**
+ * 插画/漫画下载时，在作品进入 Manager 下载队列前，把作品简介（caption）导出一份 txt。
+ *
+ * 只在 [SUPPORTED_TYPES]（illust / manga）生效；小说、动图不参与。
+ * 内容参照小说 TXT 的信息头风格：标题 / 作者 / 作品ID / 链接 / 标签 / 简介。
+ * 落盘路径走独立的 [Bucket.Caption] 桶，默认不与图片混放。
+ */
+object IllustCaptionExporter {
+
+    private const val TAG = "IllustCaptionExporter"
+
+    /** 当前只对插画 / 漫画生效。 */
+    private val SUPPORTED_TYPES = setOf("illust", "manga")
+
+    /**
+     * 导出一次作品简介。
+     *
+     * 应在「下载这个作品」的入口调用一次，而不是每张 page 完成时调用。
+     *
+     * @return true 表示确实写入了；无简介 / 不支持的 type / 按覆盖策略跳过时返回 false。
+     */
+    @JvmStatic
+    fun export(illust: IllustsBean?): Boolean {
+        if (!Shaft.sSettings.isAutoExportIllustCaption) return false
+        if (illust == null) return false
+        if (illust.type !in SUPPORTED_TYPES) return false
+        val caption = DownloadNovelTask.replaceBrWithNewLine(illust.caption).trim()
+        if (caption.isBlank()) return false
+        val minLength = Shaft.sSettings.getAutoExportCaptionMinLength().coerceAtLeast(1)
+        if (caption.length < minLength) return false
+
+        return try {
+            val destination = DownloadItems.illustCaptionDestination(illust)
+            val handle = DownloadsRegistry.downloads.openRaw(Bucket.Caption, destination, "text/plain")
+                ?: return false
+            handle.stream.use { it.write(buildContent(illust, caption).toByteArray(Charsets.UTF_8)) }
+            handle.onFinish()
+            true
+        } catch (t: Throwable) {
+            Timber.tag(TAG).w(t, "export caption failed illust=${illust.id}")
+            false
+        }
+    }
+
+    private fun buildContent(illust: IllustsBean, caption: String): String {
+        val sb = StringBuilder()
+        sb.append("标题：").append(illust.title.orEmpty()).append("\n\n")
+        sb.append("作者：").append(illust.user?.name.orEmpty()).append("\n\n")
+        sb.append("作者ID：").append(illust.user?.id ?: "").append("\n\n")
+        sb.append("作品ID：").append(illust.id).append("\n\n")
+        sb.append("作品链接：https://www.pixiv.net/artworks/").append(illust.id).append("\n\n")
+        val tags = illust.tags.orEmpty()
+            .mapNotNull { it.name?.takeIf { n -> n.isNotBlank() } }
+        if (tags.isNotEmpty()) {
+            sb.append("标签：").append(tags.joinToString(", ")).append("\n\n")
+        }
+        sb.append("简介：\n").append(caption).append('\n')
+        return sb.toString()
+    }
+}

--- a/app/src/main/java/ceui/pixiv/download/IllustCaptionExporter.kt
+++ b/app/src/main/java/ceui/pixiv/download/IllustCaptionExporter.kt
@@ -5,6 +5,10 @@ import ceui.lisa.models.IllustsBean
 import ceui.pixiv.download.config.DownloadItems
 import ceui.pixiv.download.model.Bucket
 import ceui.pixiv.ui.task.DownloadNovelTask
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 /**
@@ -22,32 +26,49 @@ object IllustCaptionExporter {
     private val SUPPORTED_TYPES = setOf("illust", "manga")
 
     /**
-     * 导出一次作品简介。
+     * 落盘串行跑在 IO 线程：调用方多半是 UI 点击（[ceui.lisa.download.IllustDownload]
+     * 各入口）或 Main 协程，SAF 的 createFile / MediaStore 的 replace 都是多次 binder
+     * 往返，不能压在主线程上。限 1 并发是为了同一作品被连点两次时不会两条写同一
+     * 路径互相踩（Replace 策略下会一边删一边建）。
+     */
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO.limitedParallelism(1))
+
+    /**
+     * 导出一次作品简介（异步、fire-and-forget）。
      *
      * 应在「下载这个作品」的入口调用一次，而不是每张 page 完成时调用。
-     *
-     * @return true 表示确实写入了；无简介 / 不支持的 type / 按覆盖策略跳过时返回 false。
+     * 开关关闭 / 无简介 / 不支持的 type / 字数不够时在调用线程上直接返回，不起协程。
      */
     @JvmStatic
-    fun export(illust: IllustsBean?): Boolean {
-        if (!Shaft.sSettings.isAutoExportIllustCaption) return false
-        if (illust == null) return false
-        if (illust.type !in SUPPORTED_TYPES) return false
+    fun export(illust: IllustsBean?) {
+        if (!Shaft.sSettings.isAutoExportIllustCaption) return
+        if (illust == null) return
+        if (illust.type !in SUPPORTED_TYPES) return
         val caption = DownloadNovelTask.replaceBrWithNewLine(illust.caption).trim()
-        if (caption.isBlank()) return false
-        val minLength = Shaft.sSettings.getAutoExportCaptionMinLength().coerceAtLeast(1)
-        if (caption.length < minLength) return false
+        if (caption.isBlank()) return
+        val minLength = Shaft.sSettings.autoExportCaptionMinLength.coerceAtLeast(1)
+        if (caption.length < minLength) return
 
-        return try {
+        scope.launch { write(illust, caption) }
+    }
+
+    private fun write(illust: IllustsBean, caption: String) {
+        try {
             val destination = DownloadItems.illustCaptionDestination(illust)
+            // openRaw 返回 null = Skip 策略且文件已存在，按策略跳过。
             val handle = DownloadsRegistry.downloads.openRaw(Bucket.Caption, destination, "text/plain")
-                ?: return false
-            handle.stream.use { it.write(buildContent(illust, caption).toByteArray(Charsets.UTF_8)) }
-            handle.onFinish()
-            true
+                ?: return
+            try {
+                handle.stream.use { it.write(buildContent(illust, caption).toByteArray(Charsets.UTF_8)) }
+                handle.onFinish()
+            } catch (t: Throwable) {
+                // 写一半失败要把 pending 行撤掉，否则 MediaStore 会留下 0 字节的
+                // `.pending-` 孤儿文件（同 ExportUtils.saveToDownloads 的处理）。
+                handle.onAbort()
+                throw t
+            }
         } catch (t: Throwable) {
             Timber.tag(TAG).w(t, "export caption failed illust=${illust.id}")
-            false
         }
     }
 

--- a/app/src/main/java/ceui/pixiv/download/config/DownloadConfig.kt
+++ b/app/src/main/java/ceui/pixiv/download/config/DownloadConfig.kt
@@ -39,13 +39,19 @@ data class DownloadConfig(
             "Bucket.TempCache is not user-configurable; resolve it through Downloads, not DownloadConfig"
         }
         val override = perBucket[bucket]
-        // [Bucket.NovelSeries] 是后加的桶：升级用户持久化的配置里没有它的条目，
-        // 空缺字段若照常掉回 defaults，合集文件会拿到插画模板 + 图片卷（Pictures/）。
-        // 所以模板缺省用它自己的默认值，存储 / 覆盖策略先跟小说走（同为 Downloads
-        // 类文本产物），再退到 defaults。
-        val inherited = if (bucket == Bucket.NovelSeries) perBucket[Bucket.Novel] else null
-        val fallbackTemplate =
-            if (bucket == Bucket.NovelSeries) DefaultTemplates.NOVEL_SERIES else defaults.template
+        // [Bucket.NovelSeries] / [Bucket.Caption] 是后加的桶：升级用户持久化的配置里
+        // 没有它们的条目，空缺字段若照常掉回 defaults，合集/简介会拿到插画模板 + 图片卷
+        // （Pictures/）。所以模板缺省用各自默认值，存储 / 覆盖策略先跟小说走（同为
+        // Downloads 类文本产物），再退到 defaults。
+        val inherited = when (bucket) {
+            Bucket.NovelSeries, Bucket.Caption -> perBucket[Bucket.Novel]
+            else -> null
+        }
+        val fallbackTemplate = when (bucket) {
+            Bucket.NovelSeries -> DefaultTemplates.NOVEL_SERIES
+            Bucket.Caption -> DefaultTemplates.CAPTION
+            else -> defaults.template
+        }
         return ResolvedBucket(
             template  = override?.template  ?: fallbackTemplate,
             storage   = override?.storage   ?: inherited?.storage   ?: defaults.storage,

--- a/app/src/main/java/ceui/pixiv/download/config/DownloadItems.kt
+++ b/app/src/main/java/ceui/pixiv/download/config/DownloadItems.kt
@@ -88,6 +88,23 @@ object DownloadItems {
     fun ugoiraRelativePath(illust: IllustsBean, asMp4: Boolean): RelativePath =
         renderedPath(ugoira(illust, asMp4))
 
+    /**
+     * Full sanitized destination for an illustration/manga caption txt.
+     * Rendered through the active [Bucket.Caption] template (separate folder
+     * by default, not mixed with image files).
+     */
+    @JvmStatic
+    fun illustCaptionDestination(illust: IllustsBean): RelativePath =
+        renderedPath(illustCaptionItem(illust))
+
+    private fun illustCaptionItem(illust: IllustsBean): DownloadItem = DownloadItem(
+        bucket = Bucket.Caption,
+        ext = "txt",
+        mime = "text/plain",
+        sourceUrl = "",
+        meta = metaOf(illust, pageIndex = null),
+    )
+
     private fun renderedPath(item: DownloadItem): RelativePath {
         val config = DownloadsRegistry.store.loadOrFallback()
         val resolved = config.resolve(item.bucket)

--- a/app/src/main/java/ceui/pixiv/download/model/Bucket.kt
+++ b/app/src/main/java/ceui/pixiv/download/model/Bucket.kt
@@ -12,6 +12,11 @@ enum class Bucket {
      * 钉死在小说模板渲染出的 `{series}/` 子目录里，希望能放作者目录）和文件名。
      */
     NovelSeries,
+
+    /**
+     * Caption txt exported when downloading illustration / manga.
+     */
+    Caption,
     Backup,
     Log,
     TempCache,

--- a/app/src/main/java/ceui/pixiv/download/template/DefaultTemplates.kt
+++ b/app/src/main/java/ceui/pixiv/download/template/DefaultTemplates.kt
@@ -33,6 +33,9 @@ object DefaultTemplates {
     // （不跟单篇小说的 legacy `ShaftNovels/` 混），也不再跟着小说模板渲染结果走，
     // 独立可改。
     const val NOVEL_SERIES = "Shaft/Novels/NovelSeries_{id}_Chapter_1~{chapters}_{series}.{ext}"
+
+    // Caption txt for illustration/manga: separate ShaftDescriptions/ folder.
+    const val CAPTION = "ShaftDescriptions/{title}_{id}.txt"
     const val BACKUP  = "Shaft/Backups/{created:yyyyMMdd_HHmmss}.zip"
     const val LOG     = "Shaft/Logs/{created:yyyyMMdd_HHmmss}.txt"
     const val TEMP    = "ugoira/{id}/{title} {id}.{ext}"
@@ -42,6 +45,7 @@ object DefaultTemplates {
         Bucket.Ugoira      to UGOIRA,
         Bucket.Novel       to NOVEL,
         Bucket.NovelSeries to NOVEL_SERIES,
+        Bucket.Caption     to CAPTION,
         Bucket.Backup      to BACKUP,
         Bucket.Log         to LOG,
         Bucket.TempCache   to TEMP,

--- a/app/src/main/java/ceui/pixiv/download/template/TemplateSamples.kt
+++ b/app/src/main/java/ceui/pixiv/download/template/TemplateSamples.kt
@@ -67,6 +67,7 @@ object TemplateSamples {
         Bucket.Ugoira      to "gif",
         Bucket.Novel       to "txt",
         Bucket.NovelSeries to "txt",
+        Bucket.Caption     to "txt",
         Bucket.Backup      to "zip",
         Bucket.Log         to "txt",
         Bucket.TempCache   to "bin",

--- a/app/src/main/java/ceui/pixiv/ui/bulk/QueueDownloadManager.kt
+++ b/app/src/main/java/ceui/pixiv/ui/bulk/QueueDownloadManager.kt
@@ -17,6 +17,7 @@ import ceui.pixiv.db.queue.DownloadQueueEntity
 import ceui.pixiv.db.queue.QueueStatus
 import ceui.pixiv.db.queue.WorkType
 import ceui.pixiv.download.StageStore
+import ceui.pixiv.download.IllustCaptionExporter
 import ceui.pixiv.download.maintenance.MediaStoreOrphanCleaner
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -746,6 +747,7 @@ object QueueDownloadManager {
             "[QUEUE-CONSUMER] TAKE id=${row.id} illustId=${row.illustId} " +
                     "pageCount=$pageCount existing=${existing.size} retry=${row.retryCount}"
         )
+        IllustCaptionExporter.export(bean)
         return true
     }
 

--- a/app/src/main/java/ceui/pixiv/ui/bulk/QueueDownloadManager.kt
+++ b/app/src/main/java/ceui/pixiv/ui/bulk/QueueDownloadManager.kt
@@ -747,7 +747,9 @@ object QueueDownloadManager {
             "[QUEUE-CONSUMER] TAKE id=${row.id} illustId=${row.illustId} " +
                     "pageCount=$pageCount existing=${existing.size} retry=${row.retryCount}"
         )
-        IllustCaptionExporter.export(bean)
+        // 只在首次拉入时导出简介：retry path（existing 非空）这条作品上一轮已经导出过，
+        // 再导一次在 Rename 策略下会多出一份 `xxx (1).txt`。
+        if (existing.isEmpty()) IllustCaptionExporter.export(bean)
         return true
     }
 

--- a/app/src/main/java/ceui/pixiv/ui/settings/DownloadPathSettingsFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/settings/DownloadPathSettingsFragment.kt
@@ -66,6 +66,8 @@ class DownloadPathSettingsFragment : Fragment(R.layout.fragment_download_path_se
         Bucket.Novel  to R.string.download_path_bucket_novel,
         // 合并下载的合集单独一张卡：它的目录 / 文件名和单篇小说互不牵连（issue #964）。
         Bucket.NovelSeries to R.string.download_path_bucket_novel_series,
+        // 插画/漫画简介 txt 单独一张卡：默认目录不与图片混放。
+        Bucket.Caption to R.string.download_path_bucket_caption,
         Bucket.Backup to R.string.download_path_bucket_backup,
         Bucket.Log    to R.string.download_path_bucket_log,
     )

--- a/app/src/main/res/layout/fragment_settings_download.xml
+++ b/app/src/main/res/layout/fragment_settings_download.xml
@@ -358,6 +358,45 @@
                 </RelativeLayout>
 
                 <RelativeLayout
+                    android:id="@+id/auto_export_caption_rela"
+                    style="@style/M3SetRow"
+                    android:background="@drawable/wit_row_mid">
+
+                    <LinearLayout style="@style/M3SetTexts">
+
+                        <TextView
+                            style="@style/M3SetTitle"
+                            android:text="@string/setting_auto_export_caption_title" />
+                    </LinearLayout>
+
+                    <androidx.appcompat.widget.SwitchCompat
+                        android:id="@+id/auto_export_caption"
+                        style="@style/M3SetSwitch" />
+
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:id="@+id/auto_export_caption_length_rela"
+                    style="@style/M3SetRow"
+                    android:background="@drawable/wit_row_mid"
+                    android:visibility="gone">
+
+                    <LinearLayout
+                        style="@style/M3SetTexts"
+                        android:layout_marginEnd="130dp">
+
+                        <TextView
+                            style="@style/M3SetTitle"
+                            android:text="@string/setting_auto_export_caption_length_title" />
+                    </LinearLayout>
+
+                    <TextView
+                        android:id="@+id/auto_export_caption_length"
+                        style="@style/M3SetValue" />
+
+                </RelativeLayout>
+
+                <RelativeLayout
                     android:id="@+id/silent_download_rela"
                     style="@style/M3SetRow"
                     android:background="@drawable/wit_row_bottom">

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -877,6 +877,9 @@
     <string name="theme_nowUsing">(In use)</string>
     <string name="core_string_novel_marker">Markers</string>
     <string name="toast_download_result">Show an in-app notice when downloads complete</string>
+    <string name="setting_auto_export_caption_title">Auto-export caption when downloading illustration/manga</string>
+    <string name="setting_auto_export_caption_length_title">Minimum caption length to export</string>
+    <string name="setting_auto_export_caption_length_value">%d chars</string>
     <string name="setting_write_exif_tags_title">Write tags into images on download</string>
     <string name="setting_write_exif_tags_desc">Embed tags as XMP keywords (dc:subject) in downloaded JPEGs so photo apps can organize by tag. JPEG only.</string>
     <string name="setting_silent_download_title">Discreet download</string>
@@ -1348,6 +1351,7 @@
     <string name="download_path_bucket_ugoira">Ugoira (final GIF)</string>
     <string name="download_path_bucket_novel">Novel</string>
     <string name="download_path_bucket_novel_series">Novel series · merged download</string>
+    <string name="download_path_bucket_caption">Caption (illustration / manga)</string>
     <string name="download_path_quick_template_label">Quick templates (tap to apply)</string>
     <string name="download_path_quick_merge_default">Default</string>
     <string name="download_path_quick_merge_by_author">Author folder</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -877,6 +877,9 @@
     <string name="theme_nowUsing">（使用中）</string>
     <string name="core_string_novel_marker">しおり</string>
     <string name="toast_download_result">ダウンロード完了時に通知</string>
+    <string name="setting_auto_export_caption_title">イラスト/漫画ダウンロード時にキャプションを自動出力</string>
+    <string name="setting_auto_export_caption_length_title">キャプション自動出力の最低文字数</string>
+    <string name="setting_auto_export_caption_length_value">%d 文字</string>
     <string name="setting_write_exif_tags_title">ダウンロード時に画像へタグを書き込む</string>
     <string name="setting_write_exif_tags_desc">ダウンロードした JPEG に XMP キーワード(dc:subject)としてタグを埋め込み、写真アプリでタグ管理できるようにします。JPEG のみ。</string>
     <string name="setting_silent_download_title">目立たないダウンロード</string>
@@ -1348,6 +1351,7 @@
     <string name="download_path_bucket_ugoira">うごイラ（最終 GIF）</string>
     <string name="download_path_bucket_novel">小説</string>
     <string name="download_path_bucket_novel_series">小説シリーズ・まとめてダウンロード</string>
+    <string name="download_path_bucket_caption">キャプション（イラスト / 漫画）</string>
     <string name="download_path_quick_template_label">クイックテンプレート（タップで適用）</string>
     <string name="download_path_quick_merge_default">デフォルト</string>
     <string name="download_path_quick_merge_by_author">作者フォルダー</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -877,6 +877,9 @@
     <string name="theme_nowUsing">(사용 중)</string>
     <string name="core_string_novel_marker">책갈피</string>
     <string name="toast_download_result">다운로드 완료 시 앱 내 알림 표시</string>
+    <string name="setting_auto_export_caption_title">일러스트/만화 다운로드 시 캡션 자동 내보내기</string>
+    <string name="setting_auto_export_caption_length_title">캡션 자동 내보내기 최소 글자 수</string>
+    <string name="setting_auto_export_caption_length_value">%d자</string>
     <string name="setting_write_exif_tags_title">다운로드 시 이미지에 태그 기록</string>
     <string name="setting_write_exif_tags_desc">다운로드한 JPEG에 XMP 키워드(dc:subject)로 태그를 넣어 사진 앱에서 태그로 정리할 수 있게 합니다. JPEG만 지원.</string>
     <string name="setting_silent_download_title">조용한 다운로드</string>
@@ -1348,6 +1351,7 @@
     <string name="download_path_bucket_ugoira">움직이는 이미지(최종 GIF)</string>
     <string name="download_path_bucket_novel">소설</string>
     <string name="download_path_bucket_novel_series">소설 시리즈 · 병합 다운로드</string>
+    <string name="download_path_bucket_caption">캡션 (일러스트 / 만화)</string>
     <string name="download_path_quick_template_label">빠른 템플릿 (탭하면 바로 적용)</string>
     <string name="download_path_quick_merge_default">기본값</string>
     <string name="download_path_quick_merge_by_author">작가 폴더</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -877,6 +877,9 @@
     <string name="theme_nowUsing">(используется)</string>
     <string name="core_string_novel_marker">Метки</string>
     <string name="toast_download_result">Показывать уведомление после завершения загрузки</string>
+    <string name="setting_auto_export_caption_title">Автоматически экспортировать описание при загрузке иллюстраций/манги</string>
+    <string name="setting_auto_export_caption_length_title">Мин. длина описания для экспорта</string>
+    <string name="setting_auto_export_caption_length_value">%d симв.</string>
     <string name="setting_write_exif_tags_title">Записывать теги в изображения при загрузке</string>
     <string name="setting_write_exif_tags_desc">Встраивать теги как ключевые слова XMP (dc:subject) в загружаемые JPEG, чтобы фотоприложения могли сортировать по тегам. Только JPEG.</string>
     <string name="setting_silent_download_title">Незаметная загрузка</string>
@@ -1348,6 +1351,7 @@
     <string name="download_path_bucket_ugoira">Ugoira (итоговый GIF)</string>
     <string name="download_path_bucket_novel">Роман</string>
     <string name="download_path_bucket_novel_series">Серия новелл · объединённая загрузка</string>
+    <string name="download_path_bucket_caption">Описание (иллюстрации / манга)</string>
     <string name="download_path_quick_template_label">Быстрые шаблоны (нажмите, чтобы применить)</string>
     <string name="download_path_quick_merge_default">По умолчанию</string>
     <string name="download_path_quick_merge_by_author">Папка автора</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -877,6 +877,9 @@
     <string name="theme_nowUsing">(Kullanılıyor)</string>
     <string name="core_string_novel_marker">Roman yer imi</string>
     <string name="toast_download_result">İndirme tamamlanınca uygulama içinde bildirim göster</string>
+    <string name="setting_auto_export_caption_title">İllüstrasyon/manga indirirken açıklamayı otomatik dışa aktar</string>
+    <string name="setting_auto_export_caption_length_title">Dışa aktarma için minimum açıklama uzunluğu</string>
+    <string name="setting_auto_export_caption_length_value">%d karakter</string>
     <string name="setting_write_exif_tags_title">İndirirken etiketleri görsele yaz</string>
     <string name="setting_write_exif_tags_desc">İndirilen JPEG\'lere etiketleri XMP anahtar kelimeleri (dc:subject) olarak gömer; böylece fotoğraf uygulamaları etikete göre düzenleyebilir. Yalnızca JPEG.</string>
     <string name="setting_silent_download_title">Sessiz indirme</string>
@@ -1348,6 +1351,7 @@
     <string name="download_path_bucket_ugoira">Ugoira (son GIF)</string>
     <string name="download_path_bucket_novel">Roman</string>
     <string name="download_path_bucket_novel_series">Roman serisi · birleşik indirme</string>
+    <string name="download_path_bucket_caption">Açıklama (illüstrasyon / manga)</string>
     <string name="download_path_quick_template_label">Hızlı şablonlar (dokununca uygulanır)</string>
     <string name="download_path_quick_merge_default">Varsayılan</string>
     <string name="download_path_quick_merge_by_author">Yazar klasörü</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -879,6 +879,9 @@
     <string name="theme_nowUsing">（正在使用）</string>
     <string name="core_string_novel_marker">小說書籤</string>
     <string name="toast_download_result">下載完成 APP 內提示</string>
+    <string name="setting_auto_export_caption_title">插畫/漫畫下載時自動匯出簡介</string>
+    <string name="setting_auto_export_caption_length_title">簡介自動匯出需達</string>
+    <string name="setting_auto_export_caption_length_value">%d 字</string>
     <string name="setting_write_exif_tags_title">下載時把標籤寫進圖片</string>
     <string name="setting_write_exif_tags_desc">為下載的 JPEG 寫入 XMP 關鍵字(dc:subject),方便相簿 / 圖片管理軟體依標籤整理。僅 JPEG。</string>
     <string name="setting_silent_download_title">低調下載</string>
@@ -1350,6 +1353,7 @@
     <string name="download_path_bucket_ugoira">動圖（最終 GIF）</string>
     <string name="download_path_bucket_novel">小說</string>
     <string name="download_path_bucket_novel_series">小說系列 · 合併下載</string>
+    <string name="download_path_bucket_caption">簡介（插畫 / 漫畫）</string>
     <string name="download_path_quick_template_label">快捷範本（點一下直接套用）</string>
     <string name="download_path_quick_merge_default">預設</string>
     <string name="download_path_quick_merge_by_author">放作者目錄</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -906,6 +906,9 @@
     <string name="theme_nowUsing">（正在使用）</string>
     <string name="core_string_novel_marker">小说书签</string>
     <string name="toast_download_result">下载完成App内提示</string>
+    <string name="setting_auto_export_caption_title">插画/漫画下载时自动导出简介</string>
+    <string name="setting_auto_export_caption_length_title">简介自动导出需达</string>
+    <string name="setting_auto_export_caption_length_value">%d 字</string>
     <string name="setting_write_exif_tags_title">下载时把标签写进图片</string>
     <string name="setting_write_exif_tags_desc">给下载的 JPEG 写入 XMP 关键词(dc:subject),方便相册 / 图管软件按标签管理。仅 JPEG。</string>
     <string name="setting_silent_download_title">低调下载</string>
@@ -1484,6 +1487,7 @@
     <string name="download_path_bucket_ugoira">动图（GIF 最终结果）</string>
     <string name="download_path_bucket_novel">小说</string>
     <string name="download_path_bucket_novel_series">小说系列 · 合并下载</string>
+    <string name="download_path_bucket_caption">简介（插画 / 漫画）</string>
     <string name="download_path_quick_template_label">快捷模板（点一下直接套用）</string>
     <string name="download_path_quick_merge_default">默认</string>
     <string name="download_path_quick_merge_by_author">放作者目录</string>

--- a/app/src/test/java/ceui/pixiv/download/DefaultTemplatesTest.kt
+++ b/app/src/test/java/ceui/pixiv/download/DefaultTemplatesTest.kt
@@ -31,7 +31,7 @@ class DefaultTemplatesTest {
             val ext = when (bucket) {
                 Bucket.Illust, Bucket.TempCache -> "jpg"
                 Bucket.Ugoira -> "gif"
-                Bucket.Novel, Bucket.NovelSeries, Bucket.Log -> "txt"
+                Bucket.Novel, Bucket.NovelSeries, Bucket.Caption, Bucket.Log -> "txt"
                 Bucket.Backup -> "zip"
             }
             val rendered = compiled.render(META, ext)

--- a/app/src/test/java/ceui/pixiv/download/NovelSeriesMergeTemplateTest.kt
+++ b/app/src/test/java/ceui/pixiv/download/NovelSeriesMergeTemplateTest.kt
@@ -127,7 +127,7 @@ class NovelSeriesMergeTemplateTest {
         val cfg = DownloadConfig(
             defaults = BucketDefaults(template = "Illust/{id}.{ext}", storage = images),
         )
-        for (bucket in Bucket.entries - Bucket.NovelSeries - Bucket.TempCache) {
+        for (bucket in Bucket.entries - Bucket.NovelSeries - Bucket.Caption - Bucket.TempCache) {
             val resolved = cfg.resolve(bucket)
             assertEquals("bucket $bucket template", "Illust/{id}.{ext}", resolved.template)
             assertEquals("bucket $bucket storage", images, resolved.storage)


### PR DESCRIPTION
# 插画/漫画下载时自动导出简介（独立简介桶 + 设置开关 + 最少字数）

> 分支：`patch-8-20`（wangwang-code fork；本地 remote 名为 `my`）
> 提交：`0c27dec47` feat(download): 插画/漫画下载时自动导出简介（可设最少字数）

## 背景

下载插画/漫画时，作品简介（caption）无实际导出实现，本地只有图片文件，**如插画/漫画因不可抗力因素无法访问，丢失简介写的配图小作文将会是一大遗憾。**

小说下载已经有「标题/作者/简介等元信息 + 正文」落 TXT 的先例，本次给插画/漫画补上同类的简介导出能力。

功能默认关闭，避免改变现有下载行为；用户开启后，在详情页下载这个作品时（进入 Manager 队列前，对于批量下载则在批量队列启动后）自动导出一份简介 txt，默认放在独立目录，不与图片混放。

## 改动内容

### 1. 新增独立“简介桶”

- 新增 `Bucket.Caption`，与图片桶分开管理。
- 默认模板：`ShaftDescriptions/{title}_{id}.txt`，命名风格对齐默认图片桶，目录默认不与图混放。
- `DownloadConfig.resolve` 增加简介桶的模板/存储兜底：老配置没有 Caption 条目时自动使用默认模板，存储与覆盖策略跟随小说等 Downloads 文本产物。
- `DownloadItems` 新增 `illustCaptionDestination()`，统一走模板渲染 + 路径清洗。

### 2. 在“下载这个作品”时导出，而不是每张图完成后导出

- 直接下载：单页下载 / 下载全部 / 下载当前页 / 收藏后自动下载，在 `Manager.addTask / addTasks` 之前导出一次。
- 批量持久化队列：队列消费者把作品拉入内存、准备把 page 交给 Manager 之前导出一次。
- “保存这一张”：保存图片前导出一次。
- 不再在每张 page 完成回调里触发导出，也没有时间窗口去重逻辑。

### 3. 下载路径设置页增加“简介（插画 / 漫画）”桶卡片

- 可在「设置 → 下载 → 下载路径与文件名」中查看/修改简介桶模板、存储位置与重复策略。
- 未配置时显示默认模板，可一键恢复默认。

### 4. 设置开关：默认关闭

- 新增「插画/漫画下载时自动导出简介」开关，默认 **关**。
- 开关关闭时所有导出入口直接跳过，不产生 txt。

### 5. 简介最少字数

- 开关打开后显示「简介自动导出需达」行，最小值为 **1**。
- 点击可设置最少字数，输入非法/为空时回落到 1。
- 导出时只有清洗后的简介字数 ≥ 该阈值才写入。

### 6. 多语言

- 补齐默认中文、繁中、英文、日文、韩文、俄文、土耳其文的新增文案。

## 涉及文件

- `app/src/main/java/ceui/lisa/activities/ImageDetailActivity.kt`
- `app/src/main/java/ceui/lisa/download/IllustDownload.java`
- `app/src/main/java/ceui/lisa/fragments/FragmentSettingsDownload.java`
- `app/src/main/java/ceui/lisa/utils/Settings.java`
- `app/src/main/java/ceui/pixiv/download/IllustCaptionExporter.kt`（新增）
- `app/src/main/java/ceui/pixiv/download/config/DownloadConfig.kt`
- `app/src/main/java/ceui/pixiv/download/config/DownloadItems.kt`
- `app/src/main/java/ceui/pixiv/download/model/Bucket.kt`
- `app/src/main/java/ceui/pixiv/download/template/DefaultTemplates.kt`
- `app/src/main/java/ceui/pixiv/download/template/TemplateSamples.kt`
- `app/src/main/java/ceui/pixiv/ui/bulk/QueueDownloadManager.kt`
- `app/src/main/java/ceui/pixiv/ui/settings/DownloadPathSettingsFragment.kt`
- `app/src/main/res/layout/fragment_settings_download.xml`
- `app/src/main/res/values*/strings.xml`（7 语言）
