### PR TITLE
feat(chat): 聊天室支持回复某条消息 — 引用条 + 气泡引用块 + 跳回原消息

### DIFF
--- a/app/src/main/java/ceui/pixiv/chat/api/ChatFrame.kt
+++ b/app/src/main/java/ceui/pixiv/chat/api/ChatFrame.kt
@@ -14,6 +14,27 @@ import timber.log.Timber
  * The legacy 64-hex `client_id` is gone (`switch from room-subscribe model
  * to uid-routing`).
  */
+/**
+ * Reference to (and, inbound, a snapshot of) a quoted message — the
+ * `reply_to` object on `msg` frames and `/history` rows.
+ *
+ * Identity is `(uid, clientMsgId)`: the only handle every message stably
+ * has on both ends (WS frames carry no server id), and equal to the quoted
+ * row's local `localKey`.
+ *
+ * Outbound (client → server) only [uid] + [clientMsgId] are sent; the server
+ * validates the target exists **in the same room** and fills
+ * [displayName] (author's current name) + [text] (≤200-char excerpt) on the
+ * broadcast and on history rows. [text] `null` on an inbound ref ⇒ the
+ * original was purged server-side — render as "原消息已不可用".
+ */
+data class ChatReplyRef(
+    val uid: Long,
+    val clientMsgId: String,
+    val displayName: String? = null,
+    val text: String? = null,
+)
+
 sealed interface ChatFrame {
 
     /**
@@ -31,7 +52,10 @@ sealed interface ChatFrame {
 
     /**
      * `{ "kind": "msg", "room", "uid", "display_name", "client_msg_id",
-     *    "text", "illust_id"?, "ts" }`
+     *    "text", "illust_id"?, "ts", "reply_to"? }`
+     *
+     * `reply_to` (optional) = [ChatReplyRef] snapshot of the quoted message
+     * when this message is a reply.
      *
      * Server populates `room` based on routing:
      *  - `"global"` for public broadcasts
@@ -50,6 +74,7 @@ sealed interface ChatFrame {
         val text: String?,
         val illustId: Long?,
         val ts: Long,
+        val replyTo: ChatReplyRef? = null,
     ) : ChatFrame
 
     /**
@@ -164,6 +189,7 @@ object ChatFrameDecoder {
                     text = obj.get("text")?.asStringOrNull(),
                     illustId = obj.get("illust_id")?.asLongOrNull(),
                     ts = ts,
+                    replyTo = obj.get("reply_to")?.let(::decodeReplyTo),
                 )
             }
             "err" -> ChatFrame.Err(
@@ -202,6 +228,25 @@ object ChatFrameDecoder {
         }
     }
 
+    /**
+     * `reply_to` object → [ChatReplyRef]. Requires `uid` + `client_msg_id`
+     * (without them the quote can't be anchored to anything); a malformed
+     * object degrades to `null` — the message still renders, just without its
+     * quote — rather than dead-lettering the whole frame.
+     */
+    private fun decodeReplyTo(el: com.google.gson.JsonElement): ChatReplyRef? {
+        if (!el.isJsonObject) return null
+        val o = el.asJsonObject
+        val uid = o.get("uid")?.asLongOrNull() ?: return null
+        val cmid = o.get("client_msg_id")?.asStringOrNull()?.takeIf { it.isNotEmpty() } ?: return null
+        return ChatReplyRef(
+            uid = uid,
+            clientMsgId = cmid,
+            displayName = o.get("display_name")?.asStringOrNull(),
+            text = o.get("text")?.asStringOrNull(),
+        )
+    }
+
     private fun com.google.gson.JsonElement.asStringOrNull(): String? = when {
         isJsonNull -> null
         isJsonPrimitive && asJsonPrimitive.isString -> asString
@@ -231,9 +276,18 @@ object ChatFrameEncoder {
 
     /**
      * Build a public-room `msg` frame:
-     * `{"kind":"msg","room":"global","client_msg_id":<id>,"text":<text>,"illust_id":<id?>}`
+     * `{"kind":"msg","room":"global","client_msg_id":<id>,"text":<text>,"illust_id":<id?>,"reply_to":{...}?}`
+     *
+     * [replyTo] (optional) quotes another message in the room — only its
+     * `uid` + `client_msg_id` go on the wire; the server resolves and
+     * snapshots the rest (see [ChatReplyRef]).
      */
-    fun msgGlobal(clientMsgId: String, text: String, illustId: Long? = null): String {
+    fun msgGlobal(
+        clientMsgId: String,
+        text: String,
+        illustId: Long? = null,
+        replyTo: ChatReplyRef? = null,
+    ): String {
         val esc = escapeJsonString(text)
         val idEsc = escapeJsonString(clientMsgId)
         return buildString {
@@ -243,6 +297,7 @@ object ChatFrameEncoder {
             append(esc)
             append('"')
             if (illustId != null) append(""","illust_id":""").append(illustId)
+            appendReplyTo(replyTo)
             append('}')
         }
     }
@@ -256,7 +311,13 @@ object ChatFrameEncoder {
      * and ACL is enforced by handshake-authed `self_uid`. Sending raw
      * numeric `room` is rejected as `err.code = "room_forbidden"`.
      */
-    fun msg1v1(toUid: Long, clientMsgId: String, text: String, illustId: Long? = null): String {
+    fun msg1v1(
+        toUid: Long,
+        clientMsgId: String,
+        text: String,
+        illustId: Long? = null,
+        replyTo: ChatReplyRef? = null,
+    ): String {
         val esc = escapeJsonString(text)
         val idEsc = escapeJsonString(clientMsgId)
         return buildString {
@@ -268,8 +329,19 @@ object ChatFrameEncoder {
             append(esc)
             append('"')
             if (illustId != null) append(""","illust_id":""").append(illustId)
+            appendReplyTo(replyTo)
             append('}')
         }
+    }
+
+    /** `,"reply_to":{"uid":<long>,"client_msg_id":"<id>"}` — or nothing when [ref] is null. */
+    private fun StringBuilder.appendReplyTo(ref: ChatReplyRef?) {
+        if (ref == null) return
+        append(""","reply_to":{"uid":""")
+        append(ref.uid)
+        append(""","client_msg_id":"""")
+        append(escapeJsonString(ref.clientMsgId))
+        append(""""}""")
     }
 
     /**

--- a/app/src/main/java/ceui/pixiv/chat/api/HttpChatHistorySource.kt
+++ b/app/src/main/java/ceui/pixiv/chat/api/HttpChatHistorySource.kt
@@ -26,6 +26,7 @@ import javax.net.ssl.SSLException
  * - server's `room` (passed through this query) → [ChatMessageEntity.room]
  * - `display_name`  → [ChatMessageEntity.displayName]
  * - `text`, `illust_id`, `ts` → straight passthrough
+ * - `reply_to.{uid,client_msg_id,display_name,text}` → `replyTo*` columns (absent → all null)
  * - state           → [SendState.Delivered] (history is always already broadcast)
  */
 class HttpChatHistorySource(
@@ -82,6 +83,10 @@ class HttpChatHistorySource(
             illustId = item.illust_id,
             ts = item.ts,
             state = SendState.Delivered,
+            replyToUid = item.reply_to?.uid,
+            replyToCmid = item.reply_to?.client_msg_id,
+            replyToDisplayName = item.reply_to?.display_name,
+            replyToText = item.reply_to?.text,
         )
     }
 

--- a/app/src/main/java/ceui/pixiv/chat/api/ShaftChatApi.kt
+++ b/app/src/main/java/ceui/pixiv/chat/api/ShaftChatApi.kt
@@ -178,6 +178,20 @@ data class ChatHistoryItem(
     val text: String?,
     val illust_id: Long?,
     val ts: Long,
+    /** Present only when this message quotes another one; see [ChatHistoryReplyTo]. */
+    val reply_to: ChatHistoryReplyTo? = null,
+)
+
+/**
+ * `reply_to` snapshot on a `/chat/history` row — same shape as the WS frame's
+ * `reply_to` (see [ChatReplyRef]). `text == null` ⇒ the quoted original has
+ * been purged server-side; `display_name` is still derived from `uid`.
+ */
+data class ChatHistoryReplyTo(
+    val uid: Long,
+    val client_msg_id: String,
+    val display_name: String?,
+    val text: String?,
 )
 
 data class ChatProfileResponse(

--- a/app/src/main/java/ceui/pixiv/chat/api/ShaftChatGateway.kt
+++ b/app/src/main/java/ceui/pixiv/chat/api/ShaftChatGateway.kt
@@ -384,21 +384,32 @@ object ShaftChatGateway {
      * 2048-UTF-16-unit cap and for generating a fresh
      * `clientMsgId` per call. This method makes no further validation
      * beyond non-empty text.
+     *
+     * [replyTo] (optional) quotes another message in the same room; only
+     * its `(uid, client_msg_id)` goes on the wire — the server validates
+     * the target and snapshots name + excerpt into the broadcast.
      */
-    fun send(toUid: Long?, clientMsgId: String, text: String, illustId: Long? = null): Boolean {
+    fun send(
+        toUid: Long?,
+        clientMsgId: String,
+        text: String,
+        illustId: Long? = null,
+        replyTo: ChatReplyRef? = null,
+    ): Boolean {
         if (text.isEmpty()) return false
         val frame = if (toUid == null) {
-            ChatFrameEncoder.msgGlobal(clientMsgId, text, illustId)
+            ChatFrameEncoder.msgGlobal(clientMsgId, text, illustId, replyTo)
         } else {
-            ChatFrameEncoder.msg1v1(toUid, clientMsgId, text, illustId)
+            ChatFrameEncoder.msg1v1(toUid, clientMsgId, text, illustId, replyTo)
         }
         val accepted = manager.send(frame)
         if (accepted) {
             Timber.tag(TAG).i(
-                "⇡ msg sent to=%s cmid=%s illust=%s text=%s",
+                "⇡ msg sent to=%s cmid=%s illust=%s replyTo=%s text=%s",
                 toUid?.toString() ?: "global",
                 clientMsgId,
                 illustId?.toString() ?: "-",
+                replyTo?.clientMsgId ?: "-",
                 text.take(80),
             )
         } else {

--- a/app/src/main/java/ceui/pixiv/chat/api/WsChatMessageStream.kt
+++ b/app/src/main/java/ceui/pixiv/chat/api/WsChatMessageStream.kt
@@ -169,5 +169,9 @@ internal fun ChatFrame.Msg.toChatMessageEntity(): ChatMessageEntity? {
         illustId = illustId,
         ts = ts,
         state = SendState.Delivered,
+        replyToUid = replyTo?.uid,
+        replyToCmid = replyTo?.clientMsgId,
+        replyToDisplayName = replyTo?.displayName,
+        replyToText = replyTo?.text,
     )
 }

--- a/app/src/main/java/ceui/pixiv/chat/data/ChatDatabase.kt
+++ b/app/src/main/java/ceui/pixiv/chat/data/ChatDatabase.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 /**
  * Dedicated Room database for chat messages, separate from [AppDatabase].
@@ -31,7 +33,11 @@ import androidx.room.RoomDatabase
     // columns added. fallbackToDestructiveMigration drops the old table on
     // the next open — chat had no real users on the old protocol so the
     // wipe is fine.
-    version = 2,
+    // v3 (2026-08-20): reply-to-message — four nullable columns
+    // (reply_to_uid / reply_to_cmid / reply_to_display_name / reply_to_text)
+    // added via MIGRATION_2_3 (ALTER TABLE ADD COLUMN), preserving the local
+    // cache and any optimistic Sending/Failed rows across the upgrade.
+    version = 3,
     exportSchema = true,
 )
 abstract class ChatDatabase : RoomDatabase() {
@@ -48,9 +54,22 @@ abstract class ChatDatabase : RoomDatabase() {
                     ChatDatabase::class.java,
                     "chat.db",
                 )
+                    .addMigrations(MIGRATION_2_3)
+                    // Safety net for any path MIGRATION_* doesn't cover (e.g. a
+                    // downgrade); chat is a cache, so dropping it is acceptable.
                     .fallbackToDestructiveMigration()
                     .build()
                     .also { instance = it }
             }
+
+        /** Additive reply-to columns; all nullable so existing rows need no backfill. */
+        private val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE chat_messages ADD COLUMN reply_to_uid INTEGER")
+                db.execSQL("ALTER TABLE chat_messages ADD COLUMN reply_to_cmid TEXT")
+                db.execSQL("ALTER TABLE chat_messages ADD COLUMN reply_to_display_name TEXT")
+                db.execSQL("ALTER TABLE chat_messages ADD COLUMN reply_to_text TEXT")
+            }
+        }
     }
 }

--- a/app/src/main/java/ceui/pixiv/chat/data/ChatMessageEntity.kt
+++ b/app/src/main/java/ceui/pixiv/chat/data/ChatMessageEntity.kt
@@ -74,7 +74,36 @@ data class ChatMessageEntity(
 
     /** Local lifecycle state — see [SendState]. */
     val state: SendState = SendState.Delivered,
+
+    // ── Reply-to (quoted message) ─────────────────────────────────────
+    // A message can quote one other message in the same room. The reference
+    // is the quoted message's `(uid, client_msg_id)` — the only identity
+    // every message stably has on both ends (WS frames carry no server id),
+    // and equal to the quoted row's own `localKey`, so "tap quote → jump to
+    // original" is a plain localKey lookup in the current list.
+    //
+    // `replyToDisplayName` / `replyToText` are the server's snapshot of the
+    // quoted message (author's current name + ≤200-char excerpt), delivered
+    // on both the WS frame and /history rows, so the bubble renders the
+    // quote even when the original isn't in the local store. `replyToText`
+    // null while `replyToCmid` is set ⇒ original was purged server-side
+    // ("原消息已不可用").
+
+    @ColumnInfo(name = "reply_to_uid")
+    val replyToUid: Long? = null,
+
+    @ColumnInfo(name = "reply_to_cmid")
+    val replyToCmid: String? = null,
+
+    @ColumnInfo(name = "reply_to_display_name")
+    val replyToDisplayName: String? = null,
+
+    @ColumnInfo(name = "reply_to_text")
+    val replyToText: String? = null,
 ) {
+    /** True when this message quotes another one (whether or not the original still exists). */
+    val isReply: Boolean get() = replyToCmid != null
+
     companion object {
         /** Synthesize a localKey from a server id when the row has no client_msg_id. */
         fun localKeyForServer(serverId: Long): String = "server:$serverId"

--- a/app/src/main/java/ceui/pixiv/chat/ui/ChatMessageAdapter.kt
+++ b/app/src/main/java/ceui/pixiv/chat/ui/ChatMessageAdapter.kt
@@ -135,6 +135,10 @@ class ChatMessageAdapter(
             holder.flash(palette(rv.context))
         } else {
             pendingFlashKey = localKey
+            // One-shot with a deadline: if the caller's scroll doesn't bind this
+            // row within ~2s (user grabbed the list mid-scroll and went elsewhere),
+            // drop it — otherwise the row would flash out of nowhere minutes later.
+            rv.postDelayed({ if (pendingFlashKey == localKey) pendingFlashKey = null }, PENDING_FLASH_TTL_MS)
         }
         return true
     }
@@ -185,6 +189,10 @@ class ChatMessageAdapter(
             onLongClick?.invoke(item)
             true
         }
+        // The quote block is clickable (jump-to-original), so it owns touch events
+        // over its area — forward its long-press to the row, otherwise long-pressing
+        // on the quote of a reply bubble silently does nothing.
+        holder.quoteView.setOnLongClickListener { holder.itemView.performLongClick() }
         if (pendingFlashKey != null && pendingFlashKey == item.localKey) {
             pendingFlashKey = null
             holder.flash(palette)
@@ -206,7 +214,9 @@ class ChatMessageAdapter(
         private val tvMonogram: TextView? = itemView.findViewById(R.id.tv_monogram) // received anon
         private val tvName: TextView? = itemView.findViewById(R.id.tv_name)   // received only
         private val ivState: ImageView? = itemView.findViewById(R.id.iv_state) // sent only
-        private val quote: View = itemView.findViewById(R.id.quote)
+        /** Exposed so the adapter can forward long-presses on the (clickable) quote to the row. */
+        val quoteView: View = itemView.findViewById(R.id.quote)
+        private val quote: View get() = quoteView
         private val quoteBar: View = itemView.findViewById(R.id.quote_bar)
         private val tvQuoteName: TextView = itemView.findViewById(R.id.tv_quote_name)
         private val tvQuoteText: TextView = itemView.findViewById(R.id.tv_quote_text)
@@ -500,6 +510,7 @@ class ChatMessageAdapter(
         const val VIEW_TYPE_SENT = 0
         const val VIEW_TYPE_RECEIVED = 1
         private const val PAYLOAD_AVATAR = "avatar"
+        private const val PENDING_FLASH_TTL_MS = 2_000L
 
         /** Below this gap, consecutive messages share one time group. */
         private const val TIME_GROUP_GAP_MS = 5 * 60 * 1000L

--- a/app/src/main/java/ceui/pixiv/chat/ui/ChatMessageAdapter.kt
+++ b/app/src/main/java/ceui/pixiv/chat/ui/ChatMessageAdapter.kt
@@ -1,10 +1,12 @@
 package ceui.pixiv.chat.ui
 
+import android.animation.ValueAnimator
 import android.content.Context
 import android.content.res.Configuration
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.GradientDrawable
+import android.view.animation.DecelerateInterpolator
 import android.text.method.LinkMovementMethod
 import android.text.util.Linkify
 import android.util.TypedValue
@@ -61,9 +63,18 @@ class ChatMessageAdapter(
     private val isGlobal: Boolean = false,
     private val onLongClick: ((ChatMessageEntity) -> Unit)? = null,
     private val onAvatarClick: ((uid: Long) -> Unit)? = null,
+    /** Tap on a bubble's quote block → the quoted message's `localKey` (= its client_msg_id). */
+    private val onQuoteClick: ((quotedLocalKey: String) -> Unit)? = null,
 ) : BaseListAdapter<ChatMessageEntity, ChatMessageAdapter.BubbleHolder>(
     diffCallback(keySelector = { it.localKey })
 ) {
+
+    /**
+     * localKey of a row that should flash-highlight the next time it is bound
+     * (set by [flashMessage] when the target isn't currently on screen — the
+     * scroll brings it in, the bind fires the flash). One-shot.
+     */
+    private var pendingFlashKey: String? = null
 
     /** Self avatar URL — set once the logged-in user's profile is known. */
     var selfAvatarUrl: String? = null
@@ -84,13 +95,7 @@ class ChatMessageAdapter(
     private var cachedPalette: V3Palette? = null
     private var nameColors: IntArray? = null
 
-    private fun palette(ctx: Context): V3Palette = cachedPalette ?: run {
-        val brand = runCatching { Color.parseColor(Shaft.getThemeColor()) }
-            .getOrDefault(ContextCompat.getColor(ctx, R.color.v3_purple))
-        val isDark = (ctx.resources.configuration.uiMode and
-            Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
-        V3Palette(brand, isDark).also { cachedPalette = it }
-    }
+    private fun palette(ctx: Context): V3Palette = cachedPalette ?: chatPalette(ctx).also { cachedPalette = it }
 
     /** Curated group-chat name palette; picked per sender uid for legibility. */
     private fun nameColor(ctx: Context, uid: Long): Int {
@@ -112,6 +117,28 @@ class ChatMessageAdapter(
         }
     }
 
+    /** Position of the row with [localKey] in the current list, or -1. */
+    fun positionOf(localKey: String): Int = currentList.indexOfFirst { it.localKey == localKey }
+
+    /**
+     * Flash-highlight the row with [localKey] (jump-to-quoted-message feedback).
+     * If its holder is attached, flash it now; otherwise arm [pendingFlashKey]
+     * so the bind that happens when the caller scrolls it on screen flashes it.
+     * Returns `false` when the row isn't in the list at all.
+     */
+    fun flashMessage(localKey: String, rv: RecyclerView): Boolean {
+        val pos = positionOf(localKey)
+        if (pos < 0) return false
+        val holder = rv.findViewHolderForAdapterPosition(pos) as? BubbleHolder
+        if (holder != null) {
+            pendingFlashKey = null
+            holder.flash(palette(rv.context))
+        } else {
+            pendingFlashKey = localKey
+        }
+        return true
+    }
+
     override fun getDataItemViewType(item: ChatMessageEntity, position: Int): Int =
         if (item.uid == selfUid) VIEW_TYPE_SENT else VIEW_TYPE_RECEIVED
 
@@ -131,19 +158,36 @@ class ChatMessageAdapter(
         val pos = holder.bindingAdapterPosition
         val older = if (pos != RecyclerView.NO_POSITION) currentList.getOrNull(pos + 1) else null
         val ctx = holder.itemView.context
+        val palette = palette(ctx)
+        // Quote accent follows the *quoted author's* identity: their name colour
+        // in the public room (so the quote reads as "that person"), brand colour
+        // for self / 1v1. Sent bubbles ignore this and use white-on-gradient.
+        val quotedUid = item.replyToUid
+        val quoteAccent = if (quotedUid != null && isGlobal && quotedUid != selfUid) {
+            nameColor(ctx, quotedUid)
+        } else {
+            palette.primary
+        }
         holder.bind(
             msg = item,
             avatarUrl = avatarUrl,
             older = older,
             isGlobal = isGlobal,
-            palette = palette(ctx),
+            selfUid = selfUid,
+            palette = palette,
             nameColor = if (isGlobal && item.uid != selfUid) nameColor(ctx, item.uid) else 0,
+            quoteAccent = quoteAccent,
             onAvatarClick = onAvatarClick,
+            onQuoteClick = onQuoteClick,
         )
         holder.itemView.setOnLongClickListener { v ->
             v.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
             onLongClick?.invoke(item)
             true
+        }
+        if (pendingFlashKey != null && pendingFlashKey == item.localKey) {
+            pendingFlashKey = null
+            holder.flash(palette)
         }
     }
 
@@ -162,26 +206,42 @@ class ChatMessageAdapter(
         private val tvMonogram: TextView? = itemView.findViewById(R.id.tv_monogram) // received anon
         private val tvName: TextView? = itemView.findViewById(R.id.tv_name)   // received only
         private val ivState: ImageView? = itemView.findViewById(R.id.iv_state) // sent only
+        private val quote: View = itemView.findViewById(R.id.quote)
+        private val quoteBar: View = itemView.findViewById(R.id.quote_bar)
+        private val tvQuoteName: TextView = itemView.findViewById(R.id.tv_quote_name)
+        private val tvQuoteText: TextView = itemView.findViewById(R.id.tv_quote_text)
+
+        private var flashAnimator: ValueAnimator? = null
 
         fun bind(
             msg: ChatMessageEntity,
             avatarUrl: String?,
             older: ChatMessageEntity?,
             isGlobal: Boolean,
+            selfUid: Long,
             palette: V3Palette,
             nameColor: Int,
+            quoteAccent: Int,
             onAvatarClick: ((uid: Long) -> Unit)?,
+            onQuoteClick: ((quotedLocalKey: String) -> Unit)?,
         ) {
             val ctx = itemView.context
             val d = ctx.resources.displayMetrics.density
             val text = msg.text.orEmpty()
 
+            // A recycled holder may still be mid-flash from a jump-to-quote.
+            cancelFlash()
+
             // Content: cap bubble width at ~70% of the screen (narrow phones →
             // tablets stay balanced), render pure-emoji messages jumbo & bubble-
             // less, and linkify URLs.
             tvContent.text = text
-            tvContent.maxWidth = (ctx.resources.displayMetrics.widthPixels * BUBBLE_WIDTH_RATIO).toInt()
-            val jumbo = isJumboEmoji(text)
+            val contentMax = (ctx.resources.displayMetrics.widthPixels * BUBBLE_WIDTH_RATIO).toInt()
+            tvContent.maxWidth = contentMax
+            // A quoted message forces the bubble chrome even for pure-emoji text —
+            // the quote block needs a surface to sit on.
+            val jumbo = !msg.isReply && isJumboEmoji(text)
+            bindQuote(msg, selfUid, palette, quoteAccent, contentMax, d, onQuoteClick)
             val hasLinks = !jumbo && LinkifyCompat.addLinks(tvContent, Linkify.WEB_URLS)
             if (hasLinks) {
                 tvContent.movementMethod = LinkMovementMethod.getInstance()
@@ -280,6 +340,129 @@ class ChatMessageAdapter(
                     iv.isClickable = false
                 }
             }
+        }
+
+        /**
+         * Quote block at the top of the bubble when [msg] is a reply.
+         *
+         *  - Sent (gradient) bubble: white 22% tonal container, white bar, white
+         *    name, white 85% excerpt — everything stays on the brand gradient.
+         *  - Received bubble: [quoteAccent] 8% fill + 15% hairline (one step
+         *    lighter than the bubble's own surface), bar + name in the accent,
+         *    excerpt in `v3_text_2`.
+         *
+         * Corner radius 12dp — one step in from the 18dp bubble so it reads as
+         * a layer *inside* the bubble rather than a second bubble.
+         */
+        private fun bindQuote(
+            msg: ChatMessageEntity,
+            selfUid: Long,
+            palette: V3Palette,
+            quoteAccent: Int,
+            contentMax: Int,
+            d: Float,
+            onQuoteClick: ((quotedLocalKey: String) -> Unit)?,
+        ) {
+            val quotedKey = msg.replyToCmid
+            if (quotedKey == null) {
+                quote.visibility = View.GONE
+                quote.setOnClickListener(null)
+                return
+            }
+            val ctx = itemView.context
+            quote.visibility = View.VISIBLE
+
+            val name = when {
+                msg.replyToUid == selfUid -> ctx.getString(R.string.chat_self_label)
+                !msg.replyToDisplayName.isNullOrBlank() -> msg.replyToDisplayName
+                else -> "匿名_${msg.replyToUid}"   // server's anonymous-name convention
+            }
+            tvQuoteName.text = name
+            val excerpt = msg.replyToText
+            val unavailable = excerpt == null
+            tvQuoteText.text = if (unavailable) ctx.getString(R.string.chat_reply_unavailable)
+                               else excerpt!!.replace('\n', ' ')
+
+            // Keep the quote inside the bubble's width cap: 10+12 padding, 3 bar, 9 gap.
+            val innerMax = contentMax - (34 * d).toInt()
+            tvQuoteName.maxWidth = innerMax
+            tvQuoteText.maxWidth = innerMax
+
+            val radius = 12 * d
+            val fill: Int
+            val stroke: Int
+            val barColor: Int
+            val nameColor: Int
+            val textColor: Int
+            if (isSent) {
+                fill = 0x38FFFFFF
+                stroke = 0
+                barColor = Color.WHITE
+                nameColor = Color.WHITE
+                textColor = 0xD9FFFFFF.toInt()
+            } else {
+                fill = V3Palette.withAlpha(quoteAccent, if (palette.isDark) 0.14f else 0.08f)
+                stroke = V3Palette.withAlpha(quoteAccent, 0.15f)
+                barColor = quoteAccent
+                nameColor = quoteAccent
+                textColor = ContextCompat.getColor(ctx, R.color.v3_text_2)
+            }
+            val container = GradientDrawable().apply {
+                cornerRadius = radius
+                setColor(fill)
+                if (stroke != 0) setStroke(maxOf(1, (0.5f * d).toInt()), stroke)
+            }
+            // Ripple clipped to the rounded container so the tap reads as "this block".
+            val rippleColor = if (isSent) 0x33FFFFFF else V3Palette.withAlpha(quoteAccent, 0.16f)
+            quote.background = android.graphics.drawable.RippleDrawable(
+                android.content.res.ColorStateList.valueOf(rippleColor),
+                container,
+                GradientDrawable().apply { cornerRadius = radius; setColor(Color.WHITE) },
+            )
+            quoteBar.background = GradientDrawable().apply {
+                cornerRadius = 999f
+                setColor(barColor)
+            }
+            tvQuoteName.setTextColor(nameColor)
+            tvQuoteText.setTextColor(textColor)
+            tvQuoteText.alpha = if (unavailable) 0.7f else 1f
+
+            if (onQuoteClick != null && !unavailable) {
+                quote.isClickable = true
+                quote.setOnClickListener { onQuoteClick(quotedKey) }
+            } else {
+                quote.isClickable = false
+                quote.setOnClickListener(null)
+            }
+        }
+
+        /** Row-wide tonal flash (brand 18% → 0 over ~900ms) used by jump-to-quote. */
+        fun flash(palette: V3Palette) {
+            cancelFlash()
+            val color = V3Palette.withAlpha(palette.primary, 0.18f)
+            val bg = ColorDrawable(color)
+            itemView.background = bg
+            flashAnimator = ValueAnimator.ofInt(255, 0).apply {
+                duration = 900L
+                startDelay = 150L
+                interpolator = DecelerateInterpolator()
+                addUpdateListener { bg.alpha = it.animatedValue as Int }
+                doOnEndOrCancel { itemView.background = null; flashAnimator = null }
+                start()
+            }
+        }
+
+        private fun cancelFlash() {
+            flashAnimator?.cancel()
+            flashAnimator = null
+            itemView.background = null
+        }
+
+        private fun ValueAnimator.doOnEndOrCancel(block: () -> Unit) {
+            addListener(object : android.animation.AnimatorListenerAdapter() {
+                override fun onAnimationEnd(animation: android.animation.Animator) = block()
+                override fun onAnimationCancel(animation: android.animation.Animator) = block()
+            })
         }
 
         private fun bindAvatar(
@@ -408,4 +591,19 @@ class ChatMessageAdapter(
             }
         }
     }
+}
+
+/**
+ * The chat screen's V3 palette: brand colour from [Shaft.getThemeColor] (NOT
+ * `?attr/colorPrimary` — this screen overlays a full Material3 theme for its
+ * StateLayout, which shadows colorPrimary; see NavExt) + current night mode.
+ * Shared by the bubble adapter and the composer's reply strip so both paint
+ * the same accent.
+ */
+internal fun chatPalette(ctx: Context): V3Palette {
+    val brand = runCatching { Color.parseColor(Shaft.getThemeColor()) }
+        .getOrDefault(ContextCompat.getColor(ctx, R.color.v3_purple))
+    val isDark = (ctx.resources.configuration.uiMode and
+        Configuration.UI_MODE_NIGHT_MASK) == Configuration.UI_MODE_NIGHT_YES
+    return V3Palette(brand, isDark)
 }

--- a/app/src/main/java/ceui/pixiv/chat/ui/DemoChatListFragment.kt
+++ b/app/src/main/java/ceui/pixiv/chat/ui/DemoChatListFragment.kt
@@ -447,6 +447,11 @@ class DemoChatListFragment : Fragment(R.layout.chat_fragment_demo_list) {
         val ctx = requireContext()
         val d = resources.displayMetrics.density
         val palette = chatPalette(ctx)
+        // The fragment instance can outlive its view (back stack / tablet panes);
+        // a fresh view always starts with the strip hidden, so resync the flag or
+        // showReplyBar() would early-return against a GONE view.
+        replyBarShown = false
+        binding.replyBar.visibility = View.GONE
         // Brand 8% tonal container + 15% hairline, 16dp — same family as the
         // in-bubble quote block (12dp) one step up the radius ladder.
         binding.replyBar.background = GradientDrawable().apply {

--- a/app/src/main/java/ceui/pixiv/chat/ui/DemoChatListFragment.kt
+++ b/app/src/main/java/ceui/pixiv/chat/ui/DemoChatListFragment.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.res.ColorStateList
 import android.graphics.Color
+import android.graphics.drawable.GradientDrawable
 import android.os.Bundle
 import android.view.HapticFeedbackConstants
 import android.view.View
@@ -38,6 +39,7 @@ import ceui.pixiv.chat.api.HttpChatHistorySource
 import ceui.pixiv.chat.api.ShaftChatGateway
 import ceui.pixiv.chat.base.PagingFooterAdapter
 import ceui.pixiv.chat.base.launchSuspend
+import ceui.pixiv.chat.base.panel.BottomPanelCoordinator
 import ceui.pixiv.chat.base.panel.PanelHost
 import ceui.pixiv.chat.base.panel.attachBottomPanel
 import ceui.pixiv.chat.base.setupToolbar
@@ -47,6 +49,7 @@ import ceui.pixiv.chat.data.ChatDatabase
 import ceui.pixiv.chat.data.ChatMessageEntity
 import ceui.pixiv.chat.data.RoomChatMessageStore
 import ceui.pixiv.chat.vm.ChatListViewModel
+import ceui.pixiv.witstudio.theme.V3Palette
 import ceui.pixiv.session.SessionManager
 import ceui.pixiv.websocket.WebSocketState
 import com.hjq.toast.Toaster
@@ -105,6 +108,12 @@ class DemoChatListFragment : Fragment(R.layout.chat_fragment_demo_list) {
     private var chatAdapter: ChatMessageAdapter? = null
     private var scrollToBottomOnNextUpdate = false
 
+    /** Emoji ↔ keyboard coordinator; kept so "reply" can pop the keyboard through the same state machine. */
+    private var panelCoordinator: BottomPanelCoordinator? = null
+
+    /** Whether the composer's reply strip is currently shown (drives the show/hide animation). */
+    private var replyBarShown = false
+
     /** "N 条新消息" pill state — only shown when a new message lands while the
      *  user is scrolled up reading history. */
     private var newMsgCount = 0
@@ -161,7 +170,7 @@ class DemoChatListFragment : Fragment(R.layout.chat_fragment_demo_list) {
         setupToolbar(title = initialTitle, showBack = true)
 
         // ── Bottom panel (emoji ↔ keyboard) ──────────────────────────
-        attachBottomPanel(
+        panelCoordinator = attachBottomPanel(
             host = object : PanelHost {
                 override val panelRoot get() = binding.root
                 override val panelView get() = binding.emojiPanel
@@ -181,6 +190,7 @@ class DemoChatListFragment : Fragment(R.layout.chat_fragment_demo_list) {
 
         // ── Input ────────────────────────────────────────────────────
         setupInput()
+        setupReplyBar()
 
         // ── RecyclerView ─────────────────────────────────────────────
         // Adapter compares msg.uid against selfUid for right-vs-left bubble.
@@ -191,6 +201,7 @@ class DemoChatListFragment : Fragment(R.layout.chat_fragment_demo_list) {
             isGlobal = isGlobalRoom,
             onLongClick = { msg -> showMessageActions(msg) },
             onAvatarClick = { uid -> openUserProfile(uid) },
+            onQuoteClick = { quotedKey -> jumpToMessage(quotedKey) },
         ).also { this.chatAdapter = it }
         val footerAdapter = PagingFooterAdapter().apply {
             onRetry = { viewModel.retryPaging() }
@@ -255,6 +266,7 @@ class DemoChatListFragment : Fragment(R.layout.chat_fragment_demo_list) {
             launch { observeFatalAuth() }
             launch { observeMarkRead() }
             launch { observePeerTyping() }
+            launch { observeReplyTarget() }
         }
     }
 
@@ -360,8 +372,11 @@ class DemoChatListFragment : Fragment(R.layout.chat_fragment_demo_list) {
     // ── Message actions ─────────────────────────────────────────────────
 
     private fun showMessageActions(msg: ChatMessageEntity) {
-        MessageActionsSheet.newInstance(msg.localKey, msg.text)
-            .show(childFragmentManager, MessageActionsSheet.TAG)
+        MessageActionsSheet.newInstance(
+            localKey = msg.localKey,
+            content = msg.text,
+            canReply = ChatListViewModel.canReplyTo(msg),
+        ).show(childFragmentManager, MessageActionsSheet.TAG)
     }
 
     private fun setupMessageActionResult() {
@@ -377,9 +392,7 @@ class DemoChatListFragment : Fragment(R.layout.chat_fragment_demo_list) {
     private fun handleMessageAction(action: String, localKey: String) {
         when (action) {
             MessageActionsSheet.ACTION_COPY -> copyMessage(localKey)
-            MessageActionsSheet.ACTION_REPLY -> {
-                Toaster.showShort("回复（TODO）")
-            }
+            MessageActionsSheet.ACTION_REPLY -> startReply(localKey)
             MessageActionsSheet.ACTION_FORWARD -> {
                 Toaster.showShort("转发（TODO）")
             }
@@ -415,6 +428,110 @@ class DemoChatListFragment : Fragment(R.layout.chat_fragment_demo_list) {
             dao.deleteByLocalKey(localKey)
             Toaster.showShort("已删除")
         }
+    }
+
+    // ── Reply (quote) ───────────────────────────────────────────────────
+
+    /**
+     * Long-press → 回复: arm the VM's reply target (it owns the state so the
+     * strip survives rotation) and pop the keyboard so the user can type
+     * straight away. The strip itself is bound reactively in [observeReplyTarget].
+     */
+    private fun startReply(localKey: String) {
+        val msg = viewModel.messages.value.find { it.localKey == localKey } ?: return
+        viewModel.setReplyTarget(msg)
+        panelCoordinator?.switchToKeyboard() ?: binding.etInput.requestFocus()
+    }
+
+    private fun setupReplyBar() {
+        val ctx = requireContext()
+        val d = resources.displayMetrics.density
+        val palette = chatPalette(ctx)
+        // Brand 8% tonal container + 15% hairline, 16dp — same family as the
+        // in-bubble quote block (12dp) one step up the radius ladder.
+        binding.replyBar.background = GradientDrawable().apply {
+            cornerRadius = 16 * d
+            setColor(V3Palette.withAlpha(palette.primary, if (palette.isDark) 0.14f else 0.08f))
+            setStroke(maxOf(1, (0.5f * d).toInt()), V3Palette.withAlpha(palette.primary, 0.15f))
+        }
+        binding.replyBarAccent.background = GradientDrawable().apply {
+            cornerRadius = 999f
+            setColor(palette.primary)
+        }
+        binding.tvReplyBarName.setTextColor(palette.textAccent)
+        binding.btnReplyBarClose.setOnClickListener {
+            it.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
+            viewModel.clearReplyTarget()
+        }
+    }
+
+    /** Bind the composer's quote strip to the VM's reply target (show / update / hide). */
+    private suspend fun observeReplyTarget() {
+        viewModel.replyTarget.collect { target ->
+            if (target == null) {
+                hideReplyBar()
+                return@collect
+            }
+            val name = when {
+                target.uid == SessionManager.loggedInUid -> getString(R.string.chat_self_label)
+                !target.displayName.isNullOrBlank() -> target.displayName
+                else -> "匿名_${target.uid}"
+            }
+            binding.tvReplyBarName.text = getString(R.string.chat_reply_bar_title, name)
+            binding.tvReplyBarText.text = target.text.orEmpty().replace('\n', ' ')
+            showReplyBar()
+        }
+    }
+
+    private fun showReplyBar() {
+        if (replyBarShown) return
+        replyBarShown = true
+        val d = resources.displayMetrics.density
+        binding.replyBar.apply {
+            animate().cancel()
+            alpha = 0f
+            translationY = 8 * d
+            visibility = View.VISIBLE
+            animate().alpha(1f).translationY(0f)
+                .setDuration(180L)
+                .setInterpolator(DecelerateInterpolator())
+                .start()
+        }
+    }
+
+    private fun hideReplyBar() {
+        if (!replyBarShown) {
+            binding.replyBar.visibility = View.GONE
+            return
+        }
+        replyBarShown = false
+        val d = resources.displayMetrics.density
+        binding.replyBar.apply {
+            animate().cancel()
+            animate().alpha(0f).translationY(6 * d)
+                .setDuration(140L)
+                .withEndAction {
+                    // The VM may have armed a new target during the fade.
+                    if (!replyBarShown) visibility = View.GONE
+                }
+                .start()
+        }
+    }
+
+    /**
+     * Tap on a quote → scroll to the original message and flash it. The
+     * quoted key is the original's localKey (= its client_msg_id); if it's
+     * older than what's loaded, say so rather than silently doing nothing.
+     */
+    private fun jumpToMessage(localKey: String) {
+        val adapter = chatAdapter ?: return
+        val rv = binding.recyclerView
+        if (!adapter.flashMessage(localKey, rv)) {
+            Toaster.showShort(getString(R.string.chat_reply_original_not_loaded))
+            return
+        }
+        val pos = adapter.positionOf(localKey)
+        if (pos >= 0) rv.smoothScrollToPosition(pos)
     }
 
     // ── Input bar ───────────────────────────────────────────────────────
@@ -575,6 +692,8 @@ class DemoChatListFragment : Fragment(R.layout.chat_fragment_demo_list) {
             "bad_illust_id"         -> "插画 ID 无效"
             "bad_client_msg_id"     -> "消息标识无效"
             "frame_too_large"       -> "消息过大"
+            "bad_reply_to"          -> "回复目标无效"
+            "reply_target_not_found" -> "原消息已不存在,无法回复"
             else                    -> "发送失败,请稍后重试"
         }
     }

--- a/app/src/main/java/ceui/pixiv/chat/ui/MessageActionsSheet.kt
+++ b/app/src/main/java/ceui/pixiv/chat/ui/MessageActionsSheet.kt
@@ -3,6 +3,7 @@ package ceui.pixiv.chat.ui
 import android.os.Bundle
 import android.view.View
 import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
 import androidx.fragment.app.setFragmentResult
 import ceui.lisa.R
 import ceui.pixiv.chat.base.viewBinding
@@ -26,6 +27,10 @@ class MessageActionsSheet : BaseBottomSheetDialogFragment(R.layout.chat_sheet_me
         super.onViewCreated(view, savedInstanceState)
 
         binding.tvPreview.text = arguments?.getString(ARG_CONTENT).orEmpty()
+
+        // Reply is only offered for messages the server knows about
+        // (Delivered + has a client_msg_id) — see ChatListViewModel.canReplyTo.
+        binding.actionReply.isVisible = arguments?.getBoolean(ARG_CAN_REPLY, true) ?: true
 
         binding.actionCopy.setOnClickListener { finish(ACTION_COPY) }
         binding.actionReply.setOnClickListener { finish(ACTION_REPLY) }
@@ -51,10 +56,15 @@ class MessageActionsSheet : BaseBottomSheetDialogFragment(R.layout.chat_sheet_me
 
         private const val ARG_LOCAL_KEY = "localKey"
         private const val ARG_CONTENT = "content"
+        private const val ARG_CAN_REPLY = "canReply"
 
-        fun newInstance(localKey: String, content: String?): MessageActionsSheet =
+        fun newInstance(localKey: String, content: String?, canReply: Boolean = true): MessageActionsSheet =
             MessageActionsSheet().apply {
-                arguments = bundleOf(ARG_LOCAL_KEY to localKey, ARG_CONTENT to content)
+                arguments = bundleOf(
+                    ARG_LOCAL_KEY to localKey,
+                    ARG_CONTENT to content,
+                    ARG_CAN_REPLY to canReply,
+                )
             }
     }
 }

--- a/app/src/main/java/ceui/pixiv/chat/vm/ChatListViewModel.kt
+++ b/app/src/main/java/ceui/pixiv/chat/vm/ChatListViewModel.kt
@@ -3,6 +3,7 @@ package ceui.pixiv.chat.vm
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import ceui.pixiv.chat.api.ChatFrame
+import ceui.pixiv.chat.api.ChatReplyRef
 import ceui.pixiv.chat.api.ChatThreadId
 import ceui.pixiv.chat.base.LoadReason
 import ceui.pixiv.chat.base.PageState
@@ -132,6 +133,15 @@ class ChatListViewModel(
     private val _peerTyping = MutableStateFlow(PeerTypingState.Idle)
     val peerTyping: StateFlow<PeerTypingState> = _peerTyping.asStateFlow()
 
+    /**
+     * The message the user is currently composing a reply to (long-press →
+     * 回复), or `null`. Lives in the VM so the composer's quote strip survives
+     * rotation / the fragment's view being recreated. Cleared on a successful
+     * dispatch in [sendText] or explicitly via [clearReplyTarget].
+     */
+    private val _replyTarget = MutableStateFlow<ChatMessageEntity?>(null)
+    val replyTarget: StateFlow<ChatMessageEntity?> = _replyTarget.asStateFlow()
+
     init {
         Timber.tag(TAG_PERF).d(
             "init: selfUid=%d toUid=%s room=%s pageSize=%d",
@@ -244,6 +254,11 @@ class ChatListViewModel(
             return false
         }
 
+        // Snapshot the reply target at dispatch time so a clear/re-pick while
+        // the frame is in flight can't change what this message quotes.
+        val quoted = _replyTarget.value?.takeIf { canReplyTo(it) }
+        val replyRef = quoted?.let { ChatReplyRef(uid = it.uid, clientMsgId = it.clientMsgId!!) }
+
         val clientMsgId = UUID.randomUUID().toString()
         val now = System.currentTimeMillis()
         val optimistic = ChatMessageEntity(
@@ -257,6 +272,12 @@ class ChatListViewModel(
             illustId = illustId,
             ts = now,
             state = SendState.Sending,
+            // Optimistic quote from the local copy of the target; the echo
+            // overwrites it with the server's canonical snapshot.
+            replyToUid = quoted?.uid,
+            replyToCmid = quoted?.clientMsgId,
+            replyToDisplayName = quoted?.displayName,
+            replyToText = quoted?.text?.take(REPLY_PREVIEW_MAX),
         )
 
         // Optimistic UI first. windowSize++ so the new row doesn't push
@@ -279,7 +300,10 @@ class ChatListViewModel(
         // latency when the echo arrives.
         inFlightSends[clientMsgId] = System.nanoTime()
 
-        val accepted = sender.send(toUid = toUid, clientMsgId = clientMsgId, text = trimmed, illustId = illustId)
+        val accepted = sender.send(
+            toUid = toUid, clientMsgId = clientMsgId, text = trimmed,
+            illustId = illustId, replyTo = replyRef,
+        )
         if (!accepted) {
             inFlightSends.remove(clientMsgId)
             store.upsert(listOf(optimistic.copy(state = SendState.Failed)))
@@ -287,8 +311,29 @@ class ChatListViewModel(
                 "⇡ sendText WS REJECTED cmid=%s → state=Failed (no active session?)",
                 clientMsgId,
             )
+        } else if (quoted != null) {
+            // The reply went out — the composer strip has done its job.
+            _replyTarget.compareAndSet(quoted, null)
         }
         return accepted
+    }
+
+    /**
+     * Start composing a reply to [msg]. No-op (and logged) for rows that
+     * can't be quoted — see [canReplyTo]; the UI hides the action for those,
+     * this is the belt to its braces.
+     */
+    fun setReplyTarget(msg: ChatMessageEntity) {
+        if (!canReplyTo(msg)) {
+            Timber.tag(TAG).w("setReplyTarget: %s not replyable (state=%s cmid=%s)",
+                msg.localKey, msg.state, msg.clientMsgId ?: "-")
+            return
+        }
+        _replyTarget.value = msg
+    }
+
+    fun clearReplyTarget() {
+        _replyTarget.value = null
     }
 
     /**
@@ -571,6 +616,19 @@ class ChatListViewModel(
         /** doc §3.1 / §12. */
         const val MAX_TEXT_LENGTH = 2048
 
+        /** Server truncates the quoted excerpt to this many UTF-16 units; mirror it optimistically. */
+        private const val REPLY_PREVIEW_MAX = 200
+
+        /**
+         * A message can be quoted only once the server knows it: it needs a
+         * `client_msg_id` (legacy `server:<id>` rows have none) and must be
+         * [SendState.Delivered] — a Sending/Failed optimistic row may never
+         * reach the server, and the server rejects quotes of unknown messages
+         * with `reply_target_not_found`.
+         */
+        fun canReplyTo(msg: ChatMessageEntity): Boolean =
+            msg.clientMsgId != null && msg.state == SendState.Delivered
+
         /**
          * How often we re-send a `typing:start` frame while user keeps
          * typing. Server bucket is 10 frames / 10s; 4 s keeps us at 1/4 s
@@ -621,5 +679,11 @@ data class PeerTypingState(
  * a lambda that records calls.
  */
 fun interface WsMsgSender {
-    fun send(toUid: Long?, clientMsgId: String, text: String, illustId: Long?): Boolean
+    fun send(
+        toUid: Long?,
+        clientMsgId: String,
+        text: String,
+        illustId: Long?,
+        replyTo: ChatReplyRef?,
+    ): Boolean
 }

--- a/app/src/main/res/layout/chat_bubble_received.xml
+++ b/app/src/main/res/layout/chat_bubble_received.xml
@@ -2,6 +2,7 @@
 <!-- 收到的消息 —— V3。竖向根:①时间分组胶囊(间隔大/跨天时居中显示,默认 GONE)
      ②气泡行(头像 + 昵称[仅公屏] + 气泡 + 气泡下方发送时间)。
      气泡用 LinearLayout + bg_chat_bubble_received(圆角 drawable),不用 MaterialCardView。
+     气泡内顶部可选引用块(quote,回复某条消息时显示)。
      头像用 FrameLayout 包一层,匿名用户叠一个白色首字 monogram(tv_monogram)。
      根的上/下 padding(分组节奏)与气泡最大宽(按屏宽 70%)在 ChatMessageAdapter 运行时设。 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
@@ -98,9 +99,72 @@
                 android:paddingHorizontal="14dp"
                 android:paddingVertical="9dp">
 
+                <!-- 引用块(回复某条消息时显示,默认 GONE):左侧 3dp 竖向强调条 + 被引用者昵称 +
+                     ≤2 行摘要。底色 / 强调色在 ChatMessageAdapter 运行时铺:发出气泡用白色半透明
+                     (压在品牌渐变上),收到气泡用品牌色 8% tonal 容器 + 15% hairline,
+                     12dp 圆角 —— 比 18dp 气泡收一档,读作「气泡里的一层」。点击跳回原消息。 -->
+                <LinearLayout
+                    android:id="@+id/quote"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="7dp"
+                    android:gravity="center_vertical"
+                    android:minWidth="156dp"
+                    android:orientation="horizontal"
+                    android:paddingStart="10dp"
+                    android:paddingTop="7dp"
+                    android:paddingEnd="12dp"
+                    android:paddingBottom="7dp"
+                    android:visibility="gone"
+                    tools:visibility="visible">
+
+                    <View
+                        android:id="@+id/quote_bar"
+                        android:layout_width="3dp"
+                        android:layout_height="match_parent"
+                        android:layout_marginTop="1dp"
+                        android:layout_marginBottom="1dp" />
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="9dp"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:id="@+id/tv_quote_name"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:ellipsize="end"
+                            android:includeFontPadding="false"
+                            android:singleLine="true"
+                            android:textSize="12sp"
+                            android:textStyle="bold"
+                            tools:text="某位画师" />
+
+                        <TextView
+                            android:id="@+id/tv_quote_text"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="2dp"
+                            android:ellipsize="end"
+                            android:includeFontPadding="false"
+                            android:lineSpacingExtra="1dp"
+                            android:maxLines="2"
+                            android:textSize="13sp"
+                            tools:text="被引用的那条消息内容,最多两行,超出省略…" />
+
+                    </LinearLayout>
+
+                </LinearLayout>
+
+                <!-- match_parent(而非 wrap_content):LinearLayout 在 wrap_content 父里只有当
+                     **所有**子 View 都 match_parent 时才按各自真实测量宽取最大值;否则 quote 这种
+                     match_parent 子 View 的宽度不计入气泡宽,引用块会被压成一条。TextView 在
+                     AT_MOST 下仍按文本期望宽测量,所以短消息的气泡照样收紧。 -->
                 <TextView
                     android:id="@+id/tv_content"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:lineSpacingExtra="3dp"
                     android:textColor="@color/v3_text_1"

--- a/app/src/main/res/layout/chat_bubble_sent.xml
+++ b/app/src/main/res/layout/chat_bubble_sent.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- 发出的消息 —— V3。竖向根:①时间分组胶囊(与收到气泡共用,居中,默认 GONE)
      ②气泡行(右对齐:气泡列 + 自己头像)。气泡底是主题色渐变,在 ChatMessageAdapter
-     运行时铺(圆角 drawable + 品牌色,右上角小尾巴)。气泡下方右下角:发送状态(失败红叹号)
-     + 发送时间。 -->
+     运行时铺(圆角 drawable + 品牌色,右上角小尾巴)。气泡内顶部可选引用块(quote,回复时显示)。
+     气泡下方右下角:发送状态(失败红叹号)+ 发送时间。 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -51,9 +51,72 @@
                 android:paddingHorizontal="14dp"
                 android:paddingVertical="9dp">
 
+                <!-- 引用块(回复某条消息时显示,默认 GONE):左侧 3dp 竖向强调条 + 被引用者昵称 +
+                     ≤2 行摘要。底色 / 强调色在 ChatMessageAdapter 运行时铺:发出气泡用白色半透明
+                     (压在品牌渐变上),收到气泡用品牌色 8% tonal 容器 + 15% hairline,
+                     12dp 圆角 —— 比 18dp 气泡收一档,读作「气泡里的一层」。点击跳回原消息。 -->
+                <LinearLayout
+                    android:id="@+id/quote"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="7dp"
+                    android:gravity="center_vertical"
+                    android:minWidth="156dp"
+                    android:orientation="horizontal"
+                    android:paddingStart="10dp"
+                    android:paddingTop="7dp"
+                    android:paddingEnd="12dp"
+                    android:paddingBottom="7dp"
+                    android:visibility="gone"
+                    tools:visibility="visible">
+
+                    <View
+                        android:id="@+id/quote_bar"
+                        android:layout_width="3dp"
+                        android:layout_height="match_parent"
+                        android:layout_marginTop="1dp"
+                        android:layout_marginBottom="1dp" />
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="9dp"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:id="@+id/tv_quote_name"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:ellipsize="end"
+                            android:includeFontPadding="false"
+                            android:singleLine="true"
+                            android:textSize="12sp"
+                            android:textStyle="bold"
+                            tools:text="某位画师" />
+
+                        <TextView
+                            android:id="@+id/tv_quote_text"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="2dp"
+                            android:ellipsize="end"
+                            android:includeFontPadding="false"
+                            android:lineSpacingExtra="1dp"
+                            android:maxLines="2"
+                            android:textSize="13sp"
+                            tools:text="被引用的那条消息内容,最多两行,超出省略…" />
+
+                    </LinearLayout>
+
+                </LinearLayout>
+
+                <!-- match_parent(而非 wrap_content):LinearLayout 在 wrap_content 父里只有当
+                     **所有**子 View 都 match_parent 时才按各自真实测量宽取最大值;否则 quote 这种
+                     match_parent 子 View 的宽度不计入气泡宽,引用块会被压成一条。TextView 在
+                     AT_MOST 下仍按文本期望宽测量,所以短消息的气泡照样收紧。 -->
                 <TextView
                     android:id="@+id/tv_content"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:lineSpacingExtra="3dp"
                     android:textColor="@android:color/white"

--- a/app/src/main/res/layout/chat_fragment_demo_list.xml
+++ b/app/src/main/res/layout/chat_fragment_demo_list.xml
@@ -14,7 +14,7 @@
         android:id="@+id/state_layout"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toTopOf="@id/input_bar"
+        app:layout_constraintBottom_toTopOf="@id/composer"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/app_bar_layout">
@@ -29,18 +29,97 @@
 
     </ceui.pixiv.chat.base.widget.StateLayout>
 
+    <!-- 输入区 = 引用条(回复某条消息时出现,默认 GONE)+ 输入行,共用一块 v3_menu_bg 表面,
+         引用条与输入行之间不画分割线,靠留白 + 引用条自己的 tonal 容器分层。 -->
+    <LinearLayout
+        android:id="@+id/composer"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@color/v3_menu_bg"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toTopOf="@id/emoji_panel"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent">
+
+        <!-- 引用条:左 3dp 品牌色强调条 + 「回复 xxx」+ 一行摘要 + 关闭。底 = 品牌色 8% tonal
+             容器 + 15% hairline、16dp 圆角(DemoChatListFragment 运行时铺,品牌色走
+             Shaft.getThemeColor,本页 M3 overlay 会遮蔽 colorPrimary)。 -->
+        <LinearLayout
+            android:id="@+id/reply_bar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:layout_marginTop="10dp"
+            android:layout_marginEnd="12dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingStart="12dp"
+            android:paddingTop="8dp"
+            android:paddingEnd="2dp"
+            android:paddingBottom="8dp"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <View
+                android:id="@+id/reply_bar_accent"
+                android:layout_width="3dp"
+                android:layout_height="match_parent"
+                android:layout_marginTop="2dp"
+                android:layout_marginBottom="2dp" />
+
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="10dp"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/tv_reply_bar_name"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:ellipsize="end"
+                    android:includeFontPadding="false"
+                    android:singleLine="true"
+                    android:textSize="13sp"
+                    android:textStyle="bold"
+                    tools:text="回复 某位画师" />
+
+                <TextView
+                    android:id="@+id/tv_reply_bar_text"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="2dp"
+                    android:ellipsize="end"
+                    android:includeFontPadding="false"
+                    android:singleLine="true"
+                    android:textColor="@color/v3_text_2"
+                    android:textSize="13sp"
+                    tools:text="被引用的那条消息内容…" />
+
+            </LinearLayout>
+
+            <ImageButton
+                android:id="@+id/btn_reply_bar_close"
+                android:layout_width="36dp"
+                android:layout_height="36dp"
+                android:layout_marginStart="6dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/chat_reply_close"
+                android:scaleType="centerInside"
+                android:src="@drawable/ic_close_black_24dp"
+                app:tint="@color/v3_text_3" />
+
+        </LinearLayout>
+
     <LinearLayout
         android:id="@+id/input_bar"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:gravity="center_vertical"
         android:paddingHorizontal="12dp"
-        android:paddingVertical="10dp"
-        android:background="@color/v3_menu_bg"
-        app:layout_constraintBottom_toTopOf="@id/emoji_panel"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent">
+        android:paddingVertical="10dp">
 
         <ImageButton
             android:id="@+id/btn_emoji"
@@ -98,6 +177,8 @@
 
     </LinearLayout>
 
+    </LinearLayout>
+
     <!-- 「N 条新消息」胶囊:向上翻历史时来新消息才浮现,点一下回到底部。 -->
     <TextView
         android:id="@+id/new_msg_pill"
@@ -120,7 +201,7 @@
         android:visibility="gone"
         app:drawableStartCompat="@drawable/ic_baseline_keyboard_arrow_down_24"
         app:drawableTint="@color/v3_text_1"
-        app:layout_constraintBottom_toTopOf="@id/input_bar"
+        app:layout_constraintBottom_toTopOf="@id/composer"
         app:layout_constraintEnd_toEndOf="parent"
         tools:text="3 条新消息"
         tools:visibility="visible" />

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -2207,6 +2207,10 @@
     <string name="chat_action_delete">Delete</string>
     <string name="chat_action_forward">Forward</string>
     <string name="chat_action_reply">Reply</string>
+    <string name="chat_reply_bar_title">Reply to %1$s</string>
+    <string name="chat_reply_unavailable">Original message unavailable</string>
+    <string name="chat_reply_original_not_loaded">Original message isn\u2019t loaded yet</string>
+    <string name="chat_reply_close">Cancel reply</string>
     <string name="chat_state_loading_default">Loading…</string>
     <string name="chat_state_error_default">Something went wrong</string>
     <string name="chat_state_empty_default">Nothing here yet</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -2207,6 +2207,10 @@
     <string name="chat_action_delete">削除</string>
     <string name="chat_action_forward">転送</string>
     <string name="chat_action_reply">返信</string>
+    <string name="chat_reply_bar_title">%1$s に返信</string>
+    <string name="chat_reply_unavailable">元のメッセージは利用できません</string>
+    <string name="chat_reply_original_not_loaded">元のメッセージは読み込まれていません</string>
+    <string name="chat_reply_close">返信をキャンセル</string>
     <string name="chat_state_loading_default">読み込み中…</string>
     <string name="chat_state_error_default">エラーが発生しました</string>
     <string name="chat_state_empty_default">まだ何もありません</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2207,6 +2207,10 @@
     <string name="chat_action_delete">삭제</string>
     <string name="chat_action_forward">전달</string>
     <string name="chat_action_reply">답장</string>
+    <string name="chat_reply_bar_title">%1$s에게 답장</string>
+    <string name="chat_reply_unavailable">원본 메시지를 사용할 수 없습니다</string>
+    <string name="chat_reply_original_not_loaded">원본 메시지가 아직 불러와지지 않았습니다</string>
+    <string name="chat_reply_close">답장 취소</string>
     <string name="chat_state_loading_default">로딩 중…</string>
     <string name="chat_state_error_default">오류가 발생했습니다</string>
     <string name="chat_state_empty_default">아직 아무것도 없습니다</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2207,6 +2207,10 @@
     <string name="chat_action_delete">Удалить</string>
     <string name="chat_action_forward">Переслать</string>
     <string name="chat_action_reply">Ответить</string>
+    <string name="chat_reply_bar_title">Ответ %1$s</string>
+    <string name="chat_reply_unavailable">Исходное сообщение недоступно</string>
+    <string name="chat_reply_original_not_loaded">Исходное сообщение ещё не загружено</string>
+    <string name="chat_reply_close">Отменить ответ</string>
     <string name="chat_state_loading_default">Загрузка…</string>
     <string name="chat_state_error_default">Что-то пошло не так</string>
     <string name="chat_state_empty_default">Здесь пока ничего нет</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -2207,6 +2207,10 @@
     <string name="chat_action_delete">Sil</string>
     <string name="chat_action_forward">İlet</string>
     <string name="chat_action_reply">Yanıtla</string>
+    <string name="chat_reply_bar_title">%1$s kişisine yanıt</string>
+    <string name="chat_reply_unavailable">Orijinal mesaj kullanılamıyor</string>
+    <string name="chat_reply_original_not_loaded">Orijinal mesaj henüz yüklenmedi</string>
+    <string name="chat_reply_close">Yanıtı iptal et</string>
     <string name="chat_state_loading_default">Yükleniyor…</string>
     <string name="chat_state_error_default">Bir hata oluştu</string>
     <string name="chat_state_empty_default">Henüz hiçbir şey yok</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -2209,6 +2209,10 @@
     <string name="chat_action_delete">刪除</string>
     <string name="chat_action_forward">轉發</string>
     <string name="chat_action_reply">回覆</string>
+    <string name="chat_reply_bar_title">回覆 %1$s</string>
+    <string name="chat_reply_unavailable">原訊息已不可用</string>
+    <string name="chat_reply_original_not_loaded">原訊息不在已載入的紀錄裡</string>
+    <string name="chat_reply_close">取消回覆</string>
     <string name="chat_state_loading_default">載入中…</string>
     <string name="chat_state_error_default">發生錯誤</string>
     <string name="chat_state_empty_default">暫時沒有內容</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2458,6 +2458,10 @@
     <string name="chat_action_delete">删除</string>
     <string name="chat_action_forward">转发</string>
     <string name="chat_action_reply">回复</string>
+    <string name="chat_reply_bar_title">回复 %1$s</string>
+    <string name="chat_reply_unavailable">原消息已不可用</string>
+    <string name="chat_reply_original_not_loaded">原消息不在已加载的记录里</string>
+    <string name="chat_reply_close">取消回复</string>
     <string name="chat_state_loading_default">加载中…</string>
     <string name="chat_state_error_default">出错了</string>
     <string name="chat_state_empty_default">暂时没有内容</string>

--- a/app/src/test/java/ceui/pixiv/chat/api/ChatFrameReplyToTest.kt
+++ b/app/src/test/java/ceui/pixiv/chat/api/ChatFrameReplyToTest.kt
@@ -1,0 +1,102 @@
+package ceui.pixiv.chat.api
+
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Wire contract for the reply-to-message feature (`reply_to` on `msg`
+ * frames, both directions) — pinned against `shaft-api-v2/src/chat/ws.js`
+ * (`parseReplyTo` / `handleMsg`) and `docs/ws-chat-integration.md` §3.
+ */
+class ChatFrameReplyToTest {
+
+    // ── Inbound (server → client) ────────────────────────────────────────
+
+    @Test
+    fun `msg frame with reply_to decodes the quoted snapshot`() {
+        val raw = """
+            {"kind":"msg","room":"global","uid":7,"display_name":"lisa",
+             "client_msg_id":"cmid-reply-0001","text":"同意","ts":1700000000000,
+             "reply_to":{"uid":5,"client_msg_id":"cmid-orig-0001","display_name":"nana","text":"原消息"}}
+        """.trimIndent()
+        val frame = ChatFrameDecoder.decode(raw)
+        assertTrue(frame is ChatFrame.Msg)
+        val ref = (frame as ChatFrame.Msg).replyTo
+        assertEquals(ChatReplyRef(uid = 5, clientMsgId = "cmid-orig-0001", displayName = "nana", text = "原消息"), ref)
+    }
+
+    @Test
+    fun `reply_to with null text means original purged - still decodes`() {
+        val raw = """
+            {"kind":"msg","room":"global","uid":7,"client_msg_id":"cmid-reply-0002","text":"x","ts":1,
+             "reply_to":{"uid":5,"client_msg_id":"cmid-orig-0002","display_name":"匿名_5","text":null}}
+        """.trimIndent()
+        val ref = (ChatFrameDecoder.decode(raw) as ChatFrame.Msg).replyTo
+        assertEquals("cmid-orig-0002", ref?.clientMsgId)
+        assertNull(ref?.text)
+    }
+
+    @Test
+    fun `msg frame without reply_to has null replyTo`() {
+        val raw = """{"kind":"msg","room":"global","uid":7,"client_msg_id":"cmid-plain-0001","text":"x","ts":1}"""
+        assertNull((ChatFrameDecoder.decode(raw) as ChatFrame.Msg).replyTo)
+    }
+
+    @Test
+    fun `malformed reply_to degrades to null instead of dead-lettering the frame`() {
+        // Missing client_msg_id → can't anchor the quote; the message itself must still render.
+        val raw = """{"kind":"msg","room":"global","uid":7,"client_msg_id":"cmid-plain-0002","text":"x","ts":1,
+                      "reply_to":{"uid":5}}"""
+        val frame = ChatFrameDecoder.decode(raw)
+        assertTrue(frame is ChatFrame.Msg)
+        assertNull((frame as ChatFrame.Msg).replyTo)
+        // Non-object reply_to likewise.
+        val raw2 = """{"kind":"msg","room":"global","uid":7,"client_msg_id":"cmid-plain-0003","text":"x","ts":1,
+                       "reply_to":"nope"}"""
+        assertNull((ChatFrameDecoder.decode(raw2) as ChatFrame.Msg).replyTo)
+    }
+
+    // ── Outbound (client → server) ───────────────────────────────────────
+
+    @Test
+    fun `msgGlobal emits reply_to with only uid and client_msg_id`() {
+        val json = ChatFrameEncoder.msgGlobal(
+            clientMsgId = "cmid-reply-0003",
+            text = "同意",
+            replyTo = ChatReplyRef(uid = 5, clientMsgId = "cmid-orig-0003", displayName = "ignored", text = "ignored"),
+        )
+        val o = JSONObject(json)
+        assertEquals("msg", o.getString("kind"))
+        assertEquals("global", o.getString("room"))
+        val rt = o.getJSONObject("reply_to")
+        assertEquals(5L, rt.getLong("uid"))
+        assertEquals("cmid-orig-0003", rt.getString("client_msg_id"))
+        // Snapshot fields are server-owned — never sent.
+        assertFalse(rt.has("display_name"))
+        assertFalse(rt.has("text"))
+        assertEquals(2, rt.length())
+    }
+
+    @Test
+    fun `msg1v1 emits reply_to and escapes the quoted id`() {
+        val json = ChatFrameEncoder.msg1v1(
+            toUid = 99,
+            clientMsgId = "cmid-reply-0004",
+            text = "ok",
+            replyTo = ChatReplyRef(uid = 5, clientMsgId = "a\"b-0123456"),
+        )
+        val o = JSONObject(json)
+        assertEquals(99L, o.getLong("to_uid"))
+        assertEquals("a\"b-0123456", o.getJSONObject("reply_to").getString("client_msg_id"))
+    }
+
+    @Test
+    fun `no replyTo means no reply_to key on the wire`() {
+        val o = JSONObject(ChatFrameEncoder.msgGlobal("cmid-plain-0004", "hi"))
+        assertFalse(o.has("reply_to"))
+    }
+}

--- a/docs/ws-chat-integration.md
+++ b/docs/ws-chat-integration.md
@@ -200,6 +200,12 @@ private fun deriveWsBase(httpBase: String): String =
 | `client_msg_id` | ✓ | `/^[A-Za-z0-9_-]{8,64}$/`,客户端生成的 UUID / ULID / nanoid |
 | `text` | ✓ | 1–2048 UTF-16 单元(emoji 算 2 单元),尾部 `\r\n` 服务端 strip |
 | `illust_id` | optional | 正整数 < 10^15,关联一个 pixiv 作品 |
+| `reply_to` | optional | `{"uid": <long>, "client_msg_id": "<id>"}` — 回复(引用)**本房间**里的另一条消息。`uid` 校验同 `to_uid`(严格数字 / canonical 十进制串),`client_msg_id` 同上方规则。服务端按 `(uid, client_msg_id)` 找到原消息并钉死 `room` 一致:找不到 / 跨房 → `err.reply_target_not_found`;形态错 → `err.bad_reply_to`。客户端只对 **Delivered 且有 client_msg_id** 的行提供「回复」 |
+
+回复示例:
+```json
+{"kind":"msg","room":"global","client_msg_id":"<UUID>","text":"同意","reply_to":{"uid":12345,"client_msg_id":"<原消息 UUID>"}}
+```
 
 整帧 ≤ **4096 UTF-16 单元**(ASCII ≈ 4 KB / 中文 ≈ 12 KB UTF-8)。超就 `err.frame_too_large`。
 
@@ -234,11 +240,18 @@ private fun deriveWsBase(httpBase: String): String =
   "client_msg_id": "<UUID>",    // ★ 客户端去重必读字段
   "text": "你好",
   "illust_id": 12345,           // optional
-  "ts": 1778740123502
+  "ts": 1778740123502,
+  "reply_to": {                 // optional — 这条是回复时才有
+    "uid": 12345,               //   被引用消息的作者 uid
+    "client_msg_id": "<UUID>",  //   被引用消息的 client_msg_id(= 客户端本地 localKey,可直接跳转)
+    "display_name": "lisa",     //   作者**当前**展示名(实时查,改名即生效)
+    "text": "原消息…"            //   原文前 200 UTF-16 单元;null = 原消息已过保留期被清理
+  }
 }
 ```
 
 **关键**:
+- **`reply_to` 是服务端下发的快照**:接收端不需要本地有那条原消息就能渲染引用块(新装 / 没翻到那么远的历史都一样)。`text:null` 渲染成「原消息已不可用」。点击引用块 → 按 `client_msg_id` 在本地列表里找原消息跳转,找不到就提示不在已加载记录里
 - **没有 server-issued `id`** —— DB autoincrement id 异步分配,广播时还没有。客户端用 `client_msg_id` 做对账锚点;真要拿 `id` 走 `/history`
 - **自己发的消息也走这条回来** —— UI 应当以这条为渲染源("回声 = 隐式 ACK"),不要双渲染 optimistic + 回声
 - **`room` 字段必看**:单 WS 多会话场景下,客户端按 `room` 分桶到对应聊天窗口
@@ -273,6 +286,8 @@ private fun deriveWsBase(httpBase: String): String =
 | `self_chat_not_allowed` | to_uid === self_uid | 不让用户给自己发(MVP 限制) |
 | `rate_limited` | 每连接 5 条/5s 令牌桶溢出 | 1s 内 disable 发送按钮 |
 | `global_send_disabled` | 管理员后台关闭了公共聊天室发言(只拦 `room:"global"`,1v1 不受影响) | toast `message` 字段文案;读历史仍可用,只是发不出去 |
+| `bad_reply_to` | `reply_to` 不是对象 / `uid` 或 `client_msg_id` 形态不合法 | 客户端 bug,记日志 |
+| `reply_target_not_found` | `reply_to` 指向的消息不存在,或不在目标房间(跨房引用一律按不存在处理,不泄露别房是否有这条) | 带 `message`(「原消息已不存在,无法回复」);标该行 Failed + toast。通常是回复了一条已过 30 天保留期的本地缓存消息 |
 
 #### `pong` — 响应客户端应用层 `ping`
 
@@ -494,13 +509,20 @@ Response:
       "display_name": "lisa",
       "text": "...",
       "illust_id": 123,                 // optional
-      "ts": 1778740123456
+      "ts": 1778740123456,
+      "reply_to": {                     // optional — 仅回复消息带;形态同 WS msg 帧
+        "uid": 12345,
+        "client_msg_id": "<UUID>",
+        "display_name": "lisa",         // 作者当前展示名
+        "text": "原消息…"                // ≤200 单元;null = 原消息已被清理
+      }
     }
   ]
 }
 ```
 
 - `items` 按 **ts 升序**(旧→新)
+- `reply_to` 由服务端读时自连接 `(uid, client_msg_id)` 填充(不是写入时的快照),所以被引用作者改名立即生效;原消息被保留期清理后 `text` 变 `null`,`display_name` 仍按 uid 派生。没引用的消息**省略**这个 key(不发 `null`)
 - 下一页 cursor:`before = items[0].id`
 - 空 = 到顶
 - `limit` 默认 50,上限 200
@@ -717,6 +739,7 @@ Android 模拟器走 `http://10.0.2.2:8080/`。
 - [ ] 单 WS / app 整个生命周期,**不要**进 1v1 才建连 / 退出 1v1 才断 —— sub/unsub 模型已被废弃
 - [ ] 客户端发送 `to_uid` 时**严格用 `Long`**(JSON 数字)或 `Long.toString()`(canonical decimal),**不要**让序列化器把 boxed Long 序成对象、把字符串带空格,会被 server `bad_to_uid` 拒
 - [ ] 收到 `onClose(1008, "replaced")` 时**不要走重连退避表** —— UI 显式提示"账号在其它设备登录",由用户决定是否切换回来
+- [ ] 回复:只对 `state=Delivered && clientMsgId != null` 的行提供「回复」;发送帧带 `reply_to:{uid,client_msg_id}`;optimistic 行用本地原消息内容先画引用块,回声到了再被服务端快照覆盖;`reply_target_not_found` 按普通 err 标 Failed
 
 ---
 


### PR DESCRIPTION
## 做了什么
聊天室「回复某条消息」端到端:长按 → 回复 → 输入区出现引用条 → 发出的气泡内带引用块;收到别人回复同样渲染;点击引用块跳回原消息并闪烁高亮。

协议对齐 shaft-api-v2 `db24f78`(已部署上线):`msg` 帧 / `/history` 行新增 `reply_to {uid, client_msg_id, display_name, text}`,引用键 = 被引用行的 `(uid, client_msg_id)`(即本地 `localKey`),服务端下发快照,本地没原消息也能渲染;新 err `bad_reply_to` / `reply_target_not_found`。

## 改动
- **数据**:`ChatMessageEntity` 加 4 列,Room v2→v3 真迁移保留缓存;Frame/Encoder/Decoder、History DTO、Stream、Gateway 全链路
- **VM**:`replyTarget` StateFlow(转屏不丢)、`canReplyTo()`(仅 Delivered 且有 cmid)、发出即清空
- **UI(V3 + MD3-E)**:引用条(品牌色 tonal 容器 + 强调条 + 「回复 xxx」+ 摘要 + 关闭)、气泡内 12dp 引用块(发出侧白半透明 / 收到侧被引用者身份色 tonal)、跳转 + 整行闪烁
- 7 locale 字符串、`docs/ws-chat-integration.md`、`ChatFrameReplyToTest`

## 验证
- `:app:compileGithubDebugKotlin` ✅,`ChatFrameReplyToTest` 7/7 ✅
- Pixel 8 真机 + 本地后端联调:回复条、发出/收到引用块、点击跳转闪烁、宽度修正均截图确认
- 与旧后端兼容:服务端忽略 `reply_to` 时回声覆盖乐观引用块,不崩

🤖 Generated with [Claude Code](https://claude.com/claude-code)