### PR TITLE
fix(feed): 清洗自建源/借号收藏与关注态并按池态恢复爱心

### DIFF
--- a/app/src/main/java/ceui/lisa/fragments/FragmentIllust.kt
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentIllust.kt
@@ -23,7 +23,6 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.viewModels
-import androidx.lifecycle.lifecycleScope
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import ceui.lisa.R
@@ -78,7 +77,6 @@ import com.zhy.view.flowlayout.FlowLayout
 import com.zhy.view.flowlayout.TagAdapter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 class FragmentIllust : BaseLazyFragment<FragmentIllustBinding>() {
@@ -129,6 +127,9 @@ class FragmentIllust : BaseLazyFragment<FragmentIllustBinding>() {
             updateUser(user)
             Common.showLog("updateUser invoke ${user.isIs_followed}")
         }
+        vm.followState.observe(viewLifecycleOwner) { currentUserBean()?.let { updateUser(it) } }
+        vm.followStateLoading.observe(viewLifecycleOwner) { currentUserBean()?.let { updateUser(it) } }
+        vm.followStateRefresh.observe(viewLifecycleOwner) { currentUserBean()?.let { updateUser(it) } }
         // 「怎么关的」不在 UserBean 里，变化时上面那条不会响 —— 同 V3 详情页，见 FollowVisibility.changes。
         FollowVisibility.changes.observe(viewLifecycleOwner) { changed ->
             if (changed == userId.toLong()) userLiveData.value?.let { updateUser(it) }
@@ -202,23 +203,46 @@ class FragmentIllust : BaseLazyFragment<FragmentIllustBinding>() {
         }
     }
 
+    private fun currentUserBean(): UserBean? {
+        val bean = ObjectPool.get<IllustsBean>(safeArgs.illustId.toLong()).value ?: return null
+        val user = bean.user ?: return null
+        return ObjectPool.get<UserBean>(user.id.toLong()).value ?: user
+    }
+
     private fun updateUser(user: UserBean) {
-        if (user.isIs_followed) {
-            baseBind.follow.isVisible = false
-            baseBind.unfollow.isVisible = true
-            baseBind.unfollow.text = getString(followedLabelRes(user.id))
-            baseBind.unfollow.setOnClick {
-                unfollowUser(it, user.id)
-            }
-        } else {
+        if (vm.followState.value?.loading == true) {
             baseBind.unfollow.isVisible = false
             baseBind.follow.isVisible = true
-            baseBind.follow.setOnClick {
-                followUser(it, user.id, PixivActions.defaultFollowRestrict())
-            }
-            baseBind.follow.setOnLongClickListener {
-                followUser((it as ProgressTextButton), user.id, Params.TYPE_PRIVATE)
-                true
+            // 真正的查询中：用 ProgressTextButton 自带的转圈进度态，同时禁用点击。
+            baseBind.follow.hideProgress()
+            baseBind.follow.showProgress()
+            baseBind.follow.isEnabled = false
+            baseBind.follow.setOnClickListener(null)
+            baseBind.follow.setOnLongClickListener(null)
+            baseBind.follow.isLongClickable = false
+        } else {
+            baseBind.follow.hideProgress()
+            baseBind.follow.isEnabled = true
+            baseBind.unfollow.isEnabled = true
+            val followed = user.isIs_followed
+            if (followed) {
+                baseBind.follow.isVisible = false
+                baseBind.unfollow.isVisible = true
+                baseBind.unfollow.text = getString(followedLabelRes(user.id))
+                baseBind.unfollow.setOnClick {
+                    unfollowUser(it, user.id)
+                }
+            } else {
+                baseBind.unfollow.isVisible = false
+                baseBind.follow.isVisible = true
+                baseBind.follow.text = getString(R.string.follow)
+                baseBind.follow.setOnClick {
+                    followUser(it, user.id, PixivActions.defaultFollowRestrict())
+                }
+                baseBind.follow.setOnLongClickListener {
+                    followUser((it as ProgressTextButton), user.id, Params.TYPE_PRIVATE)
+                    true
+                }
             }
         }
         baseBind.relaIllustBrief.setOnClick {
@@ -682,6 +706,7 @@ class FragmentIllust : BaseLazyFragment<FragmentIllustBinding>() {
 
     override fun onResume() {
         super.onResume()
+        vm.onPageVisible()
         checkDownload()
     }
 

--- a/app/src/main/java/ceui/lisa/fragments/FragmentIllustViewModel.kt
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentIllustViewModel.kt
@@ -17,6 +17,7 @@ import ceui.loxia.fetchFullIllustDetail
 import ceui.loxia.fetchIllustPageDimensions
 import ceui.loxia.hasTrustedCaption
 import ceui.loxia.isFullDetail
+import ceui.pixiv.ui.common.FollowStateBackfill
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -25,41 +26,47 @@ import timber.log.Timber
 /**
  * VM for the "new" illust detail page (FragmentIllust).
  *
- * Exists primarily to move the download-state probe (SAF existence + Room query)
- * off the main thread — on Android 11+ SAF queries per page add up fast, and for
- * multi-P works this was ANR'ing the detail screen on entry (issue #835).
+ * 关注态回补只在页面划入（onResume）后开始：
+ * - 非预载页：进入时立即开始；
+ * - 预载页：滑到该页后才开始，避免提前请求/提前进入“查询中”。
  */
 class FragmentIllustViewModel(private val illustId: Long) : ViewModel() {
 
     private val _hasDownload = MutableLiveData<Boolean>()
     val hasDownload: LiveData<Boolean> = _hasDownload
 
-    // ── 每页真实宽高(网页 ajax /ajax/illust/{id}/pages)──
-    // 与 ArtworkV3ViewModel 同一套:多 P 时提前拿到每页宽高,让顶部大图下载前就按真 ratio 摆准高度。
-    // Fragment 观察 [pageDimensions] 喂给 IllustAdapter.seedPageDimensions;缺 cookie/失败静默降级。
+    // ── 每页真实宽高 ──
     private val _pageDimensions = MutableLiveData<List<IntArray>>()
-
-    /** 每一 P 的 [width, height],按页序;拉不到则不发射(沿用解码后异步定高,不影响使用)。 */
     val pageDimensions: LiveData<List<IntArray>> = _pageDimensions
 
     private var pageDimsRequested = false
 
+    /** 关注态 UI 的主动状态：只承载“回补进行中”，关注值一律以 ObjectPool 的 UserBean 为准。 */
+    data class FollowUiState(val loading: Boolean)
+
+    private val _followState = MutableLiveData(FollowUiState(false))
+    val followState: LiveData<FollowUiState> = _followState
+
+    private val _followStateLoading = MutableLiveData(false)
+    val followStateLoading: LiveData<Boolean> = _followStateLoading
+
+    /** 回补完成后的主动刷新 tick：Fragment 观察到后立即用最新池数据重刷作者栏。 */
+    private val _followStateRefresh = MutableLiveData(0)
+    val followStateRefresh: LiveData<Int> = _followStateRefresh
+
+    private var followBackfillRequested = false
+    private var fullDetailFetchInFlight = false
+    private var pageVisible = false
+
     private val illustBeanLiveData = ObjectPool.get<IllustsBean>(illustId)
-    private val illustBeanObserver = Observer<IllustsBean> { bean -> ensurePageDimensions(bean) }
+    private val illustBeanObserver = Observer<IllustsBean> { bean ->
+        ensurePageDimensions(bean)
+        // 划入后如果池 bean 才到达/更新，也要能触发回补；未划入时不做任何预载回补。
+        if (pageVisible) startBackfills()
+    }
 
     init {
-        // issue #569: 从「按 Tag 筛选」等精简来源进来时,池里的 bean 缺分页图/原图。后台回 API 拉完整版,
-        // 整体覆盖 ObjectPool 后,FragmentIllust 的 illust observer 会带完整数据再次 fire、自动重建图片区。
-        // 拉取失败则保留现有(精简)数据 —— GlideUtil / IllustDownload 已加空值兜底,不会崩,降级显示封面。
-        viewModelScope.launch {
-            val cur = ObjectPool.get<IllustsBean>(illustId).value
-            // hasTrustedCaption:列表接口会不定期掐掉部分作品的 caption(#960),caption 为空
-            // 且没被 detail 确认过时也回源补拉,落池后 illust observer 自动重渲染简介。
-            if (cur == null || !cur.isFullDetail() || !cur.hasTrustedCaption()) {
-                fetchFullIllustDetail(illustId)
-            }
-        }
-        // 完整 bean 落地(page_count 可信)时触发一次每页宽高拉取。
+        // 回补不在 VM 创建时触发，统一由 Fragment.onResume（划入页面）调用 onPageVisible 后开始。
         illustBeanLiveData.observeForever(illustBeanObserver)
     }
 
@@ -67,13 +74,120 @@ class FragmentIllustViewModel(private val illustId: Long) : ViewModel() {
         illustBeanLiveData.removeObserver(illustBeanObserver)
     }
 
-    /** 多 P 首次拿到 bean 时拉一次每页真实宽高(单 P 无需、只拉一次)。缺 cookie/失败静默降级。 */
+    /** 多 P 首次拿到 bean 时拉一次每页真实宽高。 */
     private fun ensurePageDimensions(bean: IllustsBean) {
         if (pageDimsRequested || bean.page_count < 2) return
         pageDimsRequested = true
         viewModelScope.launch {
             fetchIllustPageDimensions(illustId)?.let { _pageDimensions.value = it }
         }
+    }
+
+    /** 把“回补进行中”状态主动推给 Fragment；关注值由池里的 UserBean 决定，VM 不缓存。 */
+    private fun publishFollowState(loading: Boolean) {
+        _followState.value = FollowUiState(loading)
+        _followStateLoading.value = loading
+    }
+
+    private fun ensureTrustedFollow(bean: IllustsBean) {
+        val illustId = bean.id.toLong()
+        if (FollowStateBackfill.isIllustUntrusted(illustId)) {
+            if (!followBackfillRequested && !FollowStateBackfill.isIllustTrusted(illustId)) {
+                publishFollowState(true)
+            }
+        } else {
+            FollowStateBackfill.markIllustTrusted(illustId)
+            if (_followStateLoading.value == true) {
+                publishFollowState(false)
+            }
+            Timber.tag("FollowState").d("信任池: 非自建源入口 illust=%d", illustId)
+        }
+    }
+
+    private fun startFollowBackfill(bean: IllustsBean) {
+        val illustId = bean.id.toLong()
+        if (followBackfillRequested) {
+            if (_followStateLoading.value == true && !FollowStateBackfill.isIllustUntrusted(illustId)) {
+                publishFollowState(false)
+            }
+            return
+        }
+        if (!FollowStateBackfill.isIllustUntrusted(illustId)) {
+            if (_followStateLoading.value == true) {
+                publishFollowState(false)
+            }
+            return
+        }
+        followBackfillRequested = true
+
+        if (FollowStateBackfill.isIllustTrusted(illustId) || ObjectPool.hasFullIllustVersion(illustId)) {
+            Timber.tag("FollowState").d("信任池: illust=%d 直接使用池并标记已确认", illustId)
+            FollowStateBackfill.markIllustConfirmed(illustId)
+            publishFollowState(false)
+            _followStateRefresh.value = (_followStateRefresh.value ?: 0) + 1
+            return
+        }
+
+        publishFollowState(true)
+        ensureFullDetailBackfill()
+    }
+
+    /**
+     * 统一的全量 detail 回补入口：caption/完整度补拉与关注态回补共用同一个在途闸门，
+     * 避免进入详情页时并发多个 v1/illust/detail 请求。
+     */
+    private fun ensureFullDetailBackfill() {
+        if (fullDetailFetchInFlight) return
+        fullDetailFetchInFlight = true
+        viewModelScope.launch {
+            try {
+                val fresh = fetchFullIllustDetail(illustId)
+                if (FollowStateBackfill.isIllustUntrusted(illustId)) {
+                    if (fresh != null) {
+                        FollowStateBackfill.markIllustConfirmed(illustId)
+                        publishFollowState(false)
+                        Timber.tag("FollowState").d("关注态回补成功: illust=%d", illustId)
+                    } else {
+                        publishFollowState(false)
+                        Timber.tag("FollowState").w("关注态回补失败: illust=%d", illustId)
+                    }
+                    _followStateRefresh.value = (_followStateRefresh.value ?: 0) + 1
+                } else if (_followStateLoading.value == true) {
+                    publishFollowState(false)
+                    _followStateRefresh.value = (_followStateRefresh.value ?: 0) + 1
+                }
+            } finally {
+                fullDetailFetchInFlight = false
+            }
+        }
+    }
+
+    private fun startBackfills() {
+        val bean = ObjectPool.get<IllustsBean>(illustId).value ?: return
+        val illustId = bean.id.toLong()
+
+        // caption/完整度需要回源时也在这里触发（与关注态共用同一在途闸门）。
+        if (!bean.isFullDetail() || !bean.hasTrustedCaption()) {
+            ensureFullDetailBackfill()
+        }
+
+        if (FollowStateBackfill.isIllustUntrusted(illustId)) {
+            if (!followBackfillRequested) {
+                ensureTrustedFollow(bean)
+                startFollowBackfill(bean)
+            } else if (_followStateLoading.value == true && !FollowStateBackfill.isIllustUntrusted(illustId)) {
+                publishFollowState(false)
+            }
+        } else {
+            FollowStateBackfill.markIllustTrusted(illustId)
+            publishFollowState(false)
+        }
+    }
+
+    /** 页面划入（onResume）时调用：非预载页立即开始，预载页滑到后才开始。 */
+    fun onPageVisible() {
+        pageVisible = true
+        startBackfills()
     }
 
     /** Kick off an async download-state refresh. Result lands on [hasDownload]. */
@@ -84,8 +198,6 @@ class FragmentIllustViewModel(private val illustId: Long) : ViewModel() {
                 val illust = ObjectPool.get<IllustsBean>(illustId).value
                     ?: return@launch
                 val hasLocalFile = Common.isIllustDownloaded(illust)
-                // hasDownloadRecord 走 v38 的 illustId 索引（O(log n)），不再扫 2GB illustGson blob；
-                // 存量回填未完成时才退回旧 LIKE 兜底。仍串行到单车道 dispatcher 兜底旧库/回填窗口期。
                 val hasRecord = if (hasLocalFile) false else withContext(downloadProbeDispatcher) {
                     AppDatabase
                         .getAppDatabase(appContext)

--- a/app/src/main/java/ceui/lisa/repo/SearchIllustRepo.kt
+++ b/app/src/main/java/ceui/lisa/repo/SearchIllustRepo.kt
@@ -61,6 +61,14 @@ class SearchIllustRepo @JvmOverloads constructor(
     @Volatile
     private var nana7miSession = Nana7miAccountSession()
 
+    /** 当前最近一页实际由哪条路由返回：true=借号官方搜索；false=预览/普通直连/空终止页。 */
+    @Volatile
+    private var lastResultBorrowed = false
+
+    /** 当前这一页是否由借号账号返回；借号结果里的收藏/关注态属于借来的号，不能信。 */
+    val isBorrowedResult: Boolean
+        get() = lastResultBorrowed
+
     @Volatile
     private var nana7miTelemetry: Nana7miSearchTelemetry.Flow? = null
 
@@ -161,6 +169,7 @@ class SearchIllustRepo @JvmOverloads constructor(
                 heightMax,
             )
                 .doOnNext { response ->
+                    lastResultBorrowed = false
                     Timber.tag(NANA7MI_LOG_TAG).d(
                         "stage=popular_preview result=success illust_count=%d has_next=%s",
                         response.illusts?.size ?: 0,
@@ -206,7 +215,7 @@ class SearchIllustRepo @JvmOverloads constructor(
                 widthMax,
                 heightMin,
                 heightMax,
-            )
+            ).doOnNext { lastResultBorrowed = false }
             return telemetry?.track(
                 source = source,
                 page = Nana7miSearchTelemetry.Page.FIRST,
@@ -288,7 +297,7 @@ class SearchIllustRepo @JvmOverloads constructor(
                                 heightMin,
                                 heightMax,
                             )
-                        }
+                        }.doOnNext { lastResultBorrowed = true }
                         (telemetry?.track(
                             source = source,
                             page = Nana7miSearchTelemetry.Page.FIRST,
@@ -324,7 +333,7 @@ class SearchIllustRepo @JvmOverloads constructor(
                 widthMax,
                 heightMin,
                 heightMax,
-            )
+            ).doOnNext { lastResultBorrowed = false }
         }
         return telemetry?.observeFirst(result) ?: result
     }
@@ -352,7 +361,7 @@ class SearchIllustRepo @JvmOverloads constructor(
         return if (session.borrowedAccountLost) {
             endBorrowedPagination("already_lost")
         } else if (payload == null) {
-            val source = Retro.getAppApi().getNextIllust(nextPageUrl)
+            val source = Retro.getAppApi().getNextIllust(nextPageUrl).doOnNext { lastResultBorrowed = false }
             telemetry?.track(
                 source = source,
                 page = Nana7miSearchTelemetry.Page.NEXT,
@@ -373,7 +382,7 @@ class SearchIllustRepo @JvmOverloads constructor(
                     },
                 ) { authorization ->
                     Retro.getAppApi().getNextIllustWithAuth(authorization, nextPageUrl)
-                }
+                }.doOnNext { lastResultBorrowed = true }
                 (telemetry?.track(
                     source = source,
                     page = Nana7miSearchTelemetry.Page.NEXT,

--- a/app/src/main/java/ceui/lisa/repo/SearchNovelRepo.kt
+++ b/app/src/main/java/ceui/lisa/repo/SearchNovelRepo.kt
@@ -54,6 +54,15 @@ class SearchNovelRepo @JvmOverloads constructor(
     private var filterMapper: Mapper<ListNovel>? = null
     @Volatile
     private var nana7miSession = Nana7miAccountSession()
+
+    /** 当前最近一页实际由哪条路由返回：true=借号官方搜索；false=预览/普通直连/空终止页。 */
+    @Volatile
+    private var lastResultBorrowed = false
+
+    /** 当前这一页是否由借号账号返回；借号结果里的收藏/关注态属于借来的号，不能信。 */
+    val isBorrowedResult: Boolean
+        get() = lastResultBorrowed
+
     @Volatile
     private var nana7miTelemetry: Nana7miSearchTelemetry.Flow? = null
 
@@ -173,6 +182,7 @@ class SearchNovelRepo @JvmOverloads constructor(
                 )
             }
                 .doOnNext { response ->
+                    lastResultBorrowed = false
                     Timber.tag(NANA7MI_LOG_TAG).d(
                         "stage=novel_popular_preview result=success novel_count=%d has_next=%s",
                         response.novels?.size ?: 0,
@@ -221,7 +231,7 @@ class SearchNovelRepo @JvmOverloads constructor(
                     readingTimeMin,
                     readingTimeMax,
                 )
-            }
+            }.doOnNext { lastResultBorrowed = false }
             return telemetry?.track(
                 source = source,
                 page = Nana7miSearchTelemetry.Page.FIRST,
@@ -310,7 +320,7 @@ class SearchNovelRepo @JvmOverloads constructor(
                                     readingTimeMax,
                                 )
                             }
-                        }
+                        }.doOnNext { lastResultBorrowed = true }
                         (telemetry?.track(
                             source = source,
                             page = Nana7miSearchTelemetry.Page.FIRST,
@@ -350,7 +360,7 @@ class SearchNovelRepo @JvmOverloads constructor(
                     readingTimeMin,
                     readingTimeMax,
                 )
-            }
+            }.doOnNext { lastResultBorrowed = false }
         }
         return telemetry?.observeFirst(result) ?: result
     }
@@ -378,7 +388,7 @@ class SearchNovelRepo @JvmOverloads constructor(
         return if (session.borrowedAccountLost) {
             endBorrowedPagination("already_lost")
         } else if (borrowed == null) {
-            val source = Retro.getAppApi().getNextNovel(nextPageUrl)
+            val source = Retro.getAppApi().getNextNovel(nextPageUrl).doOnNext { lastResultBorrowed = false }
             telemetry?.track(
                 source = source,
                 page = Nana7miSearchTelemetry.Page.NEXT,
@@ -399,7 +409,7 @@ class SearchNovelRepo @JvmOverloads constructor(
                     },
                 ) { authorization ->
                     Retro.getAppApi().getNextNovelWithAuth(authorization, nextPageUrl)
-                }
+                }.doOnNext { lastResultBorrowed = true }
                 (telemetry?.track(
                     source = source,
                     page = Nana7miSearchTelemetry.Page.NEXT,

--- a/app/src/main/java/ceui/lisa/utils/Params.java
+++ b/app/src/main/java/ceui/lisa/utils/Params.java
@@ -62,6 +62,7 @@ public class Params {
     public static final String FILTER_ILLUST        = "ceui.lisa.fragments.NetListFragment FILTER_ILLUST";
     public static final String FILTER_NOVEL        = "ceui.lisa.fragments.NetListFragment FILTER_NOVEL";
     public static final String LIKED_ILLUST        = "ceui.lisa.fragments.NetListFragment LIKED_ILLUST";
+    public static final String ILLUST_POOL_REFRESHED = "ceui.lisa.ILLUST_POOL_REFRESHED";
     public static final String LIKED_USER          = "ceui.lisa.fragments.NetListFragment LIKED_USER";
     public static final String LIKED_NOVEL         = "ceui.lisa.fragments.NetListFragment LIKED_NOVEL";
     public static final String DOWNLOAD_FINISH         = "ceui.lisa.fragments.NetListFragment DOWNLOAD_FINISH";

--- a/app/src/main/java/ceui/loxia/IllustDetailSupport.kt
+++ b/app/src/main/java/ceui/loxia/IllustDetailSupport.kt
@@ -1,5 +1,8 @@
 package ceui.loxia
 
+import android.content.Intent
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import ceui.lisa.activities.Shaft
 import ceui.lisa.http.Retro
 import ceui.lisa.interfaces.Callback
 import ceui.lisa.models.IllustsBean
@@ -8,6 +11,7 @@ import ceui.lisa.models.MetaPagesBean
 import ceui.lisa.models.MetaSinglePageBean
 import ceui.lisa.models.TagsBean
 import ceui.lisa.models.UserBean
+import ceui.lisa.utils.Params
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
@@ -66,6 +70,12 @@ suspend fun fetchFullIllustDetail(illustId: Long): IllustsBean? {
     }
     ObjectPool.update(usable, isFullVersion = true)
     usable.user?.let { ObjectPool.update(it) }
+    // 池里已有明确收藏态：通知插画列表把 bookmarkStateUnknown 的条目恢复为正常展示。
+    Shaft.getContext()?.let { ctx ->
+        LocalBroadcastManager.getInstance(ctx).sendBroadcast(
+            Intent(Params.ILLUST_POOL_REFRESHED).putExtra(Params.ID, illustId.toInt())
+        )
+    }
     return usable
 }
 

--- a/app/src/main/java/ceui/pixiv/ui/common/FollowStateBackfill.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/FollowStateBackfill.kt
@@ -1,0 +1,47 @@
+package ceui.pixiv.ui.common
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * 自建源上报 bean 清洗后，作者关注态处于「不可信 / 待确认」状态的轻量登记。
+ *
+ * 它不是可信关注态缓存：只记录「这个作者需要回源确认一次」的 id，
+ * 确认成功后立即移除，不长期保存任何关注状态。
+ */
+object FollowStateBackfill {
+
+    /** 自建源上报、尚未确认的 illust ID：进入详情页时默认不可信。 */
+    private val untrustedIllustIds = ConcurrentHashMap.newKeySet<Long>()
+
+    /** 从非自建源进入过详情页、且当前池数据仍可信的 illust ID。自建源重新上报会使它失效。 */
+    private val trustedIllustIds = ConcurrentHashMap.newKeySet<Long>()
+
+    /** 自建源把上报者的收藏/关注态清掉后调用，登记该作品需要回源确认。 */
+    fun markIllustUntrusted(illustId: Long) {
+        if (illustId > 0L) {
+            untrustedIllustIds.add(illustId)
+            // 自建源一旦重新上报，池里的关注态可能已被这份“不可信快照”覆盖，
+            // 之前从非自建源进入攒下的 trusted 标记必须作废，否则会跳过回补。
+            trustedIllustIds.remove(illustId)
+        }
+    }
+
+    /** 该作品当前是否处于「自建源上报、等待详情页确认」状态。 */
+    fun isIllustUntrusted(illustId: Long): Boolean = untrustedIllustIds.contains(illustId)
+
+    /** 非自建源进入同 ID 详情页时，把该 illust 标记为可信池成员。 */
+    fun markIllustTrusted(illustId: Long) {
+        if (illustId > 0L && !untrustedIllustIds.contains(illustId)) trustedIllustIds.add(illustId)
+    }
+
+    /** 确认完成（信任池命中或 detail 回补成功）后：移除不可信标记，并加入可信池。 */
+    fun markIllustConfirmed(illustId: Long) {
+        if (illustId > 0L) {
+            untrustedIllustIds.remove(illustId)
+            trustedIllustIds.add(illustId)
+        }
+    }
+
+    /** 自建源进入详情页时，先用它判断能否直接信任池里的同 ID bean。 */
+    fun isIllustTrusted(illustId: Long): Boolean = trustedIllustIds.contains(illustId)
+}

--- a/app/src/main/java/ceui/pixiv/ui/common/IllustFeedItem.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/IllustFeedItem.kt
@@ -15,7 +15,8 @@ val PAYLOAD_ILLUST_LIKE_CHANGED = Any()
  * 各插画卡 Renderer 的 changePayload 直接引用本函数。
  */
 fun illustLikeChangePayload(old: IllustFeedItem, new: IllustFeedItem): Any? {
-    return if (old.bean.trendingScore == new.bean.trendingScore &&
+    return if (old.bookmarkStateUnknown == new.bookmarkStateUnknown &&
+        old.bean.trendingScore == new.bean.trendingScore &&
         old.illust.copy(is_bookmarked = new.illust.is_bookmarked) == new.illust
     ) {
         PAYLOAD_ILLUST_LIKE_CHANGED
@@ -43,16 +44,20 @@ fun illustLikeChangePayload(old: IllustFeedItem, new: IllustFeedItem): Any? {
 class IllustFeedItem(
     val illust: Illust,
     val bean: IllustsBean,
+    /** 借号/自建等来源的收藏态被清洗成 false，且未回补：卡片不应展示/响应收藏爱心。 */
+    val bookmarkStateUnknown: Boolean = false,
 ) : FeedItem {
 
     override val feedKey: Any get() = illust.id
 
     override fun equals(other: Any?): Boolean {
         return other is IllustFeedItem && other.illust == illust &&
-                other.bean.trendingScore == bean.trendingScore
+                other.bean.trendingScore == bean.trendingScore &&
+                other.bookmarkStateUnknown == bookmarkStateUnknown
     }
 
-    override fun hashCode(): Int = illust.hashCode() * 31 + (bean.trendingScore?.hashCode() ?: 0)
+    override fun hashCode(): Int = illust.hashCode() * 31 + (bean.trendingScore?.hashCode() ?: 0) * 31 +
+            bookmarkStateUnknown.hashCode()
 
     /**
      * 收藏状态变更：把这次变更同步到本作品的**每一个共享表示**——
@@ -81,7 +86,21 @@ class IllustFeedItem(
         bean.setIs_bookmarked(liked)
         // 只同步作品本身：关注态没变，不必连 user 一起 merge
         ObjectPool.update(bean)
-        return IllustFeedItem(illust.copy(is_bookmarked = liked), bean)
+        // 用户对收藏态做了明确操作后，这条的收藏态就是已知的，不再按 unknown 隐藏。
+        return IllustFeedItem(illust.copy(is_bookmarked = liked), bean, bookmarkStateUnknown = false)
+    }
+
+    /**
+     * 池里已有明确（full detail 回源）收藏态时，把条目从“unknown 隐藏”恢复为正常展示。
+     * 只处理 [bookmarkStateUnknown] 的条目；普通条目原样返回。
+     */
+    fun withPoolBookmarkState(): IllustFeedItem {
+        if (!bookmarkStateUnknown) return this
+        val pooled = ObjectPool.get<IllustsBean>(illust.id).value ?: return this
+        if (!ObjectPool.hasFullIllustVersion(illust.id)) return this
+        val known = pooled.isIs_bookmarked
+        bean.setIs_bookmarked(known)
+        return IllustFeedItem(illust.copy(is_bookmarked = known), bean, bookmarkStateUnknown = false)
     }
 
     companion object {
@@ -120,12 +139,13 @@ class IllustFeedItem(
             skipR18Filter: Boolean = false,
             skipAiFilter: Boolean = false,
             skipMuteUserFilter: Boolean = false,
+            bookmarkStateUnknown: Boolean = false,
         ): IllustFeedItem? {
             if (bean == null || !passesContentFilters(bean, skipR18Filter, skipAiFilter, skipMuteUserFilter)) return null
             val illust = runCatching {
                 Shaft.sGson.fromJson(Shaft.sGson.toJsonTree(bean), Illust::class.java)
             }.getOrNull() ?: return null
-            return IllustFeedItem(illust, bean)
+            return IllustFeedItem(illust, bean, bookmarkStateUnknown)
         }
 
         /**
@@ -134,12 +154,12 @@ class IllustFeedItem(
          * 那里的搜索专属过滤（R18 三态 / 仅看 AI）feeds 侧不复刻，绝不能再走 [of]/[fromBean] 的
          * passesContentFilters（它在「仅看 AI」时会把 AI 作品误删，也会重复跑一遍过滤）。
          */
-        fun rawFromBean(bean: IllustsBean?): IllustFeedItem? {
+        fun rawFromBean(bean: IllustsBean?, bookmarkStateUnknown: Boolean = false): IllustFeedItem? {
             if (bean == null) return null
             val illust = runCatching {
                 Shaft.sGson.fromJson(Shaft.sGson.toJsonTree(bean), Illust::class.java)
             }.getOrNull() ?: return null
-            return IllustFeedItem(illust, bean)
+            return IllustFeedItem(illust, bean, bookmarkStateUnknown)
         }
 
         /**

--- a/app/src/main/java/ceui/pixiv/ui/common/IllustFeedSync.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/IllustFeedSync.kt
@@ -80,11 +80,26 @@ class IllustFeedDetailSync(
                 )
             }
         }
+        // 池里 full detail 落地后，把 bookmarkStateUnknown 的条目恢复为正常展示。
+        val poolRefreshReceiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                val id = intent?.getIntExtra(Params.ID, 0)?.toLong() ?: return
+                if (id <= 0L) return
+                feedViewModel.updateItems(IllustFeedItem::class.java) { item ->
+                    if (item.illust.id == id && item.bookmarkStateUnknown) {
+                        item.withPoolBookmarkState()
+                    } else {
+                        item
+                    }
+                }
+            }
+        }
 
         broadcastManager.registerReceiver(addDataReceiver, IntentFilter(Params.FRAGMENT_ADD_DATA))
         broadcastManager.registerReceiver(
             scrollReceiver, IntentFilter(Params.FRAGMENT_SCROLL_TO_POSITION)
         )
+        broadcastManager.registerReceiver(poolRefreshReceiver, IntentFilter(Params.ILLUST_POOL_REFRESHED))
 
         // 用 lifecycleScope 而不是 repeatOnLifecycle：广播到达时本页通常在详情页背后
         // （STOPPED），追加要照做，返回列表时数据已就位
@@ -117,6 +132,7 @@ class IllustFeedDetailSync(
             override fun onDestroy(owner: LifecycleOwner) {
                 broadcastManager.unregisterReceiver(addDataReceiver)
                 broadcastManager.unregisterReceiver(scrollReceiver)
+                broadcastManager.unregisterReceiver(poolRefreshReceiver)
                 addDataQueue.close()
             }
         })

--- a/app/src/main/java/ceui/pixiv/ui/common/IllustStaggerRenderer.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/IllustStaggerRenderer.kt
@@ -16,6 +16,7 @@ import ceui.lisa.databinding.RecyIllustStaggerBinding
 import ceui.lisa.models.IllustsBean
 import ceui.lisa.utils.GlideUtil
 import ceui.lisa.utils.Params
+import ceui.loxia.ObjectPool
 import ceui.pixiv.feeds.FeedRenderer
 import ceui.pixiv.feeds.feedRenderer
 import ceui.pixiv.ui.recommend.bindTrendingScore
@@ -100,6 +101,7 @@ internal fun IllustFeedFragment.staggerIllustRenderer():
                 // 两下时第二下仍看到上一下之前的旧态，把「取消收藏」反转成「再收藏一次」——心不回白、
                 // 烟花重放、两条 toast、两次 addBookmark，取消这个操作直接丢失。
                 val tapped = cell.itemOrNull ?: return@setOnClick
+                if (tapped.isBookmarkStateUnknown()) return@setOnClick
                 val current = currentIllustItem(tapped.illust.id) ?: return@setOnClick
                 val willBookmark = current.illust.is_bookmarked != true
                 toggleLike(current)
@@ -124,6 +126,7 @@ internal fun IllustFeedFragment.staggerIllustRenderer():
             cell.binding.likeAnim.setFailureListener { }
             // 爱心长按 → 按标签收藏（对齐 IAdapter）
             cell.binding.likeButton.setOnLongClickListener {
+                if (cell.item.isBookmarkStateUnknown()) return@setOnLongClickListener false
                 val bean = cell.item.bean
                 SelectTagBottomSheet.show(
                     this@staggerIllustRenderer, bean.id, Params.TYPE_ILLUST, bean.tagNames,
@@ -159,7 +162,7 @@ internal fun IllustFeedFragment.staggerIllustRenderer():
             }
             if (known) {
                 if (payloads.any { it === PAYLOAD_ILLUST_LIKE_CHANGED }) {
-                    renderLikeState(cell.binding.likeButton, cell.item.illust.is_bookmarked == true)
+                    renderLikeState(cell.binding.likeButton, cell.item.resolvedBookmarked())
                 }
                 if (payloads.any { it === PAYLOAD_ILLUST_SPOILER_CHANGED }) {
                     val bean = cell.item.bean
@@ -175,7 +178,7 @@ internal fun IllustFeedFragment.staggerIllustRenderer():
                         animate = true,
                     )
                     // 叠在图上的操作层跟着屏蔽态走。和全量绑定共用同一分支，两边永远一致
-                    applyIllustSpoilerMask(cell.binding, spoilered)
+                    applyIllustSpoilerMask(cell.binding, spoilered, cell.item.isBookmarkStateUnknown())
                 }
                 true
             } else {
@@ -213,9 +216,9 @@ internal fun IllustFeedFragment.staggerIllustRenderer():
         cell.binding.trendingScore.bindTrendingScore(bean.trendingScore)
         // 全量绑定可能是复用的卡换了条目：上一条残留的爆发动画/缩放必须清干净
         resetLikeAnim(cell.binding)
-        renderLikeState(cell.binding.likeButton, cell.item.illust.is_bookmarked == true)
+        renderLikeState(cell.binding.likeButton, cell.item.resolvedBookmarked())
         // 放在最后：这一步会按屏蔽态覆盖上面那批角标行 / 爱心的可见性
-        applyIllustSpoilerMask(cell.binding, spoilered)
+        applyIllustSpoilerMask(cell.binding, spoilered, cell.item.isBookmarkStateUnknown())
     }
 
 /**
@@ -236,9 +239,10 @@ internal fun IllustFeedFragment.staggerIllustRenderer():
 private fun IllustFeedFragment.applyIllustSpoilerMask(
     binding: RecyIllustStaggerBinding,
     masked: Boolean,
+    bookmarkStateUnknown: Boolean = false,
 ) {
     binding.badgeRow.isVisible = !masked
-    binding.likeButton.isVisible = !masked && !hideLikeButton
+    binding.likeButton.isVisible = !masked && !hideLikeButton && !bookmarkStateUnknown
     if (masked) {
         resetLikeAnim(binding)
     }
@@ -310,6 +314,18 @@ private fun IllustFeedFragment.loadIllustImage(
         .placeholder(ceui.pixiv.feeds.R.color.feed_skeleton_block)
         .transition(DrawableTransitionOptions.withCrossFade())
         .into(binding.illustImage)
+}
+
+/** 收藏态是否仍处于“不可信/未回补”：池里已有 full detail 的明确收藏态时不再隐藏。 */
+private fun IllustFeedItem.isBookmarkStateUnknown(): Boolean =
+    bookmarkStateUnknown && !ObjectPool.hasFullIllustVersion(illust.id)
+
+/** 收藏态展示值：unknown 但池里已回补时以池为准，否则用条目快照。 */
+private fun IllustFeedItem.resolvedBookmarked(): Boolean {
+    if (bookmarkStateUnknown && ObjectPool.hasFullIllustVersion(illust.id)) {
+        return ObjectPool.get<IllustsBean>(illust.id).value?.isIs_bookmarked == true
+    }
+    return illust.is_bookmarked == true
 }
 
 /** 未收藏 = 白色空心描边爱心，已收藏 = 红色实心爱心（图上永远配深色圆底座）。 */

--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkSectionRenderers.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkSectionRenderers.kt
@@ -142,14 +142,18 @@ class ArtworkArtistItem(
     // 可见性必须进 equals：从画师主页拿到「原来是私密关注」返回时,is_followed 没变,
     // 只有这个字段变了。不带上它 DiffUtil 就判定条目没动,作者栏会一直停在「已关注」。
     val isPrivateFollow: Boolean = resolvePrivateFollow(illust),
+    // 自建源进入详情页后、回补当前用户关注态完成前为 true：作者栏按钮转圈且不可点击。
+    val followStateLoading: Boolean = false,
 ) : FeedItem {
     override val feedKey: Any get() = "artwork_artist"
     override fun equals(other: Any?) =
         other is ArtworkArtistItem && other.illust === illust &&
-            other.isFollowed == isFollowed && other.isPrivateFollow == isPrivateFollow
+            other.isFollowed == isFollowed && other.isPrivateFollow == isPrivateFollow &&
+            other.followStateLoading == followStateLoading
 
     override fun hashCode() =
-        (System.identityHashCode(illust) * 31 + isFollowed.hashCode()) * 31 + isPrivateFollow.hashCode()
+        ((System.identityHashCode(illust) * 31 + isFollowed.hashCode()) * 31 + isPrivateFollow.hashCode()) * 31 +
+            followStateLoading.hashCode()
 
     companion object {
         // illust.user 只是快照。作者主页打开会 ObjectPool.updateUser 换掉池条目, illust.user 变孤儿。
@@ -463,19 +467,43 @@ internal fun ArtworkV3Fragment.artistRenderer() =
         b.artistHandle.setOnLongClickListener {
             Common.copy(ctx, b.artistHandle.text?.toString().orEmpty()); true
         }
-        illustGlide.load(GlideUtil.getUrl(user.profile_image_urls?.medium))
-            .error(R.drawable.no_profile)
-            .into(b.artistAvatar)
+        // 关注态重绑时头像 URL 没变就不要重发 Glide，避免“查询中”变关注时头像闪烁重载。
+        val avatarUrl = user.profile_image_urls?.medium
+        if (b.artistAvatar.tag != avatarUrl) {
+            b.artistAvatar.tag = avatarUrl
+            illustGlide.load(GlideUtil.getUrl(avatarUrl))
+                .error(R.drawable.no_profile)
+                .into(b.artistAvatar)
+        }
 
         applyTouchScale(b.artistCard)
 
-        bindArtistFollowState(b, user)
+        bindArtistFollowState(b, user, cell.item.followStateLoading)
         b.artistBio.isVisible = !user.comment.isNullOrBlank()
         if (b.artistBio.isVisible) b.artistBio.text = user.comment
     }
 
-private fun ArtworkV3Fragment.bindArtistFollowState(b: SectionV3ArtistBinding, user: UserBean) {
+private fun ArtworkV3Fragment.bindArtistFollowState(
+    b: SectionV3ArtistBinding,
+    user: UserBean,
+    followStateLoading: Boolean,
+) {
     val ctx = requireContext()
+    if (followStateLoading) {
+        // 回补完成前：显示“查询中”，不动颜色，同时不响应点击/长按。
+        b.followBtn.hideProgress()
+        b.followBtn.text = ctx.getString(R.string.follow_querying)
+        b.followBtn.isEnabled = false
+        b.followBtn.isClickable = false
+        b.followBtn.setOnClickListener(null)
+        b.followBtn.setOnLongClickListener(null)
+        b.followBtn.isLongClickable = false
+        return
+    }
+    b.followBtn.hideProgress()
+    b.followBtn.isEnabled = true
+    b.followBtn.isClickable = true
+    b.followBtn.isLongClickable = true
     val isFollowed = ObjectPool.get<UserBean>(user.id.toLong()).value?.isIs_followed
         ?: user.isIs_followed
     if (isFollowed) {

--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3FeedSource.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3FeedSource.kt
@@ -17,6 +17,7 @@ import ceui.pixiv.db.RecordType
 import ceui.pixiv.feeds.FeedItem
 import ceui.pixiv.feeds.FeedPage
 import ceui.pixiv.feeds.FeedSource
+import ceui.pixiv.ui.common.FollowStateBackfill
 import ceui.pixiv.ui.common.IllustFeedItem
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -113,7 +114,11 @@ class ArtworkV3FeedSource(
             if (illust.series != null && !TextUtils.isEmpty(illust.series.title)) {
                 list.add(ArtworkSeriesItem(illust))
             }
-            list.add(ArtworkArtistItem(illust))
+            list.add(ArtworkArtistItem(
+                illust,
+                followStateLoading = FollowStateBackfill.isIllustUntrusted(illust.id.toLong()) &&
+                    !FollowStateBackfill.isIllustTrusted(illust.id.toLong()),
+            ))
             // 产出条件仍然只看 caption:没有简介的作品(pixiv 上是多数)一旦也产出这块,
             // 详情页就会多出「简介表头 + 翻译按钮 + 一个空正文」约 120dp 的空区块。
             // 标题跟着一起带下去,只是为了让简介块的翻译按钮能连标题一起翻。

--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3Fragment.kt
@@ -27,6 +27,7 @@ import ceui.lisa.R
 import ceui.lisa.activities.Shaft
 import ceui.lisa.activities.TemplateActivity
 import ceui.pixiv.actions.FollowVisibility
+import ceui.pixiv.ui.common.FollowStateBackfill
 import ceui.pixiv.ui.bookmark.SelectTagBottomSheet
 import ceui.pixiv.ui.common.IllustMuteStore
 import ceui.lisa.adapters.IllustAdapter
@@ -280,6 +281,9 @@ class ArtworkV3Fragment : IllustFeedFragment(R.layout.fragment_artwork_v3) {
             val authorId = illust.user?.id?.toLong() ?: return@observe
             attachArtistFollowObserver(authorId)
         }
+
+        // 自建源关注态回补的 loading 开关：开始/完成时刷新作者栏（转圈 <-> 正常按钮）。
+        artworkViewModel.followStateLoading.observe(viewLifecycleOwner) { refreshArtistFollowItem() }
 
         // issue #1023: 标签编辑 sheet 是 childFragmentManager 拉起来的(见 tagsRenderer),
         // 变更经 fragment result 回来而不是 lambda —— sheet 跨横屏会重建,回调必然失效。
@@ -715,12 +719,16 @@ class ArtworkV3Fragment : IllustFeedFragment(R.layout.fragment_artwork_v3) {
 
     private fun refreshArtistFollowItem() {
         feedViewModel.updateItems<ArtworkArtistItem> { item ->
+            val loading = artworkViewModel.followStateLoading.value == true &&
+                FollowStateBackfill.isIllustUntrusted(item.illust.id.toLong())
             val followed = ArtworkArtistItem.resolveIsFollowed(item.illust)
             val private = ArtworkArtistItem.resolvePrivateFollow(item.illust)
-            if (item.isFollowed == followed && item.isPrivateFollow == private) {
+            if (item.isFollowed == followed && item.isPrivateFollow == private &&
+                item.followStateLoading == loading
+            ) {
                 item
             } else {
-                ArtworkArtistItem(item.illust, followed, private)
+                ArtworkArtistItem(item.illust, followed, private, loading)
             }
         }
     }

--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3ViewModel.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3ViewModel.kt
@@ -18,6 +18,7 @@ import ceui.loxia.fetchFullIllustDetail
 import ceui.loxia.fetchIllustPageDimensions
 import ceui.loxia.hasTrustedCaption
 import ceui.loxia.isFullDetail
+import ceui.pixiv.ui.common.FollowStateBackfill
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -57,6 +58,7 @@ class ArtworkV3ViewModel(
         _isBookmarked.value = bean.isIs_bookmarked
         ensurePageDimensions(bean)
         ensureTrustedCaption(bean)
+        ensureTrustedFollow(bean)
         if (downloadFabActive && waitingForInitialBean) {
             refreshDownloadFab()
         }
@@ -84,7 +86,10 @@ class ArtworkV3ViewModel(
     // ── caption 后台补拉(#960)──
 
     private var captionBackfillRequested = false
+    private var fullDetailFetchInFlight = false
     private var pageVisible = false
+    private val _followStateLoading = MutableLiveData(false)
+    val followStateLoading: LiveData<Boolean> = _followStateLoading
 
     /**
      * 「这一页被用户真正打开过」——由 Fragment 的 onResume 调,一次性闸门(不在 onPause 复位:
@@ -96,7 +101,10 @@ class ArtworkV3ViewModel(
      */
     fun onPageVisible() {
         pageVisible = true
-        illustBean?.let { ensureTrustedCaption(it) }
+        illustBean?.let { bean ->
+            ensureTrustedCaption(bean)
+            startFollowBackfill(bean)
+        }
     }
 
     /**
@@ -111,19 +119,97 @@ class ArtworkV3ViewModel(
      * 现在对齐 V2([ceui.lisa.fragments.FragmentIllustViewModel] 的 init):首屏照常用池里的 bean
      * 立刻渲染,detail 在后台拉;[fetchFullIllustDetail] 落池后由 Fragment 的 ObjectPool observer
      * 把简介块增量插回去(见 ArtworkV3Fragment.syncDescSection)。
-     *
-     * 只在「池里这条 bean 本来就够画首屏」时才补:[isFullDetail] 为 false 时数据源自己正在阻塞
-     * 拉 detail,那一次拉取顺带就把 caption 带回来了,这里再发一次就是重复请求。
-     *
-     * 命中率(真机实测):动态流 8 次补拉救回 4 条简介(pixiv 确实会掐动态流的 caption);推荐流
-     * 6 次全空——那些作品是**真没写简介**。所以这笔钱只花在「用户真的打开了、且这条确实缺简介」
-     * 的作品上([onPageVisible] 的闸门),每个作品至多一次(拉过即进 fullVersionKeys)。
      */
     private fun ensureTrustedCaption(bean: IllustsBean) {
         if (!pageVisible || captionBackfillRequested) return
         if (!bean.isFullDetail() || bean.hasTrustedCaption()) return
         captionBackfillRequested = true
-        viewModelScope.launch { fetchFullIllustDetail(illustId) }
+        ensureFullDetailBackfill()
+    }
+
+    // ── 自建源关注态回补（与 caption 补拉分开触发，共用 detail 在途闸门）──
+
+    private var followBackfillRequested = false
+
+    /**
+     * 观察池 bean 时先登记来源信任关系：
+     * - 自建源上报的 illust 在 [FollowStateBackfill] 里是 untrusted → 进入详情页后需要回补，先转圈；
+     * - 非自建源进入的同 ID 详情页 → 打日志（信任池），把该 illust 标记为可信池成员。
+     */
+    private fun ensureTrustedFollow(bean: IllustsBean) {
+        val illustId = bean.id.toLong()
+        if (FollowStateBackfill.isIllustUntrusted(illustId)) {
+            // 已在信任池的同 ID 不需要转圈，onPageVisible 会直接标记已确认。
+            if (!followBackfillRequested && !FollowStateBackfill.isIllustTrusted(illustId)) {
+                _followStateLoading.value = true
+            }
+        } else {
+            FollowStateBackfill.markIllustTrusted(illustId)
+            if (_followStateLoading.value == true) {
+                _followStateLoading.value = false
+            }
+            Timber.tag(FOLLOW_BACKFILL_TAG).d("信任池:  illust=%d", illustId)
+        }
+    }
+
+    /**
+     * 自建源进入详情页后的关注态回补：
+     * 1. 先查信任池——同 ID 详情页从非自建源进入过，直接拿池并标记已确认，不再发请求；
+     * 2. 未中信任池且未确认，再打 v1/illust/detail 拉真实状态，成功回池并标记已确认。
+     */
+    private fun startFollowBackfill(bean: IllustsBean) {
+        if (!pageVisible) return
+        val illustId = bean.id.toLong()
+        if (followBackfillRequested) {
+            // 自愈：如果已经确认过但 loading 没被置回，立刻收起“查询中”。
+            if (_followStateLoading.value == true && !FollowStateBackfill.isIllustUntrusted(illustId)) {
+                _followStateLoading.value = false
+            }
+            return
+        }
+        if (!FollowStateBackfill.isIllustUntrusted(illustId)) {
+            // 同 ID 已被其它入口确认过：不再需要回补，收起可能还亮着的转圈。
+            if (_followStateLoading.value == true) {
+                _followStateLoading.value = false
+            }
+            return
+        }
+        followBackfillRequested = true
+
+        if (FollowStateBackfill.isIllustTrusted(illustId) || ObjectPool.hasFullIllustVersion(illustId)) {
+            Timber.tag(FOLLOW_BACKFILL_TAG).d("信任池: illust=%d 直接使用池并标记已确认", illustId)
+            FollowStateBackfill.markIllustConfirmed(illustId)
+            _followStateLoading.value = false
+            return
+        }
+
+        _followStateLoading.value = true
+        ensureFullDetailBackfill()
+    }
+
+    /**
+     * caption 补拉与关注态回补共用同一个在途闸门：
+     * 自建源进入详情页时这两种情况都可能同时缺，避免并发打两个 v1/illust/detail。
+     */
+    private fun ensureFullDetailBackfill() {
+        if (fullDetailFetchInFlight) return
+        fullDetailFetchInFlight = true
+        viewModelScope.launch {
+            try {
+                val fresh = fetchFullIllustDetail(illustId)
+                if (FollowStateBackfill.isIllustUntrusted(illustId)) {
+                    if (fresh != null) {
+                        FollowStateBackfill.markIllustConfirmed(illustId)
+                        Timber.tag(FOLLOW_BACKFILL_TAG).d("关注态回补成功: illust=%d", illustId)
+                    } else {
+                        Timber.tag(FOLLOW_BACKFILL_TAG).w("关注态回补失败: illust=%d", illustId)
+                    }
+                }
+                _followStateLoading.value = false
+            } finally {
+                fullDetailFetchInFlight = false
+            }
+        }
     }
 
     // ── download FAB state machine ──
@@ -269,6 +355,10 @@ class ArtworkV3ViewModel(
                 recomputeFab()
             }
         }
+    }
+
+    companion object {
+        private const val FOLLOW_BACKFILL_TAG = "FollowState"
     }
 }
 

--- a/app/src/main/java/ceui/pixiv/ui/discovery/DiscoverViewModel.kt
+++ b/app/src/main/java/ceui/pixiv/ui/discovery/DiscoverViewModel.kt
@@ -12,6 +12,7 @@ import ceui.lisa.models.IllustsBean
 import ceui.lisa.network.ShaftApiV2
 import ceui.lisa.network.ShaftApiV2Client
 import ceui.lisa.repo.LatestIllustRepo
+import ceui.pixiv.ui.common.FollowStateBackfill
 import ceui.pixiv.ui.prime.PrimeTagIndexItem
 import com.blankj.utilcode.util.Utils
 import com.google.gson.Gson
@@ -69,7 +70,7 @@ class DiscoverViewModel : ViewModel() {
     /**
      * 一个 /discover 聚合请求,填两条 shaft-api-v2 货架(替掉之前 2 个独立请求)。
      * 失败整体静默塌陷:两条都发空 → 收起货架,不弹 toast(后台货架不打扰前台)。
-     * 每条 bean 的收藏态清成 false(payload 里是上报者的态,跟当前用户无关),user==null
+     * 每条 bean 的收藏/关注态清成 false(payload 里是上报者的态,跟当前用户无关),user==null
      * 的脏数据剔掉(RAdapter 直取 user.name / 头像,null 会 NPE)。
      */
     private fun loadDiscover() {
@@ -102,7 +103,9 @@ class DiscoverViewModel : ViewModel() {
                 try {
                     gson.fromJson(json, IllustsBean::class.java).apply {
                         trendingScore = scoreOf(item)
-                        setIs_bookmarked(false)
+                        isIs_bookmarked = false
+                        user?.isIs_followed = false
+                        FollowStateBackfill.markIllustUntrusted(id.toLong())
                     }
                 } catch (e: Throwable) {
                     null

--- a/app/src/main/java/ceui/pixiv/ui/recommend/ArtistRankFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/recommend/ArtistRankFeedFragment.kt
@@ -123,6 +123,7 @@ class ArtistRankFeedSource(
             // novels 给空列表：legacy 那句 setNovels(emptyList()) 是为了兜 UAdapter 在插画不足 3 张时
             // 读 getNovels().subList(...) 的 NPE；feeds 的用户卡只渲染 illusts（不足留空，见
             // UserFeedFragment），已无此坑，这里保持空列表只为与 legacy 语义一致（画师榜不出小说）。
+            // 画师榜是用户卡列表，不走插画详情页回补，无需登记 illust 待确认。
             return UserFeedItem(
                 UserPreview(
                     illusts = illusts,

--- a/app/src/main/java/ceui/pixiv/ui/recommend/BookmarkRankFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/recommend/BookmarkRankFeedFragment.kt
@@ -13,6 +13,7 @@ import ceui.pixiv.feeds.FeedPage
 import ceui.pixiv.feeds.FeedSource
 import ceui.pixiv.feeds.feedViewModels
 import ceui.pixiv.ui.common.IllustFeedFragment
+import ceui.pixiv.ui.common.FollowStateBackfill
 import ceui.pixiv.ui.common.IllustFeedItem
 import ceui.pixiv.ui.common.setUpToolbar
 import ceui.pixiv.ui.common.viewBinding
@@ -136,10 +137,12 @@ class BookmarkRankFeedSource(
                 return null
             } ?: return null
             // 收藏榜:pill 显 pixiv 总收藏数(TrendingScoreFormat 支持 K/M,990150→「990.2K」);
-            // payload 里的收藏态是上报者的,清零让用户以自己名义收藏(对齐 ViewRankFeedSource)。
+            // payload 里的收藏/关注态是上报者的,清零让用户以自己名义收藏/关注(对齐 ViewRankFeedSource)。
             bean.trendingScore = item.bookmark_count.toFloat()
-            bean.setIs_bookmarked(false)
-            return IllustFeedItem.fromBean(bean, skipAiFilter = skipAiFilter)
+            bean.isIs_bookmarked = false
+            bean.user?.isIs_followed = false
+            FollowStateBackfill.markIllustUntrusted(bean.id.toLong())
+            return IllustFeedItem.fromBean(bean, skipAiFilter = skipAiFilter, bookmarkStateUnknown = true)
         }
     }
 }

--- a/app/src/main/java/ceui/pixiv/ui/recommend/HotWorksFeed.kt
+++ b/app/src/main/java/ceui/pixiv/ui/recommend/HotWorksFeed.kt
@@ -7,6 +7,7 @@ import ceui.lisa.network.ShaftApiV2Client
 import ceui.loxia.Novel
 import ceui.pixiv.feeds.FeedPage
 import ceui.pixiv.feeds.FeedSource
+import ceui.pixiv.ui.common.FollowStateBackfill
 import ceui.pixiv.ui.common.IllustFeedItem
 import ceui.pixiv.ui.common.NovelFeedItem
 import kotlinx.coroutines.Dispatchers
@@ -114,10 +115,12 @@ private fun mapHotIllustItem(
         Timber.tag("HotWorks").w(e, "skip malformed illust bean id=${item.target_id}")
         return null
     } ?: return null
-    // 对齐 legacy TrendingWorksRepo/RecentWorksRepo：热度值装 pill、清上报者收藏态。
+    // 对齐 legacy TrendingWorksRepo/RecentWorksRepo：热度值装 pill、清上报者收藏/关注态。
     bean.trendingScore = item.hotScore(source)
-    bean.setIs_bookmarked(false)
-    return IllustFeedItem.fromBean(bean)
+    bean.isIs_bookmarked = false
+    bean.user?.isIs_followed = false
+    FollowStateBackfill.markIllustUntrusted(bean.id.toLong())
+    return IllustFeedItem.fromBean(bean, bookmarkStateUnknown = true)
 }
 
 private fun mapHotNovelItem(
@@ -132,5 +135,9 @@ private fun mapHotNovelItem(
         return null
     } ?: return null
     // 清上报者收藏态；热度分单独带进 NovelFeedItem（不是 Novel 的字段）。
-    return NovelFeedItem.of(novel.copy(is_bookmarked = false), item.hotScore(source))
+    // 小说详情不走插画关注态回补，不清 user.is_followed，也不登记 illust 待确认。
+    return NovelFeedItem.of(
+        novel.copy(is_bookmarked = false),
+        item.hotScore(source),
+    )
 }

--- a/app/src/main/java/ceui/pixiv/ui/recommend/ViewRankFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/recommend/ViewRankFeedFragment.kt
@@ -13,6 +13,7 @@ import ceui.pixiv.feeds.FeedPage
 import ceui.pixiv.feeds.FeedSource
 import ceui.pixiv.feeds.feedViewModels
 import ceui.pixiv.ui.common.IllustFeedFragment
+import ceui.pixiv.ui.common.FollowStateBackfill
 import ceui.pixiv.ui.common.IllustFeedItem
 import ceui.pixiv.ui.common.setUpToolbar
 import ceui.pixiv.ui.common.viewBinding
@@ -89,10 +90,12 @@ class ViewRankFeedSource(
                 return null
             } ?: return null
             // 浏览量榜：pill 显浏览数（TrendingScoreFormat 支持 M，6457227→「6.5M」）；
-            // payload 里的收藏态是上报者的，清零让用户以自己名义收藏（对齐 legacy ViewRankRepo）。
+            // payload 里的收藏/关注态是上报者的，清零让用户以自己名义收藏/关注（对齐 legacy ViewRankRepo）。
             bean.trendingScore = item.view_count.toFloat()
-            bean.setIs_bookmarked(false)
-            return IllustFeedItem.fromBean(bean)
+            bean.isIs_bookmarked = false
+            bean.user?.isIs_followed = false
+            FollowStateBackfill.markIllustUntrusted(bean.id.toLong())
+            return IllustFeedItem.fromBean(bean, bookmarkStateUnknown = true)
         }
     }
 }

--- a/app/src/main/java/ceui/pixiv/ui/recommend/WallpaperIllustFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/recommend/WallpaperIllustFeedFragment.kt
@@ -10,6 +10,7 @@ import ceui.pixiv.feeds.FeedPage
 import ceui.pixiv.feeds.FeedSource
 import ceui.pixiv.feeds.feedViewModels
 import ceui.pixiv.ui.common.IllustFeedFragment
+import ceui.pixiv.ui.common.FollowStateBackfill
 import ceui.pixiv.ui.common.IllustFeedItem
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -88,8 +89,10 @@ class WallpaperFeedSource(
                 return null
             } ?: return null
             bean.trendingScore = item.bookmark_count.toFloat()
-            bean.setIs_bookmarked(false)
-            return IllustFeedItem.fromBean(bean)
+            bean.isIs_bookmarked = false
+            bean.user?.isIs_followed = false
+            FollowStateBackfill.markIllustUntrusted(bean.id.toLong())
+            return IllustFeedItem.fromBean(bean, bookmarkStateUnknown = true)
         }
     }
 }

--- a/app/src/main/java/ceui/pixiv/ui/search/SearchIllustFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/search/SearchIllustFeedFragment.kt
@@ -14,6 +14,7 @@ import ceui.pixiv.feeds.FeedSource
 import ceui.pixiv.feeds.LoadState
 import ceui.pixiv.feeds.feedViewModels
 import ceui.pixiv.ui.common.IllustFeedFragment
+import ceui.pixiv.ui.common.FollowStateBackfill
 import ceui.pixiv.ui.common.IllustFeedItem
 import ceui.pixiv.ui.common.awaitFirstValue
 import io.reactivex.functions.Function
@@ -128,6 +129,17 @@ class SearchIllustFeedFragment : IllustFeedFragment() {
 }
 
 /**
+ * 调试借号 UI 的临时方法（已关闭，提交保持关闭）：
+ * debug 下借号流程可能被服务端校验挡住，想用任意搜索结果（如热度预览）模拟借号 unknown 收藏态时，
+ * 恢复下面两行并把常量改为 true 即可：
+ *
+ *     private const val DEBUG_FORCE_BOOKMARK_STATE_UNKNOWN = true
+ *     val borrowed = r.isBorrowedResult || (BuildConfig.DEBUG && DEBUG_FORCE_BOOKMARK_STATE_UNKNOWN)
+ *
+ * 注意同时需要 import ceui.lisa.BuildConfig。
+ */
+
+/**
  * 搜索插画数据源：包裹 [SearchIllustRepo]。load(null) 前 `update(searchModel)` 重读最新参数 +
  * 配置 FilterMapper（R18 三态 / onlyAi / starSize）；load(cursor) 用 repo 翻页。过滤走 repo.mapper()
  * （FilterMapper，含 legacy 全部搜索过滤 + ObjectPool 合池，setValue 失败自动 postValue 兜底，off-main 安全）。
@@ -172,10 +184,20 @@ class SearchIllustFeedSource(private val searchModel: SearchModel) : FeedSource<
             api.awaitFirstValue()
         }
         val items = withContext(Dispatchers.Default) {
+            // 借号搜索返回的 is_bookmarked / user.is_followed 都是借来账号的，跟当前用户无关；
+            // 必须在 FilterMapper（会 ObjectPool.updateIllust 喂池）之前清掉并登记回补。
+            val borrowed = r.isBorrowedResult
+            if (borrowed) {
+                list.illusts.orEmpty().forEach { bean ->
+                    bean.isIs_bookmarked = false
+                    bean.user?.isIs_followed = false
+                    FollowStateBackfill.markIllustUntrusted(bean.id.toLong())
+                }
+            }
             @Suppress("UNCHECKED_CAST")
             val filtered = (r.mapper() as Function<ListIllust, ListIllust>).apply(list)
             // FilterMapper 已做完全部搜索专属过滤 → 直接建条目，不再过滤（否则仅看 AI 误删 AI）。
-            filtered.list.orEmpty().mapNotNull { IllustFeedItem.rawFromBean(it) }
+            filtered.list.orEmpty().mapNotNull { IllustFeedItem.rawFromBean(it, bookmarkStateUnknown = borrowed) }
         }
         return FeedPage(items, list.nextUrl?.takeIf { it.isNotEmpty() })
     }

--- a/app/src/main/java/ceui/pixiv/ui/search/SearchNovelFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/search/SearchNovelFeedFragment.kt
@@ -292,6 +292,14 @@ class SearchNovelFeedSource(private val searchModel: SearchModel) : FeedSource<S
             r.initNextApi().awaitFirstValue()
         }
         val items = withContext(Dispatchers.Default) {
+            // 借号搜索返回的 is_bookmarked / user.is_followed 都是借来账号的，跟当前用户无关；
+            // 小说没有插画那套回补，直接清成 false，避免把他人收藏/关注态带进列表或后续详情。
+            if (r.isBorrowedResult) {
+                list.novels.orEmpty().forEach { bean ->
+                    bean.isIs_bookmarked = false
+                    bean.user?.isIs_followed = false
+                }
+            }
             @Suppress("UNCHECKED_CAST")
             val filtered = (r.mapper() as Function<ListNovel, ListNovel>).apply(list)
             // Mapper 已做完搜索专属过滤（R18 三态 / 仅看 AI），直接 bean→loxia Novel 建条目，不再过滤。

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -870,6 +870,7 @@
     <string name="cancel_block_this_users_work">取消屏蔽此用户的作品</string>
     <string name="add_user_to_blacklist">将此用户加入黑名单</string>
     <string name="follow">关注</string>
+    <string name="follow_querying">查询中</string>
     <string name="unfollow">取关</string>
     <string name="user_followed">已关注</string>
     <string name="user_followed_private">悄悄关注中</string>


### PR DESCRIPTION
# fix(feed): 清洗自建源/借号收藏与关注态并按池态恢复爱心

> 分支：`patch-8-20-1`（wangwang-code fork）
> 提交：`23b3c8585`

## 背景

自建源（shaft-api-v2 / pixshaft.com）和借号搜索返回的插画/漫画 bean 中：

- `is_bookmarked` 是**上报者 / 借来账号**的收藏态，不是当前用户；
- `user.is_followed` 同样是**上报者 / 借来账号**的关注态。

此前代码只清了 `is_bookmarked`，漏了 `user.is_followed`；且列表 bean 会经 `Mapper` / `VActivity` 进入 `ObjectPool`，详情页又信任池中数据，导致：

- 关注态双向错误（已关注显示未关注 / 未关注显示已关注）；
- 收藏态显示为别人的状态；
- 借号搜索因为走官方 app-api，之前完全没被识别为不可信来源。

## 改动方案

### 1. 数据源统一清洗

所有自建源 / 借号来源在进入 `ObjectPool` 之前统一：

```kotlin
bean.isIs_bookmarked = false
bean.user?.isIs_followed = false
FollowStateBackfill.markIllustUntrusted(bean.id.toLong())
```

覆盖：

- 发现页货架：`DiscoverViewModel`
- 收藏榜 / 标签榜 / 年代榜：`BookmarkRankFeedSource`
- 浏览量榜：`ViewRankFeedSource`
- 壁纸榜：`WallpaperFeedSource`
- 本月收藏 / 当前最热：`HotWorksFeed`
- 热度标签：`PrimeTagDetailFragment`（用户已回滚，不在本 PR 内）
- 事件历史：`EventHistoryFeed`（用户要求回滚，不在本 PR 内）
- 借号插画搜索：`SearchIllustFeedSource`
- 借号小说搜索：`SearchNovelFeedSource`

### 2. 借号搜索按“实际路由”标记，降级不误伤

新增：

```kotlin
val isBorrowedResult: Boolean
    get() = lastResultBorrowed
```

`SearchIllustRepo` / `SearchNovelRepo` 在真实返回链路上标记：

- 借号官方搜索成功 → `lastResultBorrowed = true`
- popular-preview / 普通直连 / 借号失败后的降级 → `lastResultBorrowed = false`

这样只有真正由借号账号返回的数据才被清洗，降级结果不会误清当前用户自己的状态。

### 3. 关注态回补

新增 `FollowStateBackfill`：

- `untrustedIllustIds`：自建源上报、尚未确认的 illust id；
- `trustedIllustIds`：当前池数据可信的 illust id；
- 自建源重新上报时会**撤销 trusted**，避免旧信任导致跳过回补；
- `markIllustTrusted` 在仍为 untrusted 时拒绝写入，保证两态互斥。

V3 详情页 `ArtworkV3ViewModel` 与 legacy `FragmentIllustViewModel`：

- 在 `onPageVisible()` 后才开始回补，避免预载页提前请求；
- 关注态回补与 caption 补拉共用同一个 `v1/illust/detail` 在途闸门；
- 回补成功用官方 detail 覆盖池，作者栏恢复正确关注态。

### 4. 收藏态 unknown + 池态恢复

#### `IllustFeedItem.bookmarkStateUnknown`

新增字段，借号 / 自建源条目标记为 `true`：

- 渲染器在 unknown 且池中尚无 full detail 时：
  - 隐藏右下角收藏爱心；
  - 点击 / 长按“按标签收藏”直接 no-op；
- 一旦池中出现明确收藏态（`ObjectPool.hasFullIllustVersion`），自动恢复爱心并显示池中真实收藏态。

#### 池态恢复广播

`fetchFullIllustDetail` 成功整体覆盖池后发送：

```kotlin
Params.ILLUST_POOL_REFRESHED
```

`IllustFeedDetailSync` 监听该广播，对 `bookmarkStateUnknown` 的条目调用：

```kotlin
item.withPoolBookmarkState()
```

把条目恢复为正常展示，同时把 `bookmarkStateUnknown` 置回 `false`。

#### 自建源列表从“整页隐藏”升级为“按条目 unknown”

原先这些页面用 `hideLikeButton = true` 整页隐藏爱心，池态恢复后也无法显示。现在改为：

```kotlin
IllustFeedItem.fromBean(bean, bookmarkStateUnknown = true)
```

覆盖：

- `HotWorksIllustFeedFragment`（本月收藏 / 当前最热）
- `BookmarkRankFeedFragment`（收藏榜）
- `TagRankIllustFeedFragment`（标签榜）
- `YearRankIllustFeedFragment`（年代榜）
- `ViewRankFeedFragment`（浏览量榜）
- `WallpaperIllustFeedFragment`（壁纸榜）

### 5. 小说借号清洗

`SearchNovelFeedSource` 对借号小说结果清洗：

```kotlin
bean.isIs_bookmarked = false
bean.user?.isIs_followed = false
```

小说没有插画那套关注态回补，因此只清洗、不登记 `FollowStateBackfill`，避免跨类型 id 污染。

## 涉及文件

- `app/src/main/java/ceui/pixiv/ui/common/FollowStateBackfill.kt`（新增）
- `app/src/main/java/ceui/pixiv/ui/common/IllustFeedItem.kt`
- `app/src/main/java/ceui/pixiv/ui/common/IllustFeedSync.kt`
- `app/src/main/java/ceui/pixiv/ui/common/IllustStaggerRenderer.kt`
- `app/src/main/java/ceui/lisa/fragments/FragmentIllust.kt`
- `app/src/main/java/ceui/lisa/fragments/FragmentIllustViewModel.kt`
- `app/src/main/java/ceui/lisa/repo/SearchIllustRepo.kt`
- `app/src/main/java/ceui/lisa/repo/SearchNovelRepo.kt`
- `app/src/main/java/ceui/lisa/utils/Params.java`
- `app/src/main/java/ceui/loxia/IllustDetailSupport.kt`
- `app/src/main/java/ceui/pixiv/ui/detail/ArtworkSectionRenderers.kt`
- `app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3FeedSource.kt`
- `app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3Fragment.kt`
- `app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3ViewModel.kt`
- `app/src/main/java/ceui/pixiv/ui/discovery/DiscoverViewModel.kt`
- `app/src/main/java/ceui/pixiv/ui/recommend/ArtistRankFeedFragment.kt`
- `app/src/main/java/ceui/pixiv/ui/recommend/BookmarkRankFeedFragment.kt`
- `app/src/main/java/ceui/pixiv/ui/recommend/HotWorksFeed.kt`
- `app/src/main/java/ceui/pixiv/ui/recommend/ViewRankFeedFragment.kt`
- `app/src/main/java/ceui/pixiv/ui/recommend/WallpaperIllustFeedFragment.kt`
- `app/src/main/java/ceui/pixiv/ui/search/SearchIllustFeedFragment.kt`
- `app/src/main/java/ceui/pixiv/ui/search/SearchNovelFeedFragment.kt`
- `app/src/main/res/values/strings.xml`

## 验证

- `:app:compileGithubDebugKotlin --offline`：**BUILD SUCCESSFUL**
- 借号流程在 debug 下受服务端校验限制，已在 `SearchIllustFeedFragment` 保留注释形式的调试方法：
  - 恢复 `DEBUG_FORCE_BOOKMARK_STATE_UNKNOWN` 后可用任意搜索结果（如热度预览）模拟借号 unknown 收藏态；
  - 已确认：unknown 时隐藏爱心，明确操作 / 池态出现后恢复爱心。

## 说明

- `EventHistoryFeed`、`PrimeTagDetailFragment` 按讨论已回滚，不在本 PR。
- `gradle.properties` 本地内存调整未包含在提交中。
