### PR TITLE
标签区分原文与翻译：新增「标签译文颜色」设置

### DIFF
--- a/app/src/main/java/ceui/lisa/activities/TemplateActivity.java
+++ b/app/src/main/java/ceui/lisa/activities/TemplateActivity.java
@@ -399,8 +399,12 @@ public class TemplateActivity extends BaseActivity<ActivityFragmentBinding> impl
                 case "小说书签":
                     return new NovelMarkersFeedFragment();
                 case "主题颜色":
-                    // feeds 框架版(替代 legacy FragmentColors);静态目录单页,带 toolbar
-                    return new ceui.pixiv.ui.settings.ThemeColorFeedFragment();
+                    // feeds 框架版(替代 legacy FragmentColors);静态目录单页,带 toolbar。
+                    // 设置 → 标签译文颜色 也复用本页，通过 extra 切成选择器模式。
+                    return ceui.pixiv.ui.settings.ThemeColorFeedFragment.newInstance(
+                            intent.getBooleanExtra(
+                                    ceui.pixiv.ui.settings.ThemeColorFeedFragment.ARG_SELECT_TAG_TRANSLATION_COLOR,
+                                    false));
                 case "测试测试":
                     return new FragmentSAF();
                 case "举报插画":

--- a/app/src/main/java/ceui/lisa/activities/TemplateActivity.java
+++ b/app/src/main/java/ceui/lisa/activities/TemplateActivity.java
@@ -68,6 +68,7 @@ import ceui.pixiv.ui.notification.NotificationPagerFragment;
 import ceui.pixiv.ui.notification.NotificationViewMoreFragment;
 import ceui.pixiv.ui.prime.PrimeTagDetailFragment;
 import ceui.pixiv.ui.prime.PrimeTagsFragment;
+import ceui.pixiv.ui.settings.ThemeColorFeedFragment;
 
 public class TemplateActivity extends BaseActivity<ActivityFragmentBinding> implements ColorPickerDialogListener {
 
@@ -401,9 +402,9 @@ public class TemplateActivity extends BaseActivity<ActivityFragmentBinding> impl
                 case "主题颜色":
                     // feeds 框架版(替代 legacy FragmentColors);静态目录单页,带 toolbar。
                     // 设置 → 标签译文颜色 也复用本页，通过 extra 切成选择器模式。
-                    return ceui.pixiv.ui.settings.ThemeColorFeedFragment.newInstance(
+                    return ThemeColorFeedFragment.newInstance(
                             intent.getBooleanExtra(
-                                    ceui.pixiv.ui.settings.ThemeColorFeedFragment.ARG_SELECT_TAG_TRANSLATION_COLOR,
+                                    ThemeColorFeedFragment.ARG_SELECT_TAG_TRANSLATION_COLOR,
                                     false));
                 case "测试测试":
                     return new FragmentSAF();

--- a/app/src/main/java/ceui/lisa/fragments/FragmentSettingsAppearance.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSettingsAppearance.java
@@ -28,6 +28,7 @@ import ceui.lisa.utils.Common;
 import ceui.lisa.utils.Local;
 import ceui.pixiv.ui.settings.CustomThemeColor;
 import ceui.pixiv.ui.settings.ThemeColorCatalog;
+import ceui.pixiv.ui.settings.ThemeColorFeedFragment;
 import ceui.pixiv.widget.RecommendCardWidgetProvider;
 import ceui.pixiv.widget.RecommendStripWidgetProvider;
 import ceui.pixiv.widget.SpotlightWidgetProvider;
@@ -418,7 +419,7 @@ public class FragmentSettingsAppearance extends SettingsPageFragment<FragmentSet
                     } else {
                         Intent intent = new Intent(mContext, TemplateActivity.class);
                         intent.putExtra(TemplateActivity.EXTRA_FRAGMENT, "主题颜色");
-                        intent.putExtra(ceui.pixiv.ui.settings.ThemeColorFeedFragment.ARG_SELECT_TAG_TRANSLATION_COLOR, true);
+                        intent.putExtra(ThemeColorFeedFragment.ARG_SELECT_TAG_TRANSLATION_COLOR, true);
                         startActivity(intent);
                     }
                     dialog.dismiss();
@@ -430,9 +431,7 @@ public class FragmentSettingsAppearance extends SettingsPageFragment<FragmentSet
     public void onResume() {
         super.onResume();
         // 从「主题色彩页」选完标签译文颜色返回时刷新这一行的展示值。
-        if (baseBind != null) {
-            setTagTranslationColorName();
-        }
+        setTagTranslationColorName();
     }
 
     private String currentLanguageDisplay() {

--- a/app/src/main/java/ceui/lisa/fragments/FragmentSettingsAppearance.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSettingsAppearance.java
@@ -80,6 +80,10 @@ public class FragmentSettingsAppearance extends SettingsPageFragment<FragmentSet
             startActivity(intent);
         });
 
+        // 标签译文颜色（#1047-5）：跟随主题 or 从主题色彩页中选择
+        setTagTranslationColorName();
+        baseBind.tagTranslationColorRela.setOnClickListener(v -> showTagTranslationColorDialog());
+
         // 语言
         baseBind.appLanguage.setText(currentLanguageDisplay());
         baseBind.appLanguageRela.setOnClickListener(v -> {
@@ -383,6 +387,52 @@ public class FragmentSettingsAppearance extends SettingsPageFragment<FragmentSet
         }
         final int index = Shaft.sSettings.getThemeIndex();
         baseBind.colorSelect.setText(getString(ThemeColorCatalog.nameResOf(index)));
+    }
+
+    private void setTagTranslationColorName() {
+        if (Shaft.sSettings.isTagTranslationColorFollowTheme()) {
+            baseBind.tagTranslationColor.setText(getString(R.string.tag_translation_color_follow_theme));
+            return;
+        }
+        if (Shaft.sSettings.getTagTranslationColorIndex() == CustomThemeColor.INDEX) {
+            String hex = CustomThemeColor.normalize(Shaft.sSettings.getTagTranslationColorCustomHex());
+            baseBind.tagTranslationColor.setText(getString(R.string.custom_theme_color_entry) + " " +
+                    (hex != null ? hex : CustomThemeColor.currentHex()));
+            return;
+        }
+        baseBind.tagTranslationColor.setText(getString(ThemeColorCatalog.nameResOf(Shaft.sSettings.getTagTranslationColorIndex())));
+    }
+
+    private void showTagTranslationColorDialog() {
+        int checkedIndex = Shaft.sSettings.isTagTranslationColorFollowTheme() ? 0 : 1;
+        new WitDialog.CheckableDialogBuilder(mActivity)
+                .setCheckedIndex(checkedIndex)
+                .addItems(new String[]{
+                        getString(R.string.tag_translation_color_follow_theme),
+                        getString(R.string.tag_translation_color_pick_from_theme_page)
+                }, (dialog, which) -> {
+                    if (which == 0) {
+                        Shaft.sSettings.setTagTranslationColorFollowTheme();
+                        baseBind.tagTranslationColor.setText(getString(R.string.tag_translation_color_follow_theme));
+                        Local.setSettings(Shaft.sSettings);
+                    } else {
+                        Intent intent = new Intent(mContext, TemplateActivity.class);
+                        intent.putExtra(TemplateActivity.EXTRA_FRAGMENT, "主题颜色");
+                        intent.putExtra(ceui.pixiv.ui.settings.ThemeColorFeedFragment.ARG_SELECT_TAG_TRANSLATION_COLOR, true);
+                        startActivity(intent);
+                    }
+                    dialog.dismiss();
+                })
+                .show();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        // 从「主题色彩页」选完标签译文颜色返回时刷新这一行的展示值。
+        if (baseBind != null) {
+            setTagTranslationColorName();
+        }
     }
 
     private String currentLanguageDisplay() {

--- a/app/src/main/java/ceui/lisa/fragments/SettingsCatalog.kt
+++ b/app/src/main/java/ceui/lisa/fragments/SettingsCatalog.kt
@@ -91,6 +91,7 @@ object SettingsCatalog {
             " 自定义颜色 自定义主题色彩 自定义色值 十六进制 hex 色号 取色器 拾色器 调色板 custom color color picker"
         } else ""
         add(Entry(APPEARANCE, "color_select_rela", R.string.string_324, keywords = "主题色 颜色 配色 强调色 粉色 accent color$customColorAliases"))
+        add(Entry(APPEARANCE, "tag_translation_color_rela", R.string.tag_translation_color, keywords = "标签 译文 翻译 颜色 跟随主题 主题色彩 标签译文 tag translation color"))
         add(Entry(APPEARANCE, "app_language_rela", R.string.language, keywords = "语言 简体 繁体 英文 日文 韩文 中文 language english"))
         add(Entry(APPEARANCE, "navigation_init_position_rela", R.string.string_426, keywords = "启动页 默认页 初始页 首页 导航 start page"))
         add(Entry(APPEARANCE, "bottom_bar_order_rela", R.string.string_342, keywords = "底部导航 tab 顺序 排序 页签 bottom bar"))

--- a/app/src/main/java/ceui/lisa/utils/Settings.java
+++ b/app/src/main/java/ceui/lisa/utils/Settings.java
@@ -113,10 +113,9 @@ public class Settings {
     private String tagTranslationColorCustomHex;
 
     public int getTagTranslationColorIndex() {
-        if (tagTranslationColorIndex == null) {
-            return TAG_TRANSLATION_COLOR_FOLLOW_THEME;
-        }
-        return tagTranslationColorIndex;
+        return tagTranslationColorIndex != null
+                ? tagTranslationColorIndex
+                : TAG_TRANSLATION_COLOR_FOLLOW_THEME;
     }
 
     public boolean isTagTranslationColorFollowTheme() {

--- a/app/src/main/java/ceui/lisa/utils/Settings.java
+++ b/app/src/main/java/ceui/lisa/utils/Settings.java
@@ -98,6 +98,47 @@ public class Settings {
         this.customThemeColor = customThemeColor;
     }
 
+    // ===== 标签译文颜色（#1047-5）=====
+    /** 跟随主题（默认）：译文与标签原文同色。 */
+    public static final int TAG_TRANSLATION_COLOR_FOLLOW_THEME = -2;
+
+    /**
+     * 标签译文颜色：-2 = 跟随主题；0..9 = 主题色目录预设；
+     * {@link ceui.pixiv.ui.settings.CustomThemeColor#INDEX} = 自定义色。
+     * 老配置没有该字段时按跟随主题处理（getter 兜底）。
+     */
+    private Integer tagTranslationColorIndex;
+
+    /** 标签译文自定义色的 #RRGGBB（仅 tagTranslationColorIndex 为自定义档时读取）。 */
+    private String tagTranslationColorCustomHex;
+
+    public int getTagTranslationColorIndex() {
+        if (tagTranslationColorIndex == null) {
+            return TAG_TRANSLATION_COLOR_FOLLOW_THEME;
+        }
+        return tagTranslationColorIndex;
+    }
+
+    public boolean isTagTranslationColorFollowTheme() {
+        return getTagTranslationColorIndex() == TAG_TRANSLATION_COLOR_FOLLOW_THEME;
+    }
+
+    public void setTagTranslationColorFollowTheme() {
+        this.tagTranslationColorIndex = TAG_TRANSLATION_COLOR_FOLLOW_THEME;
+    }
+
+    public void setTagTranslationColorIndex(int tagTranslationColorIndex) {
+        this.tagTranslationColorIndex = tagTranslationColorIndex;
+    }
+
+    public String getTagTranslationColorCustomHex() {
+        return tagTranslationColorCustomHex;
+    }
+
+    public void setTagTranslationColorCustomHex(String tagTranslationColorCustomHex) {
+        this.tagTranslationColorCustomHex = tagTranslationColorCustomHex;
+    }
+
     //主页显示R18
     private boolean mainViewR18 = false;
 

--- a/app/src/main/java/ceui/pixiv/ui/settings/CustomThemeColorSheet.kt
+++ b/app/src/main/java/ceui/pixiv/ui/settings/CustomThemeColorSheet.kt
@@ -103,11 +103,13 @@ class CustomThemeColorSheet : V3BottomSheetBase() {
     }
 
     /**
-     * 打开时的初始色：优先用户已存的自定义色，其次当前正在用的主题色 —— 从当前主题色起步，
-     * 用户微调一下就能得到「和现在差不多但更喜欢一点」的色，比每次都从纯红开始有用。
+     * 打开时的初始色：调用方显式给了 [ARG_INITIAL_HEX] 就用它（标签译文颜色模式传的是当前译文色，
+     * 不能拿主题的自定义色顶上）；否则优先用户已存的自定义主题色，其次当前正在用的主题色 ——
+     * 从当前主题色起步，用户微调一下就能得到「和现在差不多但更喜欢一点」的色，比每次都从纯红开始有用。
      */
     private fun initialColor(): Int =
-        CustomThemeColor.savedColor()
+        CustomThemeColor.normalize(arguments?.getString(ARG_INITIAL_HEX))?.let(Color::parseColor)
+            ?: CustomThemeColor.savedColor()
             ?: Color.parseColor(ThemeColorCatalog.hexOf(ceui.lisa.activities.Shaft.sSettings.themeIndex))
 
     private fun currentColor(): Int = Color.HSVToColor(floatArrayOf(hue, saturation, value))
@@ -142,5 +144,12 @@ class CustomThemeColorSheet : V3BottomSheetBase() {
     companion object {
         const val REQUEST_KEY = "custom_theme_color"
         const val KEY_HEX = "hex"
+        private const val ARG_INITIAL_HEX = "initial_hex"
+
+        /** 指定打开时的初始色（`#RRGGBB`）；null / 非法时回落 [initialColor] 的默认规则。 */
+        fun newInstance(initialHex: String?): CustomThemeColorSheet =
+            CustomThemeColorSheet().apply {
+                arguments = bundleOf(ARG_INITIAL_HEX to initialHex)
+            }
     }
 }

--- a/app/src/main/java/ceui/pixiv/ui/settings/ThemeColorFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/settings/ThemeColorFeedFragment.kt
@@ -147,8 +147,8 @@ class ThemeColorFeedFragment : FeedFragment(R.layout.fragment_toolbar_feed) {
             CustomThemeColorSheet().show(childFragmentManager, "custom_theme_color")
             return
         }
-        if (item.index == Shaft.sSettings.getTagTranslationColorIndex()) return
-        Shaft.sSettings.setTagTranslationColorIndex(item.index)
+        if (item.index == Shaft.sSettings.tagTranslationColorIndex) return
+        Shaft.sSettings.tagTranslationColorIndex = item.index
         Local.setSettings(Shaft.sSettings)
         Common.showToast(getString(R.string.string_428), 2)
         requireActivity().finish()
@@ -156,11 +156,11 @@ class ThemeColorFeedFragment : FeedFragment(R.layout.fragment_toolbar_feed) {
 
     /** 标签译文颜色自定义档：写盘后直接返回设置页，不需要重启。 */
     private fun onPickTagTranslationCustomColor(hex: String) {
-        val alreadyUsing = Shaft.sSettings.getTagTranslationColorIndex() == CustomThemeColor.INDEX &&
-                CustomThemeColor.normalize(Shaft.sSettings.getTagTranslationColorCustomHex()) == hex
+        val alreadyUsing = Shaft.sSettings.tagTranslationColorIndex == CustomThemeColor.INDEX &&
+                CustomThemeColor.normalize(Shaft.sSettings.tagTranslationColorCustomHex) == hex
         if (alreadyUsing) return
-        Shaft.sSettings.setTagTranslationColorIndex(CustomThemeColor.INDEX)
-        Shaft.sSettings.setTagTranslationColorCustomHex(hex)
+        Shaft.sSettings.tagTranslationColorIndex = CustomThemeColor.INDEX
+        Shaft.sSettings.tagTranslationColorCustomHex = hex
         Local.setSettings(Shaft.sSettings)
         Common.showToast(getString(R.string.string_428), 2)
         requireActivity().finish()
@@ -222,18 +222,18 @@ private fun themeColorItems(): List<FeedItem> {
  * 跟随主题（-2）时没有任何一行高亮 —— 该选项在设置页的弹窗里。
  */
 private fun tagTranslationColorItems(): List<FeedItem> {
-    val current = Shaft.sSettings.getTagTranslationColorIndex()
+    val current = Shaft.sSettings.tagTranslationColorIndex
     val presets = ThemeColorCatalog.entries.mapIndexed { index, entry ->
         ThemeColorFeedItem(index, entry.nameRes, entry.hex, index == current)
     }
     if (!CustomThemeColor.isSupported) return presets
-    val customHex = CustomThemeColor.normalize(Shaft.sSettings.getTagTranslationColorCustomHex())
+    val customHex = CustomThemeColor.normalize(Shaft.sSettings.tagTranslationColorCustomHex)
         ?: ThemeColorCatalog.hexOf(current.takeIf { it in ThemeColorCatalog.entries.indices } ?: 0)
     return presets + ThemeColorFeedItem(
         index = CustomThemeColor.INDEX,
         nameRes = R.string.custom_theme_color_entry,
         hex = customHex,
         selected = current == CustomThemeColor.INDEX &&
-                CustomThemeColor.normalize(Shaft.sSettings.getTagTranslationColorCustomHex()) == customHex,
+                CustomThemeColor.normalize(Shaft.sSettings.tagTranslationColorCustomHex) == customHex,
     )
 }

--- a/app/src/main/java/ceui/pixiv/ui/settings/ThemeColorFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/settings/ThemeColorFeedFragment.kt
@@ -37,20 +37,40 @@ class ThemeColorFeedFragment : FeedFragment(R.layout.fragment_toolbar_feed) {
 
     private val binding by viewBinding(FragmentToolbarFeedBinding::bind)
 
+    /** 是否为「标签译文颜色」选择模式（#1047-5）：选中颜色只写标签译文设置，不改主题。 */
+    private val selectTagTranslationColor by lazy {
+        arguments?.getBoolean(ARG_SELECT_TAG_TRANSLATION_COLOR, false) ?: false
+    }
+
     override val feedViewModel by feedViewModels<Int> {
-        // 零捕获：静态目录 + Settings 全局单例，source 不碰 Fragment（约定见 feedViewModels 文档）。
+        // 零捕获：先把 arguments 读成局部值，source 不碰 Fragment（约定见 feedViewModels 文档）。
         // 游标恒 null —— 十行就是全部，没有下一页。
-        FeedSource { FeedPage(themeColorItems(), null) }
+        val selectTagTranslationColor =
+            arguments?.getBoolean(ARG_SELECT_TAG_TRANSLATION_COLOR, false) ?: false
+        FeedSource {
+            FeedPage(
+                if (selectTagTranslationColor) tagTranslationColorItems() else themeColorItems(),
+                null
+            )
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setUpToolbar(binding, feedBinding.feedListView)
-        binding.toolbarTitle.text = getString(R.string.string_324)
+        binding.toolbarTitle.text = getString(
+            if (selectTagTranslationColor) R.string.tag_translation_color else R.string.string_324
+        )
         childFragmentManager.setFragmentResultListener(
             CustomThemeColorSheet.REQUEST_KEY, viewLifecycleOwner
         ) { _, bundle ->
-            bundle.getString(CustomThemeColorSheet.KEY_HEX)?.let(::onPickCustomColor)
+            bundle.getString(CustomThemeColorSheet.KEY_HEX)?.let { hex ->
+                if (selectTagTranslationColor) {
+                    onPickTagTranslationCustomColor(hex)
+                } else {
+                    onPickCustomColor(hex)
+                }
+            }
         }
     }
 
@@ -69,7 +89,13 @@ class ThemeColorFeedFragment : FeedFragment(R.layout.fragment_toolbar_feed) {
 
     private fun themeColorRenderer() = feedRenderer<ThemeColorFeedItem, CellThemeColorBinding>(
         inflate = CellThemeColorBinding::inflate,
-        create = { cell -> cell.binding.root.setOnClickListener { onPickColor(cell.item) } },
+        create = { cell -> cell.binding.root.setOnClickListener {
+            if (selectTagTranslationColor) {
+                onPickTagTranslationColor(cell.item)
+            } else {
+                onPickColor(cell.item)
+            }
+        } },
     ) { cell ->
         val item = cell.item
         // 卡片本身就是色块；hex 全部来自目录里的字面量，parseColor 不会抛。
@@ -112,6 +138,46 @@ class ThemeColorFeedFragment : FeedFragment(R.layout.fragment_toolbar_feed) {
         Common.restart()
         Common.showToast(getString(R.string.string_428), 2)
     }
+
+    /**
+     * 标签译文颜色模式：选预设只写标签译文设置，不改主题、不重启，选完直接返回设置页。
+     */
+    private fun onPickTagTranslationColor(item: ThemeColorFeedItem) {
+        if (item.index == CustomThemeColor.INDEX) {
+            CustomThemeColorSheet().show(childFragmentManager, "custom_theme_color")
+            return
+        }
+        if (item.index == Shaft.sSettings.getTagTranslationColorIndex()) return
+        Shaft.sSettings.setTagTranslationColorIndex(item.index)
+        Local.setSettings(Shaft.sSettings)
+        Common.showToast(getString(R.string.string_428), 2)
+        requireActivity().finish()
+    }
+
+    /** 标签译文颜色自定义档：写盘后直接返回设置页，不需要重启。 */
+    private fun onPickTagTranslationCustomColor(hex: String) {
+        val alreadyUsing = Shaft.sSettings.getTagTranslationColorIndex() == CustomThemeColor.INDEX &&
+                CustomThemeColor.normalize(Shaft.sSettings.getTagTranslationColorCustomHex()) == hex
+        if (alreadyUsing) return
+        Shaft.sSettings.setTagTranslationColorIndex(CustomThemeColor.INDEX)
+        Shaft.sSettings.setTagTranslationColorCustomHex(hex)
+        Local.setSettings(Shaft.sSettings)
+        Common.showToast(getString(R.string.string_428), 2)
+        requireActivity().finish()
+    }
+
+    companion object {
+        /** 设置页从「从主题色彩页中选择」进入时置 true，本页变成标签译文颜色选择器。 */
+        const val ARG_SELECT_TAG_TRANSLATION_COLOR = "select_tag_translation_color"
+
+        @JvmStatic
+        fun newInstance(selectTagTranslationColor: Boolean): ThemeColorFeedFragment =
+            ThemeColorFeedFragment().apply {
+                arguments = Bundle().apply {
+                    putBoolean(ARG_SELECT_TAG_TRANSLATION_COLOR, selectTagTranslationColor)
+                }
+            }
+    }
 }
 
 /**
@@ -148,5 +214,26 @@ private fun themeColorItems(): List<FeedItem> {
         nameRes = R.string.custom_theme_color_entry,
         hex = customHex,
         selected = current == CustomThemeColor.INDEX,
+    )
+}
+
+/**
+ * 标签译文颜色模式的列表数据：同样复用主题色目录和自定义档，但 selected 以标签译文设置为准。
+ * 跟随主题（-2）时没有任何一行高亮 —— 该选项在设置页的弹窗里。
+ */
+private fun tagTranslationColorItems(): List<FeedItem> {
+    val current = Shaft.sSettings.getTagTranslationColorIndex()
+    val presets = ThemeColorCatalog.entries.mapIndexed { index, entry ->
+        ThemeColorFeedItem(index, entry.nameRes, entry.hex, index == current)
+    }
+    if (!CustomThemeColor.isSupported) return presets
+    val customHex = CustomThemeColor.normalize(Shaft.sSettings.getTagTranslationColorCustomHex())
+        ?: ThemeColorCatalog.hexOf(current.takeIf { it in ThemeColorCatalog.entries.indices } ?: 0)
+    return presets + ThemeColorFeedItem(
+        index = CustomThemeColor.INDEX,
+        nameRes = R.string.custom_theme_color_entry,
+        hex = customHex,
+        selected = current == CustomThemeColor.INDEX &&
+                CustomThemeColor.normalize(Shaft.sSettings.getTagTranslationColorCustomHex()) == customHex,
     )
 }

--- a/app/src/main/java/ceui/pixiv/ui/settings/ThemeColorFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/settings/ThemeColorFeedFragment.kt
@@ -144,7 +144,8 @@ class ThemeColorFeedFragment : FeedFragment(R.layout.fragment_toolbar_feed) {
      */
     private fun onPickTagTranslationColor(item: ThemeColorFeedItem) {
         if (item.index == CustomThemeColor.INDEX) {
-            CustomThemeColorSheet().show(childFragmentManager, "custom_theme_color")
+            // 初始色给这一行展示的 hex（当前译文自定义色 / 回落值），不能让 picker 默认去读主题的自定义色。
+            CustomThemeColorSheet.newInstance(item.hex).show(childFragmentManager, "custom_theme_color")
             return
         }
         if (item.index == Shaft.sSettings.tagTranslationColorIndex) return
@@ -220,13 +221,15 @@ private fun themeColorItems(): List<FeedItem> {
 /**
  * 标签译文颜色模式的列表数据：同样复用主题色目录和自定义档，但 selected 以标签译文设置为准。
  * 跟随主题（-2）时没有任何一行高亮 —— 该选项在设置页的弹窗里。
+ *
+ * 自定义档这里**不**看 [CustomThemeColor.isSupported]：那个门槛是主题色要靠 API 30 的
+ * ResourcesLoader 才能送进 `?attr/colorPrimary`；译文色只是一个 ForegroundColorSpan，任何版本都能画。
  */
 private fun tagTranslationColorItems(): List<FeedItem> {
     val current = Shaft.sSettings.tagTranslationColorIndex
     val presets = ThemeColorCatalog.entries.mapIndexed { index, entry ->
         ThemeColorFeedItem(index, entry.nameRes, entry.hex, index == current)
     }
-    if (!CustomThemeColor.isSupported) return presets
     val customHex = CustomThemeColor.normalize(Shaft.sSettings.tagTranslationColorCustomHex)
         ?: ThemeColorCatalog.hexOf(current.takeIf { it in ThemeColorCatalog.entries.indices } ?: 0)
     return presets + ThemeColorFeedItem(

--- a/app/src/main/java/ceui/pixiv/widgets/V3TagFlowView.kt
+++ b/app/src/main/java/ceui/pixiv/widgets/V3TagFlowView.kt
@@ -215,10 +215,14 @@ class V3TagFlowView @JvmOverloads constructor(
     private fun renderPairs(pairs: List<Pair<String, String?>>) {
         val prevCount = lastPairs.size
         lastPairs = pairs
+        // 译文色每次渲染算一次（不在 chip 循环里逐个算），并进签名：设置页改完色回来同一组
+        // tags 再 setTags 也要重画，不能被 dedupe 吞掉。
+        val translationColor = tagTranslationColor()
         val sig = buildString {
             pairs.forEach { (n, t) ->
                 append(n); append('|'); append(t ?: ""); append(';')
             }
+            append('#'); append(translationColor)
         }
         if (sig == lastSignature && childCount > 0) return
         lastSignature = sig
@@ -271,7 +275,7 @@ class V3TagFlowView @JvmOverloads constructor(
                     )
                     if (originalEnd < length) {
                         setSpan(
-                            ForegroundColorSpan(tagTranslationColor(palette)),
+                            ForegroundColorSpan(translationColor),
                             originalEnd, length,
                             Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
                         )
@@ -390,22 +394,22 @@ class V3TagFlowView @JvmOverloads constructor(
     }
 
     /**
-     * 标签译文颜色（#1047-5）：跟随主题时与原文同色，否则取主题色目录/自定义色。
-     * 任何异常配置都回落原文色，保证可读性。
+     * 标签译文颜色（#1047-5）：跟随主题时与原文同色；否则把所选色（目录预设 / 自定义 hex）
+     * 按 [V3Palette.textTag] 同一套压暗/压亮规则处理后再用 —— 原文色本身就是主题色这么派生的，
+     * 目录里的裸 hex（浅色底上的 #fee65e 夏日黄、深色底上的 #673AB7 经典紫）直接涂上去看不清。
+     * 只钳 HSL 的 L，色相饱和度不动，用户选的还是那个色。任何异常配置都回落原文色。
      */
-    private fun tagTranslationColor(palette: V3Palette): Int {
+    private fun tagTranslationColor(): Int {
         val settings = Shaft.sSettings ?: return palette.textTag
         if (settings.isTagTranslationColorFollowTheme) return palette.textTag
         val index = settings.tagTranslationColorIndex
-        if (index == CustomThemeColor.INDEX) {
-            CustomThemeColor.normalize(settings.tagTranslationColorCustomHex)
-                ?.let { return it.toColorInt() }
-            return palette.textTag
-        }
-        if (index in ThemeColorCatalog.entries.indices) {
-            return ThemeColorCatalog.hexOf(index).toColorInt()
-        }
-        return palette.textTag
+        val hex = when {
+            index == CustomThemeColor.INDEX ->
+                CustomThemeColor.normalize(settings.tagTranslationColorCustomHex)
+            index in ThemeColorCatalog.entries.indices -> ThemeColorCatalog.hexOf(index)
+            else -> null
+        } ?: return palette.textTag
+        return V3Palette(hex.toColorInt(), palette.isDark).textTag
     }
 
     private fun ensureEditor(): EditText {

--- a/app/src/main/java/ceui/pixiv/widgets/V3TagFlowView.kt
+++ b/app/src/main/java/ceui/pixiv/widgets/V3TagFlowView.kt
@@ -3,7 +3,11 @@ package ceui.pixiv.widgets
 import android.content.ClipData
 import android.content.Context
 import android.content.Intent
+import android.graphics.Color
 import android.text.InputType
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.style.ForegroundColorSpan
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
@@ -23,6 +27,8 @@ import ceui.lisa.utils.Params
 import ceui.lisa.utils.PixivOperate
 import ceui.lisa.utils.SearchTypeUtil
 import ceui.pixiv.witstudio.theme.V3Palette
+import ceui.pixiv.ui.settings.CustomThemeColor
+import ceui.pixiv.ui.settings.ThemeColorCatalog
 import ceui.loxia.Tag
 import ceui.pixiv.ui.synonym.SynonymOperate
 import ceui.pixiv.utils.ppppx
@@ -248,11 +254,27 @@ class V3TagFlowView @JvmOverloads constructor(
                 else -> gap
             }
             val tv = TextView(context).apply {
-                text = buildString {
+                val translationSuffix =
+                    if (showTranslation && !translated.isNullOrBlank()) "  $translated" else ""
+                val fullText = buildString {
                     if (showHashPrefix) append("# ")
                     append(name)
-                    if (showTranslation && !translated.isNullOrBlank()) {
-                        append("  "); append(translated)
+                    append(translationSuffix)
+                }
+                // #1047-5：原文与译文用 SpannableString 分别上色，避免整段 setTextColor 混在一起。
+                text = SpannableString(fullText).apply {
+                    val originalEnd = fullText.length - translationSuffix.length
+                    setSpan(
+                        ForegroundColorSpan(palette.textTag),
+                        0, originalEnd,
+                        Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+                    )
+                    if (originalEnd < length) {
+                        setSpan(
+                            ForegroundColorSpan(tagTranslationColor(palette)),
+                            originalEnd, length,
+                            Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+                        )
                     }
                 }
                 textSize = chipTextSize
@@ -365,6 +387,25 @@ class V3TagFlowView @JvmOverloads constructor(
                 hsv.post { hsv.fullScroll(View.FOCUS_RIGHT) }
             }
         }
+    }
+
+    /**
+     * 标签译文颜色（#1047-5）：跟随主题时与原文同色，否则取主题色目录/自定义色。
+     * 任何异常配置都回落原文色，保证可读性。
+     */
+    private fun tagTranslationColor(palette: V3Palette): Int {
+        val settings = Shaft.sSettings ?: return palette.textTag
+        if (settings.isTagTranslationColorFollowTheme()) return palette.textTag
+        val index = settings.tagTranslationColorIndex
+        if (index == CustomThemeColor.INDEX) {
+            CustomThemeColor.normalize(settings.tagTranslationColorCustomHex)
+                ?.let { return Color.parseColor(it) }
+            return palette.textTag
+        }
+        if (index in ThemeColorCatalog.entries.indices) {
+            return Color.parseColor(ThemeColorCatalog.hexOf(index))
+        }
+        return palette.textTag
     }
 
     private fun ensureEditor(): EditText {

--- a/app/src/main/java/ceui/pixiv/widgets/V3TagFlowView.kt
+++ b/app/src/main/java/ceui/pixiv/widgets/V3TagFlowView.kt
@@ -3,7 +3,6 @@ package ceui.pixiv.widgets
 import android.content.ClipData
 import android.content.Context
 import android.content.Intent
-import android.graphics.Color
 import android.text.InputType
 import android.text.Spannable
 import android.text.SpannableString
@@ -17,6 +16,7 @@ import android.widget.EditText
 import android.widget.HorizontalScrollView
 import android.widget.TextView
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.graphics.toColorInt
 import ceui.lisa.R
 import ceui.lisa.activities.SearchActivity
 import ceui.lisa.activities.Shaft
@@ -395,15 +395,15 @@ class V3TagFlowView @JvmOverloads constructor(
      */
     private fun tagTranslationColor(palette: V3Palette): Int {
         val settings = Shaft.sSettings ?: return palette.textTag
-        if (settings.isTagTranslationColorFollowTheme()) return palette.textTag
+        if (settings.isTagTranslationColorFollowTheme) return palette.textTag
         val index = settings.tagTranslationColorIndex
         if (index == CustomThemeColor.INDEX) {
             CustomThemeColor.normalize(settings.tagTranslationColorCustomHex)
-                ?.let { return Color.parseColor(it) }
+                ?.let { return it.toColorInt() }
             return palette.textTag
         }
         if (index in ThemeColorCatalog.entries.indices) {
-            return Color.parseColor(ThemeColorCatalog.hexOf(index))
+            return ThemeColorCatalog.hexOf(index).toColorInt()
         }
         return palette.textTag
     }

--- a/app/src/main/res/layout/fragment_settings_appearance.xml
+++ b/app/src/main/res/layout/fragment_settings_appearance.xml
@@ -94,6 +94,26 @@
                 </RelativeLayout>
 
                 <RelativeLayout
+                    android:id="@+id/tag_translation_color_rela"
+                    style="@style/M3SetRow"
+                    android:background="@drawable/wit_row_mid">
+
+                    <LinearLayout
+                        style="@style/M3SetTexts"
+                        android:layout_marginEnd="130dp">
+
+                        <TextView
+                            style="@style/M3SetTitle"
+                            android:text="@string/tag_translation_color" />
+                    </LinearLayout>
+
+                    <TextView
+                        android:id="@+id/tag_translation_color"
+                        style="@style/M3SetValue" />
+
+                </RelativeLayout>
+
+                <RelativeLayout
                     android:id="@+id/app_language_rela"
                     style="@style/M3SetRow"
                     android:background="@drawable/wit_row_bottom">

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -549,6 +549,9 @@
     <string name="string_322">My fans</string>
     <string name="string_323">My good friend p</string>
     <string name="string_324">Theme color</string>
+    <string name="tag_translation_color">Tag translation color</string>
+    <string name="tag_translation_color_follow_theme">Follow theme</string>
+    <string name="tag_translation_color_pick_from_theme_page">Choose from theme color page</string>
     <string name="string_325">Go to settings</string>
     <string name="string_326">start</string>
     <string name="string_327">Suspend</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -549,6 +549,9 @@
     <string name="string_322">フォロワー</string>
     <string name="string_323">マイピク</string>
     <string name="string_324">テーマカラー</string>
+    <string name="tag_translation_color">タグ翻訳色</string>
+    <string name="tag_translation_color_follow_theme">テーマに従う</string>
+    <string name="tag_translation_color_pick_from_theme_page">テーマカラーページから選択</string>
     <string name="string_325">設定を開く</string>
     <string name="string_326">開始</string>
     <string name="string_327">停止</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -549,6 +549,9 @@
     <string name="string_322">내 팬.</string>
     <string name="string_323">나의 좋 은 P 친구</string>
     <string name="string_324">테마 컬러</string>
+    <string name="tag_translation_color">태그 번역 색상</string>
+    <string name="tag_translation_color_follow_theme">테마 따르기</string>
+    <string name="tag_translation_color_pick_from_theme_page">테마 색상 페이지에서 선택</string>
     <string name="string_325">클릭 설정</string>
     <string name="string_326">시작 하 다.</string>
     <string name="string_327">잠시 멈추다.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -549,6 +549,9 @@
     <string name="string_322">Мои подписчики</string>
     <string name="string_323">Мои P-друзья</string>
     <string name="string_324">Цвет темы</string>
+    <string name="tag_translation_color">Цвет перевода тега</string>
+    <string name="tag_translation_color_follow_theme">Следовать теме</string>
+    <string name="tag_translation_color_pick_from_theme_page">Выбрать на странице цветов темы</string>
     <string name="string_325">Перейти к настройкам</string>
     <string name="string_326">Начать</string>
     <string name="string_327">Приостановить</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -549,6 +549,9 @@
     <string name="string_322">Hayranlarım</string>
     <string name="string_323">P-Arkadaşlarım</string>
     <string name="string_324">Tema rengi</string>
+    <string name="tag_translation_color">Etiket çeviri rengi</string>
+    <string name="tag_translation_color_follow_theme">Temayı takip et</string>
+    <string name="tag_translation_color_pick_from_theme_page">Tema renk sayfasından seç</string>
     <string name="string_325">Ayarlara git</string>
     <string name="string_326">Başlat</string>
     <string name="string_327">Durdur</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -551,6 +551,9 @@
     <string name="string_322">我的粉絲</string>
     <string name="string_323">我的好P友</string>
     <string name="string_324">主題色彩</string>
+    <string name="tag_translation_color">標籤譯文顏色</string>
+    <string name="tag_translation_color_follow_theme">跟隨主題</string>
+    <string name="tag_translation_color_pick_from_theme_page">從主題色彩頁中選擇</string>
     <string name="string_325">點擊設定</string>
     <string name="string_326">開始</string>
     <string name="string_327">暫停</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -573,6 +573,9 @@
     <string name="string_322">我的粉丝</string>
     <string name="string_323">我的好P友</string>
     <string name="string_324">主题色彩</string>
+    <string name="tag_translation_color">标签译文颜色</string>
+    <string name="tag_translation_color_follow_theme">跟随主题</string>
+    <string name="tag_translation_color_pick_from_theme_page">从主题色彩页中选择</string>
     <string name="string_325">点击设置</string>
     <string name="string_326">开始</string>
     <string name="string_327">暂停</string>


### PR DESCRIPTION
# 标签区分原文与翻译：新增「标签译文颜色」设置

> 分支：`patch-#1047-5`（wangwang-code fork）
> 提交：
> - `8cf62f318` feat(tags): 标签译文颜色可独立设置，区分原文与翻译（#1047-5）
> - `1621339f1` refactor(tags): 收敛标签译文颜色代码并补全多语言（#1047-5）

## 背景

对应 [CeuiLiSA/Pixiv-Shaft#1047](https://github.com/CeuiLiSA/Pixiv-Shaft/issues/1047) 第 5 点：标签区分原文和翻译。

作品标签（小说与插画都涉及）目前把「原文 + 译文」拼接后整体 `setTextColor`，原文和译文显示的文本颜色完全相同，有翻译的标签与没有翻译的标签混在一起，难以一眼区分。

本次改动让标签原文与译文可以分别上色，并提供「标签译文颜色」设置项，可选择跟随主题或从主题色彩页中挑选（或自定义）一个颜色作为译文颜色。

## 改动内容

### 1. V3TagFlowView 原文 / 译文分色显示

- 不再使用拼接后整体 `setTextColor`。
- 改用 `SpannableString`：
  - 原文（含 `# ` 前缀）继续使用 `palette.textTag`
  - 译文使用新增的「标签译文颜色」设置值
- `V3TagFlowView` 同时被小说与插画场景复用：
  - 小说：`NovelTextFeed` 等
  - 插画：`ArtworkSectionRenderers` 等

### 2. 设置页新增「标签译文颜色」

- 位置：设置 → 界面 → 「主题色彩」下方
- 点击后使用项目惯用的 `WitDialog.CheckableDialogBuilder` 弹窗，两个选项：
  - 跟随主题（默认，保持原行为：译文与原文同色）
  - 从主题色彩页中选择
- 展示方式与「主题色彩」同款：
  - 跟随主题：显示「跟随主题」
  - 预设色：显示主题色名称
  - 自定义色：显示「自定义 + HEX」

### 3. 复用主题色彩页作为标签译文颜色选择器

- `ThemeColorFeedFragment` 增加「标签译文颜色选择模式」。
- 从设置弹窗选择「从主题色彩页中选择」后，打开同款色卡页，标题为「标签译文颜色」。
- 选择预设或自定义色后只写标签译文设置，不改变主题、不重启，选完直接返回设置页。
- 设置页通过 `onResume` 刷新该行显示值。

### 4. 设置持久化与搜索

- `Settings.java` 新增：
  - `tagTranslationColorIndex`：`-2` = 跟随主题；`0..9` = 主题色预设；`-1` = 自定义
  - `tagTranslationColorCustomHex`：自定义标签译文颜色 HEX
- 老配置缺少该字段时按「跟随主题」处理。
- `SettingsCatalog` 已加入搜索索引，支持「标签译文颜色 / 标签译文 / 翻译颜色 / 跟随主题」等搜索。

### 5. 代码收敛

- 按 Android Studio 检查建议收敛新增代码：
  - Kotlin 侧改为属性访问 Java getter/setter
  - Java 侧移除恒真判断、使用 import 替代全限定名
  - 色值解析改用 `toColorInt()` 扩展，移除未使用 import

### 6. 多语言

- 补全默认中文、繁中、英文、日文、韩文、俄文、土耳其文的新增文案。

## 涉及文件

- `app/src/main/java/ceui/lisa/activities/TemplateActivity.java`
- `app/src/main/java/ceui/lisa/fragments/FragmentSettingsAppearance.java`
- `app/src/main/java/ceui/lisa/fragments/SettingsCatalog.kt`
- `app/src/main/java/ceui/lisa/utils/Settings.java`
- `app/src/main/java/ceui/pixiv/ui/settings/ThemeColorFeedFragment.kt`
- `app/src/main/java/ceui/pixiv/widgets/V3TagFlowView.kt`
- `app/src/main/res/layout/fragment_settings_appearance.xml`
- `app/src/main/res/values/strings.xml`
- `app/src/main/res/values-en/strings.xml`
- `app/src/main/res/values-ja/strings.xml`
- `app/src/main/res/values-ko/strings.xml`
- `app/src/main/res/values-ru/strings.xml`
- `app/src/main/res/values-tr/strings.xml`
- `app/src/main/res/values-zh-rTW/strings.xml`
