### PR TITLE
小说系列「作品列表」标签跟随「小说列表标签折叠」设置 (#1047)

### DIFF
--- a/app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFeed.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFeed.kt
@@ -344,7 +344,9 @@ private fun bindNovelCardBookmark(
 private fun bindNovelCardTags(b: CellNovelV3Binding, novel: Novel, palette: V3Palette) {
     val tags = novel.tags
     val ctx = b.root.context
-    if (tags.isNullOrEmpty()) {
+    // 与主力小说卡同一套设置（#982/#1047）：「小说列表显示标签」关闭时整体隐藏；
+    // 「小说列表标签折叠」开启时超 6 个折叠成「+N」，关闭时 maxTags=-1 全量展示。
+    if (tags.isNullOrEmpty() || !Shaft.sSettings.isShowNovelCardTags) {
         b.tagsSection.isVisible = false
         return
     }
@@ -352,40 +354,44 @@ private fun bindNovelCardTags(b: CellNovelV3Binding, novel: Novel, palette: V3Pa
     b.tagsFlow.removeAllViews()
     val density = ctx.resources.displayMetrics.density
     val tagBg = palette.tagLockedBg(999f * density).constantState
-    val maxTags = 6
-    tags.take(maxTags).forEach { tag ->
-        val tv = TextView(ctx).apply {
-            // 列表条目只显示 tag 原文，译名进详情页看（#1038，与主力小说卡同口径）
-            text = "# ${tag.name ?: ""}"
-            textSize = 11f
-            setTextColor(palette.textTag)
-            background = tagBg?.newDrawable()?.mutate()
-            setPaddingRelative(10.ppppx, 5.ppppx, 10.ppppx, 5.ppppx)
-            layoutParams = FlexboxLayout.LayoutParams(
-                ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT,
-            ).apply { setMargins(0, 0, 6.ppppx, 6.ppppx); flexShrink = 0f }
-            setOnClickListener {
-                val intent = Intent(ctx, SearchActivity::class.java).apply {
-                    putExtra(Params.KEY_WORD, tag.name)
-                    putExtra(Params.INDEX, 1)
-                }
-                ctx.startActivity(intent)
-            }
+    val maxTags = if (Shaft.sSettings.isCollapseNovelCardTags) 6 else -1
+    val visibleTags = if (maxTags > 0) tags.take(maxTags) else tags
+    visibleTags.forEach { tag ->
+        val tv = TextView(ctx)
+        // 列表条目只显示 tag 原文，译名进详情页看（#1038，与主力小说卡同口径）
+        tv.text = "# ${tag.name ?: ""}"
+        tv.textSize = 11f
+        tv.setTextColor(palette.textTag)
+        tv.background = tagBg?.newDrawable()?.mutate()
+        tv.setPaddingRelative(10.ppppx, 5.ppppx, 10.ppppx, 5.ppppx)
+        val lp = FlexboxLayout.LayoutParams(
+            ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT,
+        )
+        lp.setMargins(0, 0, 6.ppppx, 6.ppppx)
+        lp.flexShrink = 0f
+        tv.layoutParams = lp
+        tv.setOnClickListener {
+            val intent = Intent(ctx, SearchActivity::class.java)
+                .putExtra(Params.KEY_WORD, tag.name)
+                .putExtra(Params.INDEX, 1)
+            ctx.startActivity(intent)
         }
         applyCardTouchScale(tv, 0.94f)
         b.tagsFlow.addView(tv)
     }
-    if (tags.size > maxTags) {
-        val overflow = TextView(ctx).apply {
-            text = "+${tags.size - maxTags}"
-            textSize = 11f
-            setTextColor(palette.textSecondary)
-            background = tagBg?.newDrawable()?.mutate()
-            setPaddingRelative(10.ppppx, 5.ppppx, 10.ppppx, 5.ppppx)
-            layoutParams = FlexboxLayout.LayoutParams(
-                ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT,
-            ).apply { setMargins(0, 0, 6.ppppx, 6.ppppx); flexShrink = 0f }
-        }
+    if (maxTags > 0 && tags.size > maxTags) {
+        val overflow = TextView(ctx)
+        overflow.text = "+${tags.size - maxTags}"
+        overflow.textSize = 11f
+        overflow.setTextColor(palette.textSecondary)
+        overflow.background = tagBg?.newDrawable()?.mutate()
+        overflow.setPaddingRelative(10.ppppx, 5.ppppx, 10.ppppx, 5.ppppx)
+        val overflowLp = FlexboxLayout.LayoutParams(
+            ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT,
+        )
+        overflowLp.setMargins(0, 0, 6.ppppx, 6.ppppx)
+        overflowLp.flexShrink = 0f
+        overflow.layoutParams = overflowLp
         b.tagsFlow.addView(overflow)
     }
 }


### PR DESCRIPTION
# 小说系列「作品列表」标签跟随「小说列表标签折叠」设置

> 分支：`patch-#1047-bug1`（wangwang-code fork）
> 提交：`4b784739a` fix(novel): 小说系列「作品列表」标签跟随「小说列表标签折叠」设置 (#1047)

## 背景

对应 [CeuiLiSA/Pixiv-Shaft#1047](https://github.com/CeuiLiSA/Pixiv-Shaft/issues/1047) 的后续反馈：系列内界面与其他小说列表不统一。

#982 已为普通小说列表加入「小说列表标签折叠」设置，关闭后标签全量展示；但小说系列详情页的「作品列表」仍然硬编码只显示 6 个标签并追加 `+N`，导致用户即使在设置里关闭了折叠，系列内的小说标签依然显示不全。

本次改动回补 #982 遗漏的系列内小说卡，让系列「作品列表」与普通小说列表、搜索小说列表共用同一套标签显示设置。

## 改动内容

### `NovelSeriesFeed.bindNovelCardTags` 跟随小说标签设置

- 读取 `Shaft.sSettings.isShowNovelCardTags`：
  - 设置里关闭「小说列表显示标签」时，整块标签区域隐藏；
  - 开启时按设置继续显示标签。
- 读取 `Shaft.sSettings.isCollapseNovelCardTags`：
  - 开启（默认）时维持原行为：最多展示 6 个，超出显示 `+N`；
  - 关闭时 `maxTags = -1`，标签全量展示，不再截断。
- 标签点击、原文显示、`#` 前缀等行为与主力小说卡保持一致。

### 按 AS inspection 收敛新增代码

- 设置项改用 Kotlin 属性访问语法（消除 `UsePropertyAccessSyntax`）。
- 去掉 `apply` 隐式 `this`，标签 chip 与溢出 chip 改为直接赋值/方法调用（消除改动范围内的 `ImplicitThis`）。
- 改动函数经 Android Studio inspection 无诊断。

## 涉及文件

- `app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFeed.kt`
