### PR TITLE
fix(novel): 纵向滚动中点击停滚时不呼出菜单栏 (#1047)

### DIFF
--- a/app/src/main/java/ceui/pixiv/ui/novel/reader/render/NovelScrollReaderView.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/reader/render/NovelScrollReaderView.kt
@@ -67,8 +67,7 @@ class NovelScrollReaderView(context: Context) : RecyclerView(context) {
     var selectionMenuEntries: List<Pair<Int, String>> = emptyList()
     var onSelectionMenuAction: ((id: Int) -> Unit)? = null
 
-    /** 记录 RecyclerView 最近一次滚动状态，区分“滚动中点击停滚”与“静止时单击呼出菜单”（#1047）。 */
-    private var scrollState = SCROLL_STATE_IDLE
+    /** 手指落下那一刻 RecyclerView 是否还在滚动，区分“滚动中点击停滚”与“静止时单击呼出菜单”（#1047）。 */
     private var wasScrollingOnTouchDown = false
 
     private val lm = LinearLayoutManager(context)
@@ -106,7 +105,6 @@ class NovelScrollReaderView(context: Context) : RecyclerView(context) {
             }
 
             override fun onScrollStateChanged(rv: RecyclerView, newState: Int) {
-                scrollState = newState
                 if (newState == RecyclerView.SCROLL_STATE_IDLE) {
                     onCharIndexChanged?.invoke(currentCharIndex())
                 }
@@ -116,8 +114,9 @@ class NovelScrollReaderView(context: Context) : RecyclerView(context) {
 
     override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
         if (ev.actionMasked == MotionEvent.ACTION_DOWN) {
-            // 在手指落下前先记住 RecyclerView 是否还在滚动：这次单击如果发生在
-            // 滚动中，ACTION_UP 后状态可能已被点击停滚改成 IDLE，不能再用来判断（#1047）。
+            // 在手指落下前先记住 RecyclerView 是否还在滚动（super.dispatchTouchEvent 里
+            // onInterceptTouchEvent 会把 SETTLING 改成 DRAGGING，ACTION_UP 后更是 IDLE，
+            // 再晚就判不出来了），所以必须在这里、交给 super 之前读 scrollState（#1047）。
             wasScrollingOnTouchDown = scrollState != SCROLL_STATE_IDLE
         }
         gestureDetector.onTouchEvent(ev)

--- a/app/src/main/java/ceui/pixiv/ui/novel/reader/render/NovelScrollReaderView.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/reader/render/NovelScrollReaderView.kt
@@ -67,11 +67,20 @@ class NovelScrollReaderView(context: Context) : RecyclerView(context) {
     var selectionMenuEntries: List<Pair<Int, String>> = emptyList()
     var onSelectionMenuAction: ((id: Int) -> Unit)? = null
 
+    /** 记录 RecyclerView 最近一次滚动状态，区分“滚动中点击停滚”与“静止时单击呼出菜单”（#1047）。 */
+    private var scrollState = SCROLL_STATE_IDLE
+    private var wasScrollingOnTouchDown = false
+
     private val lm = LinearLayoutManager(context)
     private var contentAdapter: ContentAdapter? = null
 
     private val gestureDetector = GestureDetector(context, object : GestureDetector.SimpleOnGestureListener() {
         override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
+            // 滚动中点击只负责停滚，不呼出菜单；等滚动完全停下后再单击才呼出（#1047）。
+            if (wasScrollingOnTouchDown) {
+                wasScrollingOnTouchDown = false
+                return true
+            }
             // 纵向滚动没有左右翻页语义，整屏单击都呼出菜单——不是横向那套三分区
             //（只留中间一竖条反直觉，#1038）。落在插画/跳转按钮上的点击让给它们自己的
             // onClick，避免「打开大图的同时菜单也弹出来」。
@@ -97,6 +106,7 @@ class NovelScrollReaderView(context: Context) : RecyclerView(context) {
             }
 
             override fun onScrollStateChanged(rv: RecyclerView, newState: Int) {
+                scrollState = newState
                 if (newState == RecyclerView.SCROLL_STATE_IDLE) {
                     onCharIndexChanged?.invoke(currentCharIndex())
                 }
@@ -105,6 +115,11 @@ class NovelScrollReaderView(context: Context) : RecyclerView(context) {
     }
 
     override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+        if (ev.actionMasked == MotionEvent.ACTION_DOWN) {
+            // 在手指落下前先记住 RecyclerView 是否还在滚动：这次单击如果发生在
+            // 滚动中，ACTION_UP 后状态可能已被点击停滚改成 IDLE，不能再用来判断（#1047）。
+            wasScrollingOnTouchDown = scrollState != SCROLL_STATE_IDLE
+        }
         gestureDetector.onTouchEvent(ev)
         return super.dispatchTouchEvent(ev)
     }


### PR DESCRIPTION
# 纵向滚动中点击停滚时不呼出菜单栏

> 分支：`patch-#1047-4`（wangwang-code fork）
> 提交：`6f824957` fix(novel): 纵向滚动中点击停滚时不呼出菜单栏 (#1047)

## 背景

对应 [CeuiLiSA/Pixiv-Shaft#1047](https://github.com/CeuiLiSA/Pixiv-Shaft/issues/1047) 的第 4 点反馈：

阅读方向为纵向滚动时，快速滑动屏幕触发滚动后，在滚动中再次点击屏幕会停止滚动，但此时会**同时触发“呼出菜单栏”操作**。

用户核心诉求：

- 滚动中的点击只负责停下滚动；
- 不唤出菜单栏；
- 只有在静止状态下点击屏幕，才呼出菜单栏。

## 改动内容

### `NovelScrollReaderView` 增加“滚动中点击停滚”判断

- 新增 `scrollState` 字段，记录 RecyclerView 当前滚动状态；
- 新增 `wasScrollingOnTouchDown` 字段，在 `dispatchTouchEvent` 的 `ACTION_DOWN` 时记录“手指落下前是否还在滚动”；
- `onScrollStateChanged` 中同步更新 `scrollState`；
- `onSingleTapConfirmed` 中：
  - 如果这次点击落下时 RecyclerView 还在滚动，则只消费本次点击、不调用 `onCenterTap`，因此不会呼出菜单；
  - 如果已经静止，则维持原有行为，单击呼出菜单栏。

关键点：必须在 `ACTION_DOWN` 时记录滚动状态，因为点击停滚后 `ACTION_UP` 时 RecyclerView 可能已经变成 `IDLE`，若在确认单击时才判断会误判为静止点击。

## 涉及文件

- `app/src/main/java/ceui/pixiv/ui/novel/reader/render/NovelScrollReaderView.kt`
