### PR TITLE
修复动态页刷新后分页加载被“静默吃掉”（IllustFeedFragment 触底预取补发）

### DIFF
--- a/feeds/src/main/java/ceui/pixiv/feeds/FeedAdapter.kt
+++ b/feeds/src/main/java/ceui/pixiv/feeds/FeedAdapter.kt
@@ -91,7 +91,7 @@ class FeedAdapter(
         } else {
             renderer.onBind(cell, payloads)
         }
-        if (onNearEnd != null && position >= itemCount - prefetchDistance) {
+        if (onNearEnd != null && isNearEnd(position)) {
             onNearEnd.invoke()
         }
     }
@@ -115,6 +115,9 @@ class FeedAdapter(
         if (position !in 0 until itemCount) return 1
         return renderers[getItemViewType(position)].spanSize(spanCount)
     }
+
+    /** 是否处于触底预取区；供 [FeedFragment] 在列表提交后补一次预取检查。 */
+    internal fun isNearEnd(position: Int): Boolean = position >= itemCount - prefetchDistance
 }
 
 /** 兜底 payload：告诉 RecyclerView「复用原 holder 全量重绑」，而不是播放 change 动画。 */

--- a/feeds/src/main/java/ceui/pixiv/feeds/FeedFragment.kt
+++ b/feeds/src/main/java/ceui/pixiv/feeds/FeedFragment.kt
@@ -410,6 +410,9 @@ abstract class FeedFragment(
             // 的列表上设回 animator——无害且不泄漏（listView 随 view 一起回收）。
             listView.post { listView.itemAnimator = listItemAnimator }
             onListCommitted(state)
+            // 刷新可能把长列表截成很短的前缀：幸存 ViewHolder 不会重新 onBind，
+            // onNearEnd 的预取信号会永久丢失，这里提交后主动补一次检查。
+            listView.post { rearmPaginationIfNearEnd() }
         }
     }
 
@@ -438,6 +441,31 @@ abstract class FeedFragment(
         }
     }
 
+    /**
+     * 列表 diff 提交后补一次“触底预取”检查。
+     *
+     * 常规翻页由 [FeedAdapter] 的 onBind 驱动；但刷新把长列表截成很短的前缀时，
+     * 幸存的 ViewHolder 内容没变、RecyclerView 不会重新 onBind，短列表又可能没有
+     * 滚动空间，onNearEnd 永远不会再触发。这里在提交后主动看一次当前可见位置，
+     * 如果已经处于预取区就补调 [FeedViewModel.loadMore]，避免分页被“静默吃掉”。
+     */
+    private fun rearmPaginationIfNearEnd() {
+        if (!loadMoreEnabled) return
+        val listView = _binding?.feedListView ?: return
+        val adapter = feedAdapter ?: return
+        val layoutManager = listView.layoutManager ?: return
+        val lastVisible = when (layoutManager) {
+            is StaggeredGridLayoutManager ->
+                layoutManager.findLastVisibleItemPositions(null).maxOrNull() ?: -1
+            is LinearLayoutManager -> layoutManager.findLastVisibleItemPosition()
+            else -> -1
+        }
+        if (lastVisible < 0) return
+        if (adapter.isNearEnd(lastVisible)) {
+            feedViewModel.loadMore()
+        }
+    }
+
     /** adapter 现取不缓存：[rebuildList] 换过 adapter 之后，长活的 uiState collector 不能再往旧的提交。 */
     private fun render(state: FeedUiState) {
         val adapter = feedAdapter ?: return
@@ -450,12 +478,18 @@ abstract class FeedFragment(
         // adapter 还空着（首屏、旋转重建、rebuildList 换过 adapter）时没有「旧代」可撕。
         val newGeneration = state.refreshGeneration != lastRenderedGeneration
         lastRenderedGeneration = state.refreshGeneration
+        val listView = feedBinding.feedListView
         if (newGeneration && adapter.itemCount > 0 && displayList.isNotEmpty() &&
             needsCleanSwapAcrossGenerations(adapter.currentList, displayList)
         ) {
             commitNewGeneration(adapter, displayList, state)
         } else {
-            adapter.submitList(displayList) { onListCommitted(state) }
+            adapter.submitList(displayList) {
+                onListCommitted(state)
+                // 刷新可能把长列表截成很短的前缀：幸存 ViewHolder 不会重新 onBind，
+                // onNearEnd 的预取信号会永久丢失，这里提交后主动补一次检查。
+                listView.post { rearmPaginationIfNearEnd() }
+            }
         }
 
         val binding = feedBinding


### PR DESCRIPTION
# 修复动态页刷新后分页加载被“静默吃掉”（IllustFeedFragment 触底预取补发）

> 分支：`patch-8-24`（wangwang-code fork）
> 提交：`b19b744f1` fix(feeds): 刷新截短列表后补一次触底预取，避免分页被静默吃掉

## 背景

动态页（`FollowingIllustFeedFragment`，继承自 `IllustFeedFragment`）在触发刷新后，会出现“分页加载被吃掉”的问题：

- 刷新前列表已经翻过几页；
- 刷新后首屏被截得很短（例如过滤后只剩 4 条）；
- 此时界面自动回顶，只有 4 张卡；
- 继续下滑不再加载新卡；
- 短时间内反复刷新也无法恢复。

## 根因

分页触发完全依赖 `FeedAdapter.onBindViewHolder` 里的 `onNearEnd` 回调：

```kotlin
if (onNearEnd != null && position >= itemCount - prefetchDistance) {
    onNearEnd.invoke()
}
```

刷新把长列表截成短前缀时，DiffUtil 只移除后面的条目；如果剩下的可见卡片内容没变，RecyclerView **不会重新 onBindViewHolder**。短列表又没有足够滚动空间，于是 `onNearEnd` 永远不会再触发，`loadMore()` 也不会被调用。

真机 logcat 证据（本地埋点）：

```
refresh success items=4 nextCursor=...offset=30 reachedEnd=false append=Idle refresh=Idle
```

但之后没有：

```
loadMore called
loadMore launching cursor=...offset=30
```

也没有任何 `offset=30` 请求。所有刷新响应都是 `200`，因此不是服务端限流，而是本地请求根本没启动。

## 改动内容

### 1. `FeedAdapter.kt`

- 抽出 `isNearEnd(position)`，统一“是否处于触底预取区”的判断；
- `onBindViewHolder` 内部改用该方法，行为不变。

### 2. `FeedFragment.kt`

- 新增 `rearmPaginationIfNearEnd()`：
  - 在列表 diff 提交后，`post` 一帧读取当前 `LayoutManager` 的最后可见位置；
  - 如果已经处于预取区，就主动调用 `feedViewModel.loadMore()`；
- 普通 `submitList` diff 路径和 `commitNewGeneration` 清空重填路径都接入该检查；
- `loadMore()` 自身已有 `reachedEnd` / `refresh Loading` / `append 非 Idle` / single-flight 守卫，不会造成重复请求或过度加载。

## 涉及文件

- `feeds/src/main/java/ceui/pixiv/feeds/FeedAdapter.kt`
- `feeds/src/main/java/ceui/pixiv/feeds/FeedFragment.kt`

## 测试情况

- 真机复现路径：动态页下滑翻页 → 触发刷新 → 自动回顶后只剩 4 条；
- 修复后刷新完成会自动发起 `offset=30`，随后 `offset=60 / 90 / 120 ...` 连续加载；
- 验证 logcat：

```
refresh success items=4 nextCursor=...offset=30 ...
loadMore launching cursor=...offset=30
--> GET https://app-api.pixiv.net/v2/illust/follow?restrict=all&offset=30
```

- `:feeds:compileReleaseKotlin` 编译通过。
