### PR TITLE
详情页已缓存原图自动回填：退出大图后不再看模糊图（V3/经典同享）

### DIFF
--- a/app/src/main/java/ceui/lisa/adapters/IllustAdapter.java
+++ b/app/src/main/java/ceui/lisa/adapters/IllustAdapter.java
@@ -636,6 +636,13 @@ public class IllustAdapter extends AbstractIllustAdapter<ViewHolder<RecyIllustDe
                     public boolean onLoadFailed(@Nullable GlideException e, Object m, Target<Bitmap> target, boolean isFirstResource) {
                         if (!guardUrl.equals(holder.baseBind.illust.getTag(R.id.tag_image_url))) return false;
                         if (isFinal) {
+                            // 缓存原图与 LARGE 是并行加载的：原图已经成功盖上后，迟到的
+                            // LARGE 失败只是底层占位失败，不能再把清晰原图改成错误态。
+                            if (cachedOriginalShownPages.contains(position)) {
+                                Timber.d("[IllustAdapter] base(large) FAIL ignored after cached-original success pos=%d, url=%s",
+                                        position, shortUrl);
+                                return false;
+                            }
                             Timber.w(e, "[IllustAdapter] base(large) FAIL pos=%d, url=%s", position, shortUrl);
                             holder.baseBind.reload.setVisibility(View.VISIBLE);
                             holder.baseBind.progressLayout.donutProgress.setVisibility(View.GONE);

--- a/app/src/main/java/ceui/lisa/adapters/IllustAdapter.java
+++ b/app/src/main/java/ceui/lisa/adapters/IllustAdapter.java
@@ -136,6 +136,15 @@ public class IllustAdapter extends AbstractIllustAdapter<ViewHolder<RecyIllustDe
      */
     private final Set<Integer> shownPages = ConcurrentHashMap.newKeySet();
 
+    /**
+     * 当前仍绑定在屏上的页 binding（V3 feeds 委托模式），用于不重绑直接回填缓存原图。
+     * 存 binding 而不是 ViewHolder：外层 renderer 每次 onBind/onRecycle 都 new 一个 ViewHolder 壳。
+     */
+    private final Map<Integer, RecyIllustDetailBinding> boundBindings = new ConcurrentHashMap<>();
+
+    /** 已对当前 holder 显示过缓存原图 overlay 的页码，避免 onResume 重复触发淡入。 */
+    private final Set<Integer> cachedOriginalShownPages = ConcurrentHashMap.newKeySet();
+
     public IllustAdapter(FragmentActivity activity, Fragment fragment, Illust illustsBean, int maxHeight, boolean isForceOriginal) {
         Common.showLog("IllustAdapter maxHeight " + maxHeight);
         mActivity = activity;
@@ -166,6 +175,41 @@ public class IllustAdapter extends AbstractIllustAdapter<ViewHolder<RecyIllustDe
         localPageUris.put(page, uri);
     }
 
+    /**
+     * 不重绑列表，直接把当前仍绑定在屏上的这一页升级为缓存原图。
+     * 仅处理进程内已缓存 ORIGINAL 的页；未绑定或已显示过则 no-op。
+     */
+    public void showCachedOriginalOverlay(int position) {
+        if (released || snapshotId != null || cachedOriginalShownPages.contains(position)) return;
+        if (Shaft.sSettings.isShowOriginalPreviewImage() || isForceOriginal) return;
+        RecyIllustDetailBinding binding = boundBindings.get(position);
+        if (binding == null || localPageUris.containsKey(position)) return;
+        String originalUrl = IllustDownload.getUrl(allIllust, position, Params.IMAGE_RESOLUTION_ORIGINAL);
+        String largeUrl = IllustDownload.getUrl(allIllust, position, Params.IMAGE_RESOLUTION_LARGE);
+        if (originalUrl == null || originalUrl.equals(largeUrl)) return;
+        File file = ImageLoaderV3.peekFile(originalUrl);
+        if (file == null) return;
+        renderCachedOriginalOverlay(new ViewHolder<>(binding), file, largeUrl, position);
+    }
+
+    /**
+     * 对当前作品所有已绑定页执行缓存原图回填，未绑定页留到下次绑定时自动走缓存检查。
+     * 快照模式 / 已开启原图模式 / 已 forceOriginal 时内部直接 no-op。
+     */
+    public void showCachedOriginalOverlays() {
+        if (released || snapshotId != null) return;
+        if (Shaft.sSettings.isShowOriginalPreviewImage() || isForceOriginal) return;
+        if (allIllust == null || allIllust.isGif()) return;
+        int pageCount = Math.max(allIllust.getPage_count(), 1);
+        for (int position = 0; position < pageCount; position++) {
+            String originalUrl = IllustDownload.getUrl(allIllust, position, Params.IMAGE_RESOLUTION_ORIGINAL);
+            String largeUrl = IllustDownload.getUrl(allIllust, position, Params.IMAGE_RESOLUTION_LARGE);
+            if (originalUrl != null && !originalUrl.equals(largeUrl) && ImageLoaderV3.peekFile(originalUrl) != null) {
+                showCachedOriginalOverlay(position);
+            }
+        }
+    }
+
     /** View 生命周期结束时断开回调，避免后台下载记录扫描把旧 Fragment/View 留到扫描完成。 */
     public void release() {
         released = true;
@@ -174,6 +218,8 @@ public class IllustAdapter extends AbstractIllustAdapter<ViewHolder<RecyIllustDe
         pageRatio.clear();
         overlaySizedPages.clear();
         shownPages.clear();
+        boundBindings.clear();
+        cachedOriginalShownPages.clear();
         mainHandler.removeCallbacksAndMessages(null);
     }
 
@@ -281,6 +327,15 @@ public class IllustAdapter extends AbstractIllustAdapter<ViewHolder<RecyIllustDe
     @Override
     public void onViewRecycled(@NonNull ViewHolder<RecyIllustDetailBinding> holder) {
         super.onViewRecycled(holder);
+        // 解除当前 binding 的绑定记录，避免已回收页被 onResume 直接回填。
+        Integer recycledPosition = boundBindings.entrySet().stream()
+                .filter(e -> e.getValue() == holder.baseBind)
+                .map(Map.Entry::getKey)
+                .findFirst().orElse(null);
+        if (recycledPosition != null) {
+            boundBindings.remove(recycledPosition);
+            cachedOriginalShownPages.remove(recycledPosition);
+        }
         // Detach this holder's LoadTask observers (see loadIllust) so they don't outlive
         // the bind and pile up on the per-URL task's LiveData.
         detachTaskObservers(holder);
@@ -312,6 +367,8 @@ public class IllustAdapter extends AbstractIllustAdapter<ViewHolder<RecyIllustDe
     @Override
     public void onBindViewHolder(@NonNull ViewHolder<RecyIllustDetailBinding> holder, int position) {
         super.onBindViewHolder(holder, position);
+        boundBindings.entrySet().removeIf(e -> e.getValue() == holder.baseBind);
+        boundBindings.put(position, holder.baseBind);
         // 快照只读：长按下载会拿 shaftsnap:// 当远程地址去下,还可能顺带触发「下载即收藏」
         // 发出真实的收藏请求 —— 这一页所有写操作都该是哑的(V3 侧 renderer 已经把长按置空)。
         if(longPressDownload && snapshotId == null && mActivity instanceof BaseActivity<?>){
@@ -458,6 +515,7 @@ public class IllustAdapter extends AbstractIllustAdapter<ViewHolder<RecyIllustDe
         fragmentRequestManager.clear(holder.baseBind.illustHd);
         holder.baseBind.illustHd.setImageDrawable(null);
         holder.baseBind.illustHd.setVisibility(View.GONE);
+        cachedOriginalShownPages.remove(position);
 
         // 命中已下载的本地文件就直读，跳过网络 LoadTask —— 详情页展开多图复用下载结果。
         Uri localUri = localPageUris.get(position);
@@ -471,9 +529,15 @@ public class IllustAdapter extends AbstractIllustAdapter<ViewHolder<RecyIllustDe
     private void loadFromNetwork(ViewHolder<RecyIllustDetailBinding> holder, int position, boolean changeSize) {
         boolean loadOriginal = Shaft.sSettings.isShowOriginalPreviewImage() || isForceOriginal;
         final String largeUrl = IllustDownload.getUrl(allIllust, position, Params.IMAGE_RESOLUTION_LARGE);
-        final String targetUrl = loadOriginal
-                ? IllustDownload.getUrl(allIllust, position, Params.IMAGE_RESOLUTION_ORIGINAL)
-                : largeUrl;
+        final String originalUrl = IllustDownload.getUrl(allIllust, position, Params.IMAGE_RESOLUTION_ORIGINAL);
+        // 不主动下载原图；但若这一页原图已经在进程内缓存（如刚从大图页看过），
+        // 就直接用缓存原图覆盖 LARGE，避免明明有更清晰的图却显示模糊。
+        // 这是 bonus 路径：失败仍保留 LARGE，不影响不开启原图的省流量语义。
+        final File cachedOriginalFile = (!loadOriginal && snapshotId == null && originalUrl != null && !originalUrl.equals(largeUrl))
+                ? ImageLoaderV3.peekFile(originalUrl)
+                : null;
+        boolean cachedOriginal = cachedOriginalFile != null;
+        final String targetUrl = loadOriginal ? originalUrl : largeUrl;
 
         // tag = 本次 bind 想显示的「最终」url;所有回调据此判 stale,复用时旧回调自动变 no-op(#912)。
         holder.baseBind.illust.setTag(R.id.tag_image_url, targetUrl);
@@ -486,6 +550,10 @@ public class IllustAdapter extends AbstractIllustAdapter<ViewHolder<RecyIllustDe
         if (!loadOriginal) {
             // 仅 large 模式:large 就是最终图,每页都要真正下下来展示。
             renderBase(holder, position, changeSize, new GlideUrlChild(largeUrl), targetUrl, /*isFinal=*/true);
+            // bonus：该页原图已在进程内缓存，叠加显示原图；失败静默保留 LARGE。
+            if (cachedOriginal && cachedOriginalFile != null) {
+                renderCachedOriginalOverlay(holder, cachedOriginalFile, targetUrl, position);
+            }
             return;
         }
 
@@ -691,6 +759,58 @@ public class IllustAdapter extends AbstractIllustAdapter<ViewHolder<RecyIllustDe
                         holder.baseBind.progressLayout.donutProgress.setVisibility(View.GONE);
                         holder.baseBind.illustHd.setVisibility(View.VISIBLE);
                         Shaft.getMMKV().encode(guardUrl, true);
+                        return false;
+                    }
+                })
+                .into(holder.baseBind.illustHd);
+    }
+
+    /**
+     * bonus 路径：仅当详情页不主动加载原图、但该页原图已在进程内缓存时使用。
+     * 与 [renderOverlay] 的区别：原图只是增强，失败/解码异常时静默保留底层 LARGE，
+     * 不亮 reload、不把已有的大图展示变成错误态。
+     */
+    private void renderCachedOriginalOverlay(ViewHolder<RecyIllustDetailBinding> holder, File file,
+                                            String guardUrl, int position) {
+        // 防御：快照模式 / 已开启原图模式时本 bonus 路径完全不跑。
+        if (released || snapshotId != null) return;
+        if (Shaft.sSettings.isShowOriginalPreviewImage() || isForceOriginal) return;
+        // 首次为该页拿原图真尺寸，校准展示盒；与 renderOverlay 同一套去重。
+        if (overlaySizedPages.add(position)) {
+            int[] bounds = readImageBounds(file);
+            if (bounds != null) {
+                applyPixelSize(holder, position, bounds[0], bounds[1]);
+            }
+        }
+        holder.baseBind.illustHd.setVisibility(View.INVISIBLE);
+        RequestManager requestManager = mFragment != null ? Glide.with(mFragment) : Glide.with(mContext);
+        requestManager
+                .asBitmap()
+                .load(file)
+                .transform(new LargeBitmapScaleTransformer())
+                .transition(BitmapTransitionOptions.withCrossFade())
+                .listener(new RequestListener<Bitmap>() {
+                    @Override
+                    public boolean onLoadFailed(@Nullable GlideException e, Object m, Target<Bitmap> target, boolean isFirstResource) {
+                        if (!guardUrl.equals(holder.baseBind.illust.getTag(R.id.tag_image_url)))
+                            return false;
+                        // bonus：失败就退回 LARGE，不亮 reload、不干扰已成功的大图。
+                        Timber.w(e, "[IllustAdapter] cached-original overlay FAIL, keep LARGE pos=%d", position);
+                        holder.baseBind.illustHd.setImageDrawable(null);
+                        holder.baseBind.illustHd.setVisibility(View.GONE);
+                        return false;
+                    }
+
+                    @Override
+                    public boolean onResourceReady(Bitmap resource, Object m, Target<Bitmap> target, DataSource dataSource, boolean isFirstResource) {
+                        if (!guardUrl.equals(holder.baseBind.illust.getTag(R.id.tag_image_url)))
+                            return false;
+                        Timber.d("[IllustAdapter] cached-original overlay OK pos=%d, %dx%d, ds=%s",
+                                position, resource.getWidth(), resource.getHeight(), dataSource.name());
+                        holder.baseBind.reload.setVisibility(View.GONE);
+                        holder.baseBind.progressLayout.donutProgress.setVisibility(View.GONE);
+                        holder.baseBind.illustHd.setVisibility(View.VISIBLE);
+                        cachedOriginalShownPages.add(position);
                         return false;
                     }
                 })

--- a/app/src/main/java/ceui/lisa/fragments/FragmentIllust.kt
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentIllust.kt
@@ -932,7 +932,11 @@ class FragmentIllust : BaseLazyFragment<FragmentIllustBinding>() {
 
     override fun onResume() {
         super.onResume()
-        if (!isSnapshotMode) checkDownload()
+        if (!isSnapshotMode) {
+            checkDownload()
+            // 从二级大图页返回后，把进程内已缓存 ORIGINAL 的页直接回填，不重绑列表。
+            (baseBind.recyclerView.adapter as? IllustAdapter)?.showCachedOriginalOverlays()
+        }
     }
 
     private fun checkDownload() {

--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3Fragment.kt
@@ -409,6 +409,16 @@ class ArtworkV3Fragment : IllustFeedFragment(R.layout.fragment_artwork_v3) {
         }
         artworkViewModel.onPageVisible()
         artworkViewModel.refreshDownloadFab()
+        refreshCachedOriginalPages()
+    }
+
+    /**
+     * 从二级大图页返回后，把进程内已缓存 ORIGINAL 的顶部大图页回填成原图。
+     * 遍历和快照/原图模式防御都在 [IllustAdapter.showCachedOriginalOverlays] 内。
+     */
+    private fun refreshCachedOriginalPages() {
+        if (isSnapshotMode) return
+        pageAdapter?.showCachedOriginalOverlays()
     }
 
     override fun onPause() {


### PR DESCRIPTION
# 详情页已缓存原图自动回填：退出大图后不再看模糊图（V3/经典同享）

> 分支：`patch-8-24-1`（wangwang-code fork）
> 提交：`6daaa684f` feat(detail): 已缓存原图返回详情页自动回填，V3/经典同享

## 背景

在详情页「不开启原图」时，顶部大图按设计只加载 LARGE。用户点图进入二级大图页后，大图页会加载 ORIGINAL；退出大图返回详情页时，详情页仍然显示 LARGE。

虽然这符合“不主动下载原图”的省流量语义，但用户**已经为这张图加载过原图**了，返回后却还要看更模糊的 LARGE，体验上是明显的落差：

> 明明有更清晰的图，为什么还让我看模糊的？

## 方案

把口径收敛为：

> 开关只控制“是否主动下载原图”；如果某页 ORIGINAL 已经在进程内缓存，就直接展示缓存原图。

实现上采用 **bonus overlay**：

- 不改变“未缓存原图继续显示 LARGE、不触发下载”的行为；
- 只在 `ImageLoaderV3.peekFile(originalUrl)` 命中时，把缓存原图叠加到 `illust_hd`；
- 不重绑 RecyclerView / 不触发 DiffUtil，避免整页闪烁；
- 多 P 作品只回填“已经缓存了原图”的页，不会因为看过 p0 就把其余页也拉成原图；
- 快照模式、全局已开启原图、已 `forceOriginal`、本地下载文件路径均完全跳过。

## 改动内容

### 1. `IllustAdapter.java`

- 新增 `boundBindings`：记录当前仍绑定在屏上的页 binding。
  - 存 binding 而不是 ViewHolder：V3 feeds 委托模式下外层 renderer 每次 `onBind/onRecycle` 都会 `new ViewHolder(cell.binding)`，binding 才是稳定身份。
- 新增 `cachedOriginalShownPages`：避免同一 holder 重复触发原图淡入。
- 新增 `showCachedOriginalOverlay(position)`：
  - 不重绑列表，直接对当前已绑定的页 overlay 缓存原图；
  - 快照 / 已开原图 / `forceOriginal` / 本地下载页直接 no-op；
  - 失败静默保留 LARGE，不亮 reload。
- 新增 `showCachedOriginalOverlays()`：V3 与经典共用的批量入口。
- `loadFromNetwork()`：
  - 非原图模式下，若该页 ORIGINAL 已在进程内缓存，则 LARGE 正常展示后叠加缓存原图；
  - 未缓存页保持原逻辑，不发起原图下载；
  - 快照模式不进入该 bonus 路径。
- 新增 `renderCachedOriginalOverlay()`：
  - 独立于正式原图 `renderOverlay()`；
  - 失败不影响 LARGE，成功才淡入原图。

### 2. `ArtworkV3Fragment.kt`

- `onResume()` 调用 `refreshCachedOriginalPages()`；
- 该方法只做一件事：`pageAdapter?.showCachedOriginalOverlays()`；
- 快照模式跳过；遍历与防御逻辑统一收敛在 `IllustAdapter` 内。

### 3. `FragmentIllust.kt`（经典详情页）

- `onResume()` 非快照分支增加：

```kotlin
(baseBind.recyclerView.adapter as? IllustAdapter)?.showCachedOriginalOverlays()
```

- 经典页的 `IllustAdapter` 是真实 RecyclerView adapter，`boundBindings` 由 RecyclerView 自动维护；
- 返回大图页后同样只对当前可见页直接 overlay，不可见页下次绑定时自动走缓存检查。

## 涉及文件

- `app/src/main/java/ceui/lisa/adapters/IllustAdapter.java`
- `app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3Fragment.kt`
- `app/src/main/java/ceui/lisa/fragments/FragmentIllust.kt`

## 测试情况

- AS Bridge `inspect`：三个文件均无语法/解析错误。
- 真机验证：
  1. 详情页不开启原图；
  2. 点图进入大图页，等待 ORIGINAL 加载完成；
  3. 退出大图页；
  4. 详情页当前页直接从 LARGE 缓刷为缓存原图，无任何闪烁；
  5. 未缓存原图的页仍显示 LARGE，不触发额外下载。
