### PR TITLE
修复动态页瀑布流刷新后左列短暂空出 / 首卡跑右 / 列间距错误变宽

### DIFF
--- a/app/src/main/java/ceui/pixiv/ui/common/IllustFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/IllustFeedFragment.kt
@@ -7,6 +7,7 @@ import androidx.annotation.LayoutRes
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModel
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.StaggeredGridLayoutManager
 import androidx.viewbinding.ViewBinding
 import ceui.lisa.R
 import ceui.lisa.activities.Shaft
@@ -143,7 +144,12 @@ abstract class IllustFeedFragment(
         return StaggeredManager(
             Shaft.sSettings.lineCount,
             RecyclerView.VERTICAL,
-        )
+        ).apply {
+            // GAP_HANDLING_NONE 对齐 legacy / Recmd / Artwork：SGLM 默认 gap 策略在刷新换代时
+            // 会把首行 item decoration 的 top 间距误判成“顶部有洞”，清 lookup 重排，造成左列空出、
+            // 首卡跑右、列间距闪跳。纯瀑布流页统一关掉，避免这类跨代重排。
+            gapStrategy = StaggeredGridLayoutManager.GAP_HANDLING_NONE
+        }
     }
 
     override fun onListReady(listView: RecyclerView) {


### PR DESCRIPTION
# 修复动态页瀑布流刷新后左列短暂空出 / 首卡跑右 / 列间距错误变宽

> 分支：`patch-8-25`（wangwang-code fork）
> 提交：`c795039d5` fix(feeds): 瀑布流关闭 SGLM gap 重排，消除刷新后左列短暂空出

## 背景

`FollowingIllustFeedFragment` 驱动的动态页（瀑布流模式）刷新后，概率出现：

- 左列短暂空出；
- 第一个卡片跑到右列；
- 随后发现左列空了又跑回左列；
- 左列第二个跑到右列第一；
- 此时左 1 与右 1 之间的间距错误变宽。

## 根因

### 1. SGLM 的 gap 修正重排

瀑布流使用 `StaggeredGridLayoutManager`，默认 `gapStrategy` 是 `GAP_HANDLING_MOVE_ITEMS_BETWEEN_SPANS`。

刷新换代时，SGLM 在 `onLayoutChildren()` 中会检查 `hasGapsToFix()`。由于本页使用 `SpacesItemDecoration` 给第一行加了 `8dp` 的 top 间距，SGLM 可能把首行顶部间距误判成“顶部有洞”，随后执行：

```java
mLazySpanLookup.clear();
requestSimpleAnimationsInNextLayout();
requestLayout();
```

也就是清空 span lookup 并重新 layout。这次重排的锚点/分配顺序可能不再从 position 0 开始，于是出现：

- 新列表第 1 个卡片被分到右列；
- 左列顶部空出；
- 后续再被 gap 修正搬回时，出现跨列移动。

### 2. 间距变宽的具体机制

`SpacesItemDecoration` 的左右 margin 依赖 `StaggeredGridLayoutManager.LayoutParams.getSpanIndex()`：

```java
if (params.getSpanIndex() % 2 != 0) {
    // 右边：left = space / 2, right = space
} else {
    // 左边：left = space, right = space / 2
}
```

正常两列布局：

- 左卡 `spanIndex = 0`：`left = 8dp, right = 4dp`
- 右卡 `spanIndex = 1`：`left = 4dp, right = 8dp`
- 两卡之间间距 = `4dp + 4dp = 8dp`

当 SGLM 在刷新重排/动画帧中给出瞬态或错误的 span 分配时，例如左卡拿到 `1`、右卡拿到 `0`：

- 左卡变成 `left = 4dp, right = 8dp`
- 右卡变成 `left = 8dp, right = 4dp`
- 两卡之间间距 = `8dp + 8dp = 16dp`

这就是用户看到的“重排后间距错误变宽”。

## 修复内容

在 `IllustFeedFragment.onCreateLayoutManager()` 的默认瀑布流 `StaggeredManager` 上设置：

```kotlin
gapStrategy = StaggeredGridLayoutManager.GAP_HANDLING_NONE
```

效果：

- 关闭 SGLM 的 `checkForGaps()` 二次重排；
- 刷新后不再因为“首行 top 间距被误判成洞”而清空 span lookup 并重排；
- 从源头消除“左列短暂空出 / 首卡跑右 / 重排后间距错误变宽”。

该做法与仓库内 `RecmdIllustFeedFragment`、`ArtworkV3Fragment` 已有的 `GAP_HANDLING_NONE` 取舍保持一致。

## 临时缓解建议（未包含在本 PR）

如果某些设备/时序下仍看到跨列移动的动画帧，可临时加：

```kotlin
listView.itemAnimator = null
```

但请注意：

- 它只是关闭 RecyclerView 的 predictive animation 帧；
- 并不能阻止 SGLM 内部 `mLazySpanLookup.clear()` + 重新 layout 的发生；
- 属于“藏住动画帧”的临时缓解，不是根因修复，因此本 PR 未把它作为正式改动合入。

## 涉及文件

- `app/src/main/java/ceui/pixiv/ui/common/IllustFeedFragment.kt`

## 测试情况

- `:app:compileGithubDebugKotlin` — BUILD SUCCESSFUL
- AS Bridge inspect 无新增语法/编译错误
- 真机反复测试左1不再被短暂空出
