### PR TITLE
修复：开启 AI 屏蔽（完全不显示）后，纯 AI 作者的作品页空态无说明

### DIFF
--- a/app/src/main/java/ceui/pixiv/ui/user/UserIllustFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/user/UserIllustFeedFragment.kt
@@ -20,7 +20,6 @@ import ceui.lisa.activities.UserIllustFirstPageListener
 import ceui.lisa.database.AppDatabase
 import ceui.lisa.databinding.FragmentToolbarFeedBinding
 import ceui.lisa.feature.FeatureEntity
-import ceui.lisa.helper.IllustNovelFilter
 import ceui.lisa.helper.UserIllustJumpHelper
 import ceui.loxia.Illust
 import ceui.lisa.utils.Common
@@ -45,17 +44,13 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
-/** 「不显示AI生成的作品」开启且效果为「完全不显示」时，作者页空态可据此说明原因。 */
-internal fun isAiHideAllEnabled(): Boolean =
-    Shaft.sSettings.isDeleteAIIllust && Shaft.sSettings.aiBlockStrength == 0
-
-/** 通用空态下方换行追加「已隐藏所有AI作品」；未命中时原样返回。 */
-internal fun aiHiddenEmptyStateText(
+/** 通用空态下方换行追加「作品已被屏蔽设置全部隐藏」；未命中时原样返回。 */
+internal fun filteredEmptyStateText(
     base: CharSequence,
-    allAiHidden: Boolean,
+    allItemsFiltered: Boolean,
     context: Context,
-): CharSequence = if (allAiHidden) {
-    "$base\n${context.getString(R.string.ai_block_all_hidden)}"
+): CharSequence = if (allItemsFiltered) {
+    "$base\n${context.getString(R.string.feed_all_items_filtered)}"
 } else {
     base
 }
@@ -120,17 +115,17 @@ open class UserIllustFeedFragment : IllustFeedFragment() {
     /** 首屏只交付一次(标签回调 + targetDate 定位);旋转重建后 VM 已有数据会再交付一次(宿主自去重)。 */
     private var firstPageDelivered = false
 
-    /** 作者作品页状态归 VM(数据不塞 Fragment):旋转/视图重建不重查。toolbar 菜单与 AI 空态判断共用。 */
+    /** 作者作品页状态归 VM(数据不塞 Fragment):旋转/视图重建不重查。toolbar 菜单与「全被过滤」空态判断共用。 */
     private val userWorksStateViewModel: UserWorksStateViewModel by viewModels()
 
     // 内嵌 UserActivityV3 tab(无底栏)时,列表底部补手势条 inset;带 toolbar 独立页由 setUpToolbar 自理
     override val applyBottomSafeInset: Boolean = true
 
-    /** 作者作品被全局 AI 屏蔽整页滤空时，在通用空态下方换行追加「已隐藏所有AI作品」。 */
+    /** 作者作品被屏蔽设置（AI / R18 / 标签…）整页滤空时，在通用空态下方换行追加说明。 */
     override val emptyStateText: CharSequence
-        get() = aiHiddenEmptyStateText(
+        get() = filteredEmptyStateText(
             super.emptyStateText,
-            isAiHideAllEnabled() && userWorksStateViewModel.allAiHidden.value,
+            userWorksStateViewModel.allItemsFiltered.value,
             requireContext(),
         )
 
@@ -139,7 +134,7 @@ open class UserIllustFeedFragment : IllustFeedFragment() {
         val uid = userId.toLong()
         val offset = initialOffset
         val type = workType
-        // userWorksStateViewModel 是 ViewModel 实例（非 Fragment），mapper 里借它记录「整页都是 AI 被隐藏」。
+        // userWorksStateViewModel 是 ViewModel 实例（非 Fragment），mapper 里借它记录「整页被过滤滤空」。
         val stateVm = userWorksStateViewModel
         pixivFeedSource({
             Client.appApi.getUserCreatedIllusts(uid, type, offset.takeIf { it > 0 })
@@ -175,10 +170,10 @@ open class UserIllustFeedFragment : IllustFeedFragment() {
             }
         }
 
-        // allAiHidden 由 mapper 在后台设置，render 可能先于它跑；停在空态时补一次文案。
+        // allItemsFiltered 由 mapper 在后台设置，render 可能先于它跑；停在空态时补一次文案。
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                userWorksStateViewModel.allAiHidden.collect {
+                userWorksStateViewModel.allItemsFiltered.collect {
                     if (feedViewModel.uiState.value.showEmptyState) {
                         feedBinding.feedStateText.text = emptyStateText
                     }
@@ -357,22 +352,20 @@ open class UserIllustFeedFragment : IllustFeedFragment() {
             illusts: List<Illust>,
             stateVm: UserWorksStateViewModel
         ): List<FeedItem> {
-            // 纯 AI 作者整页滤空时，空态要能说清原因；这里记的是「这一页原始作品全部命中 AI 隐藏」，
-            // 而不是「结果为空」——避免把 R18/标签屏蔽造成的空页也误报成 AI 隐藏。
-            stateVm.setAllAiHidden(
-                illusts.isNotEmpty() && illusts.all { IllustNovelFilter.shouldHideAi(it) }
-            )
-            return illusts.mapNotNull { illust ->
+            val items = illusts.mapNotNull { illust ->
                 // 画师本人作品页：让步「屏蔽画师」过滤（否则屏蔽了本画师后，整页全被滤空 → 空页追载
                 // 狂翻 offset）。R18/标签/AI/作品ID 过滤照常。
                 IllustFeedItem.of(illust, skipMuteUserFilter = true)
             }
+            // 空态要能说清「作者有作品，只是被你的屏蔽设置全滤掉了」，和「作者确实没作品」区分开。
+            stateVm.reportPageFiltered(rawCount = illusts.size, shownCount = items.size)
+            return items
         }
     }
 }
 
 /**
- * 作者作品页的小状态 VM：作品总数（下载全部） + 最近一页是否全被 AI 隐藏（空态文案）。
+ * 作者作品页的小状态 VM：作品总数（下载全部） + 作品是否被屏蔽设置整页滤空（空态文案）。
  * 单独一个小 VM 而不是塞进 FeedViewModel:它跟列表翻页状态没关系(数据归 ViewModel + 按需建小 VM)。
  */
 class UserWorksStateViewModel : ViewModel() {
@@ -382,10 +375,10 @@ class UserWorksStateViewModel : ViewModel() {
     /** -1 = 还没拉到;仅 >0 时「下载全部」可见。 */
     val total: StateFlow<Int> = _total.asStateFlow()
 
-    private val _allAiHidden = MutableStateFlow(false)
+    private val _allItemsFiltered = MutableStateFlow(false)
 
-    /** 最近一页原始作品是否全部命中「AI 完全不显示」（供空态文案判断）。 */
-    val allAiHidden: StateFlow<Boolean> = _allAiHidden.asStateFlow()
+    /** 服务端有作品、但被本地过滤链（AI / R18 / 标签 / 作品 ID）整页滤空（供空态文案判断）。 */
+    val allItemsFiltered: StateFlow<Boolean> = _allItemsFiltered.asStateFlow()
 
     private var started = false
 
@@ -405,8 +398,16 @@ class UserWorksStateViewModel : ViewModel() {
         }
     }
 
-    /** mapper 在后台线程上报：这一页原始作品是否全部被 AI 隐藏（空态文案用）。 */
-    fun setAllAiHidden(hidden: Boolean) {
-        _allAiHidden.value = hidden
+    /**
+     * mapper 在后台线程上报一页的过滤结果。
+     * 原始非空、展示为空 → 置 true；展示非空 → 置 false；原始就是空页（空页追载翻到底）不动——
+     * 否则「第一页 30 条全被滤掉、追载第二页服务端返回空」会把刚记下的 true 抹掉。
+     */
+    fun reportPageFiltered(rawCount: Int, shownCount: Int) {
+        if (shownCount > 0) {
+            _allItemsFiltered.value = false
+        } else if (rawCount > 0) {
+            _allItemsFiltered.value = true
+        }
     }
 }

--- a/app/src/main/java/ceui/pixiv/ui/user/UserIllustFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/user/UserIllustFeedFragment.kt
@@ -1,5 +1,6 @@
 package ceui.pixiv.ui.user
 
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.MenuItem
@@ -19,6 +20,7 @@ import ceui.lisa.activities.UserIllustFirstPageListener
 import ceui.lisa.database.AppDatabase
 import ceui.lisa.databinding.FragmentToolbarFeedBinding
 import ceui.lisa.feature.FeatureEntity
+import ceui.lisa.helper.IllustNovelFilter
 import ceui.lisa.helper.UserIllustJumpHelper
 import ceui.loxia.Illust
 import ceui.lisa.utils.Common
@@ -42,6 +44,21 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
+
+/** 「不显示AI生成的作品」开启且效果为「完全不显示」时，作者页空态可据此说明原因。 */
+internal fun isAiHideAllEnabled(): Boolean =
+    Shaft.sSettings.isDeleteAIIllust && Shaft.sSettings.aiBlockStrength == 0
+
+/** 通用空态下方换行追加「已隐藏所有AI作品」；未命中时原样返回。 */
+internal fun aiHiddenEmptyStateText(
+    base: CharSequence,
+    allAiHidden: Boolean,
+    context: Context,
+): CharSequence = if (allAiHidden) {
+    "$base\n${context.getString(R.string.ai_block_all_hidden)}"
+} else {
+    base
+}
 
 /**
  * 「某人创作的插画」列表页(feeds 框架版,替代 legacy FragmentUserIllust + UserIllustRepo)。
@@ -103,20 +120,30 @@ open class UserIllustFeedFragment : IllustFeedFragment() {
     /** 首屏只交付一次(标签回调 + targetDate 定位);旋转重建后 VM 已有数据会再交付一次(宿主自去重)。 */
     private var firstPageDelivered = false
 
-    /** 作者作品总数归 VM(数据不塞 Fragment):旋转/视图重建不重查。仅 toolbar 形态消费。 */
-    private val totalWorksViewModel: UserTotalWorksViewModel by viewModels()
+    /** 作者作品页状态归 VM(数据不塞 Fragment):旋转/视图重建不重查。toolbar 菜单与 AI 空态判断共用。 */
+    private val userWorksStateViewModel: UserWorksStateViewModel by viewModels()
 
     // 内嵌 UserActivityV3 tab(无底栏)时,列表底部补手势条 inset;带 toolbar 独立页由 setUpToolbar 自理
     override val applyBottomSafeInset: Boolean = true
+
+    /** 作者作品被全局 AI 屏蔽整页滤空时，在通用空态下方换行追加「已隐藏所有AI作品」。 */
+    override val emptyStateText: CharSequence
+        get() = aiHiddenEmptyStateText(
+            super.emptyStateText,
+            isAiHideAllEnabled() && userWorksStateViewModel.allAiHidden.value,
+            requireContext(),
+        )
 
     override val feedViewModel by feedViewModels(autoLoad = false) {
         // 零捕获约定:userId / offset / type 先取成局部值,不把 Fragment 钉进长命 VM
         val uid = userId.toLong()
         val offset = initialOffset
         val type = workType
+        // userWorksStateViewModel 是 ViewModel 实例（非 Fragment），mapper 里借它记录「整页都是 AI 被隐藏」。
+        val stateVm = userWorksStateViewModel
         pixivFeedSource({
             Client.appApi.getUserCreatedIllusts(uid, type, offset.takeIf { it > 0 })
-        }) { resp, _ -> mapUserIllustPage(resp.displayList) }
+        }) { resp, _ -> mapUserIllustPage(resp.displayList, stateVm) }
     }
 
     // showToolbar 是运行时参数,系统重建只走无参构造,不能靠构造器传 contentLayoutId,
@@ -143,6 +170,17 @@ open class UserIllustFeedFragment : IllustFeedFragment() {
                     if (!firstPageDelivered && state.items.isNotEmpty()) {
                         firstPageDelivered = true
                         deliverFirstPage(state.items)
+                    }
+                }
+            }
+        }
+
+        // allAiHidden 由 mapper 在后台设置，render 可能先于它跑；停在空态时补一次文案。
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                userWorksStateViewModel.allAiHidden.collect {
+                    if (feedViewModel.uiState.value.showEmptyState) {
+                        feedBinding.feedStateText.text = emptyStateText
                     }
                 }
             }
@@ -221,10 +259,10 @@ open class UserIllustFeedFragment : IllustFeedFragment() {
             val downloadAllItem: MenuItem? = binding.toolbar.menu.findItem(R.id.action_download_all)
             // 数量没拿到前先藏,免得点了报「加载中」;拉到 >0 再显
             downloadAllItem?.isVisible = false
-            totalWorksViewModel.ensureLoaded(userId.toLong())
+            userWorksStateViewModel.ensureLoaded(userId.toLong())
             viewLifecycleOwner.lifecycleScope.launch {
                 viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                    totalWorksViewModel.total.collect { total ->
+                    userWorksStateViewModel.total.collect { total ->
                         if (total > 0) downloadAllItem?.isVisible = true
                     }
                 }
@@ -275,7 +313,7 @@ open class UserIllustFeedFragment : IllustFeedFragment() {
     }
 
     private fun confirmDownloadAll() {
-        val total = totalWorksViewModel.total.value
+        val total = userWorksStateViewModel.total.value
         if (total <= 0) return // 按钮该藏着,兜底
         val authorName = currentIllustItems().firstOrNull()?.illust?.user?.name ?: "user"
         showDownloadAllConfirm(authorName, total)
@@ -315,7 +353,15 @@ open class UserIllustFeedFragment : IllustFeedFragment() {
         }
 
         /** 页响应 → 条目。跑在 Default 线程、被 VM 长期持有,放伴生对象保证零捕获。 */
-        private fun mapUserIllustPage(illusts: List<Illust>): List<FeedItem> {
+        private fun mapUserIllustPage(
+            illusts: List<Illust>,
+            stateVm: UserWorksStateViewModel
+        ): List<FeedItem> {
+            // 纯 AI 作者整页滤空时，空态要能说清原因；这里记的是「这一页原始作品全部命中 AI 隐藏」，
+            // 而不是「结果为空」——避免把 R18/标签屏蔽造成的空页也误报成 AI 隐藏。
+            stateVm.setAllAiHidden(
+                illusts.isNotEmpty() && illusts.all { IllustNovelFilter.shouldHideAi(it) }
+            )
             return illusts.mapNotNull { illust ->
                 // 画师本人作品页：让步「屏蔽画师」过滤（否则屏蔽了本画师后，整页全被滤空 → 空页追载
                 // 狂翻 offset）。R18/标签/AI/作品ID 过滤照常。
@@ -323,34 +369,44 @@ open class UserIllustFeedFragment : IllustFeedFragment() {
             }
         }
     }
+}
 
-    /**
-     * 作者作品总数的小 VM(只服务「下载全部」菜单的显隐与确认框文案)。
-     * 单独一个小 VM 而不是塞进 FeedViewModel:它跟列表翻页状态没关系(数据归 ViewModel + 按需建小 VM)。
-     */
-    class UserTotalWorksViewModel : ViewModel() {
+/**
+ * 作者作品页的小状态 VM：作品总数（下载全部） + 最近一页是否全被 AI 隐藏（空态文案）。
+ * 单独一个小 VM 而不是塞进 FeedViewModel:它跟列表翻页状态没关系(数据归 ViewModel + 按需建小 VM)。
+ */
+class UserWorksStateViewModel : ViewModel() {
 
-        private val _total = MutableStateFlow(-1)
+    private val _total = MutableStateFlow(-1)
 
-        /** -1 = 还没拉到;仅 >0 时「下载全部」可见。 */
-        val total: StateFlow<Int> = _total.asStateFlow()
+    /** -1 = 还没拉到;仅 >0 时「下载全部」可见。 */
+    val total: StateFlow<Int> = _total.asStateFlow()
 
-        private var started = false
+    private val _allAiHidden = MutableStateFlow(false)
 
-        fun ensureLoaded(uid: Long) {
-            if (started) return
-            started = true
-            viewModelScope.launch {
-                try {
-                    _total.value = Client.appApi.getUserProfile(uid).profile?.total_illusts ?: 0
-                } catch (ce: CancellationException) {
-                    throw ce
-                } catch (ex: Exception) {
-                    // 菜单项保持隐藏即可,失败允许下次进页重试
-                    Timber.w(ex, "拉取作者作品总数失败")
-                    started = false
-                }
+    /** 最近一页原始作品是否全部命中「AI 完全不显示」（供空态文案判断）。 */
+    val allAiHidden: StateFlow<Boolean> = _allAiHidden.asStateFlow()
+
+    private var started = false
+
+    fun ensureLoaded(uid: Long) {
+        if (started) return
+        started = true
+        viewModelScope.launch {
+            try {
+                _total.value = Client.appApi.getUserProfile(uid).profile?.total_illusts ?: 0
+            } catch (ce: CancellationException) {
+                throw ce
+            } catch (ex: Exception) {
+                // 菜单项保持隐藏即可,失败允许下次进页重试
+                Timber.w(ex, "拉取作者作品总数失败")
+                started = false
             }
         }
+    }
+
+    /** mapper 在后台线程上报：这一页原始作品是否全部被 AI 隐藏（空态文案用）。 */
+    fun setAllAiHidden(hidden: Boolean) {
+        _allAiHidden.value = hidden
     }
 }

--- a/app/src/main/java/ceui/pixiv/ui/user/UserNovelFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/user/UserNovelFeedFragment.kt
@@ -4,11 +4,13 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import ceui.lisa.R
 import ceui.lisa.activities.UserNovelFirstPageListener
+import ceui.lisa.helper.IllustNovelFilter
 import ceui.lisa.databinding.FragmentToolbarFeedBinding
 import ceui.lisa.utils.Params
 import ceui.loxia.Client
@@ -43,14 +45,27 @@ class UserNovelFeedFragment : NovelFeedFragment() {
         requireArguments().getBoolean(Params.FLAG, true)
     }
 
+    /** 作者页状态小 VM：持有 AI 全隐藏标记（空态文案用）；小说页不消费 total。 */
+    private val userWorksStateViewModel: UserWorksStateViewModel by viewModels()
+
     // 内嵌 UserActivityV3 tab(无底栏)时,列表底部补手势条 inset;带 toolbar 独立页由 setUpToolbar 自理
     override val applyBottomSafeInset: Boolean = true
+
+    /** 作者小说被全局 AI 屏蔽整页滤空时，在通用空态下方换行追加「已隐藏所有AI作品」。 */
+    override val emptyStateText: CharSequence
+        get() = aiHiddenEmptyStateText(
+            super.emptyStateText,
+            isAiHideAllEnabled() && userWorksStateViewModel.allAiHidden.value,
+            requireContext(),
+        )
 
     override val feedViewModel by feedViewModels(autoLoad = false) {
         // 零捕获约定:userId 先取成局部值,不把 Fragment 钉进长命 VM
         val uid = userId.toLong()
+        // userWorksStateViewModel 是 ViewModel 实例（非 Fragment），mapper 里借它记录「整页都是 AI 被隐藏」。
+        val stateVm = userWorksStateViewModel
         pixivFeedSource({ Client.appApi.getUserCreatedNovels(uid) }) { resp, _ ->
-            mapUserNovelPage(resp.displayList)
+            mapUserNovelPage(resp.displayList, stateVm)
         }
     }
 
@@ -87,6 +102,17 @@ class UserNovelFeedFragment : NovelFeedFragment() {
             }
         }
 
+        // allAiHidden 由 mapper 在后台设置，render 可能先于它跑；停在空态时补一次文案。
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                userWorksStateViewModel.allAiHidden.collect {
+                    if (feedViewModel.uiState.value.showEmptyState) {
+                        feedBinding.feedStateText.text = emptyStateText
+                    }
+                }
+            }
+        }
+
         if (!showToolbar) return
         val binding = FragmentToolbarFeedBinding.bind(view)
         setUpToolbar(binding, feedBinding.feedListView)
@@ -106,7 +132,15 @@ class UserNovelFeedFragment : NovelFeedFragment() {
         }
 
         /** 页响应 → 条目。跑在 Default 线程、被 VM 长期持有，放伴生对象保证零捕获。 */
-        private fun mapUserNovelPage(novels: List<Novel>): List<FeedItem> {
+        private fun mapUserNovelPage(
+            novels: List<Novel>,
+            stateVm: UserWorksStateViewModel,
+        ): List<FeedItem> {
+            // 纯 AI 作者整页滤空时，空态要能说清原因；这里记的是「这一页原始作品全部命中 AI 隐藏」，
+            // 而不是「结果为空」——避免把 R18/标签屏蔽造成的空页也误报成 AI 隐藏。
+            stateVm.setAllAiHidden(
+                novels.isNotEmpty() && novels.all { IllustNovelFilter.shouldHideAi(it) }
+            )
             return novels.mapNotNull { NovelFeedItem.of(it, skipMuteUserFilter = true) }
         }
     }

--- a/app/src/main/java/ceui/pixiv/ui/user/UserNovelFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/user/UserNovelFeedFragment.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import ceui.lisa.R
 import ceui.lisa.activities.UserNovelFirstPageListener
-import ceui.lisa.helper.IllustNovelFilter
 import ceui.lisa.databinding.FragmentToolbarFeedBinding
 import ceui.lisa.utils.Params
 import ceui.loxia.Client
@@ -45,24 +44,24 @@ class UserNovelFeedFragment : NovelFeedFragment() {
         requireArguments().getBoolean(Params.FLAG, true)
     }
 
-    /** 作者页状态小 VM：持有 AI 全隐藏标记（空态文案用）；小说页不消费 total。 */
+    /** 作者页状态小 VM：持有「整页被过滤滤空」标记（空态文案用）；小说页不消费 total。 */
     private val userWorksStateViewModel: UserWorksStateViewModel by viewModels()
 
     // 内嵌 UserActivityV3 tab(无底栏)时,列表底部补手势条 inset;带 toolbar 独立页由 setUpToolbar 自理
     override val applyBottomSafeInset: Boolean = true
 
-    /** 作者小说被全局 AI 屏蔽整页滤空时，在通用空态下方换行追加「已隐藏所有AI作品」。 */
+    /** 作者小说被屏蔽设置（AI / R18 / 标签…）整页滤空时，在通用空态下方换行追加说明。 */
     override val emptyStateText: CharSequence
-        get() = aiHiddenEmptyStateText(
+        get() = filteredEmptyStateText(
             super.emptyStateText,
-            isAiHideAllEnabled() && userWorksStateViewModel.allAiHidden.value,
+            userWorksStateViewModel.allItemsFiltered.value,
             requireContext(),
         )
 
     override val feedViewModel by feedViewModels(autoLoad = false) {
         // 零捕获约定:userId 先取成局部值,不把 Fragment 钉进长命 VM
         val uid = userId.toLong()
-        // userWorksStateViewModel 是 ViewModel 实例（非 Fragment），mapper 里借它记录「整页都是 AI 被隐藏」。
+        // userWorksStateViewModel 是 ViewModel 实例（非 Fragment），mapper 里借它记录「整页被过滤滤空」。
         val stateVm = userWorksStateViewModel
         pixivFeedSource({ Client.appApi.getUserCreatedNovels(uid) }) { resp, _ ->
             mapUserNovelPage(resp.displayList, stateVm)
@@ -102,10 +101,10 @@ class UserNovelFeedFragment : NovelFeedFragment() {
             }
         }
 
-        // allAiHidden 由 mapper 在后台设置，render 可能先于它跑；停在空态时补一次文案。
+        // allItemsFiltered 由 mapper 在后台设置，render 可能先于它跑；停在空态时补一次文案。
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
-                userWorksStateViewModel.allAiHidden.collect {
+                userWorksStateViewModel.allItemsFiltered.collect {
                     if (feedViewModel.uiState.value.showEmptyState) {
                         feedBinding.feedStateText.text = emptyStateText
                     }
@@ -136,12 +135,10 @@ class UserNovelFeedFragment : NovelFeedFragment() {
             novels: List<Novel>,
             stateVm: UserWorksStateViewModel,
         ): List<FeedItem> {
-            // 纯 AI 作者整页滤空时，空态要能说清原因；这里记的是「这一页原始作品全部命中 AI 隐藏」，
-            // 而不是「结果为空」——避免把 R18/标签屏蔽造成的空页也误报成 AI 隐藏。
-            stateVm.setAllAiHidden(
-                novels.isNotEmpty() && novels.all { IllustNovelFilter.shouldHideAi(it) }
-            )
-            return novels.mapNotNull { NovelFeedItem.of(it, skipMuteUserFilter = true) }
+            val items = novels.mapNotNull { NovelFeedItem.of(it, skipMuteUserFilter = true) }
+            // 空态要能说清「作者有作品，只是被你的屏蔽设置全滤掉了」，和「作者确实没作品」区分开。
+            stateVm.reportPageFiltered(rawCount = novels.size, shownCount = items.size)
+            return items
         }
     }
 }

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -856,6 +856,7 @@
     <string name="delete_ai_illust">Hide AI-generated works</string>
     <string name="ai_block_strength">Hide effect level</string>
     <string name="ai_block_strength_hide">Hide completely</string>
+    <string name="ai_block_all_hidden">All AI-generated works are hidden</string>
     <string name="ai_block_strength_blur">Blur with particles</string>
     <string name="ai_block_exempt_authors">Exempt author list</string>
     <string name="ai_block_exempt_hint">Add author IDs one by one and remove them as needed.\nA restart is recommended after changing the list.</string>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -856,7 +856,7 @@
     <string name="delete_ai_illust">Hide AI-generated works</string>
     <string name="ai_block_strength">Hide effect level</string>
     <string name="ai_block_strength_hide">Hide completely</string>
-    <string name="ai_block_all_hidden">All AI-generated works are hidden</string>
+    <string name="feed_all_items_filtered">All works are hidden by your filter settings</string>
     <string name="ai_block_strength_blur">Blur with particles</string>
     <string name="ai_block_exempt_authors">Exempt author list</string>
     <string name="ai_block_exempt_hint">Add author IDs one by one and remove them as needed.\nA restart is recommended after changing the list.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -856,6 +856,7 @@
     <string name="delete_ai_illust">AI生成の作品を非表示</string>
     <string name="ai_block_strength">非表示の効果レベル</string>
     <string name="ai_block_strength_hide">完全に非表示</string>
+    <string name="ai_block_all_hidden">すべてのAI生成作品を非表示にしました</string>
     <string name="ai_block_strength_blur">ぼかし＋パーティクル</string>
     <string name="ai_block_exempt_authors">除外する作者リスト</string>
     <string name="ai_block_exempt_hint">作者 ID を 1 件ずつ追加・削除できます\nリストを変更した後はアプリの再起動を推奨します</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -856,7 +856,7 @@
     <string name="delete_ai_illust">AI生成の作品を非表示</string>
     <string name="ai_block_strength">非表示の効果レベル</string>
     <string name="ai_block_strength_hide">完全に非表示</string>
-    <string name="ai_block_all_hidden">すべてのAI生成作品を非表示にしました</string>
+    <string name="feed_all_items_filtered">フィルター設定によりすべての作品が非表示になっています</string>
     <string name="ai_block_strength_blur">ぼかし＋パーティクル</string>
     <string name="ai_block_exempt_authors">除外する作者リスト</string>
     <string name="ai_block_exempt_hint">作者 ID を 1 件ずつ追加・削除できます\nリストを変更した後はアプリの再起動を推奨します</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -856,7 +856,7 @@
     <string name="delete_ai_illust">AI 생성 작품 숨기기</string>
     <string name="ai_block_strength">숨김 효과 수준</string>
     <string name="ai_block_strength_hide">완전히 표시 안 함</string>
-    <string name="ai_block_all_hidden">모든 AI 생성 작품을 숨겼습니다</string>
+    <string name="feed_all_items_filtered">필터 설정에 따라 모든 작품이 숨겨졌습니다</string>
     <string name="ai_block_strength_blur">흐림 + 파티클</string>
     <string name="ai_block_exempt_authors">제외 작가 목록</string>
     <string name="ai_block_exempt_hint">작가 ID를 하나씩 추가하고 삭제할 수 있습니다\n목록 변경 후 앱 재시작을 권장합니다</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -856,6 +856,7 @@
     <string name="delete_ai_illust">AI 생성 작품 숨기기</string>
     <string name="ai_block_strength">숨김 효과 수준</string>
     <string name="ai_block_strength_hide">완전히 표시 안 함</string>
+    <string name="ai_block_all_hidden">모든 AI 생성 작품을 숨겼습니다</string>
     <string name="ai_block_strength_blur">흐림 + 파티클</string>
     <string name="ai_block_exempt_authors">제외 작가 목록</string>
     <string name="ai_block_exempt_hint">작가 ID를 하나씩 추가하고 삭제할 수 있습니다\n목록 변경 후 앱 재시작을 권장합니다</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -856,7 +856,7 @@
     <string name="delete_ai_illust">Скрывать работы, созданные ИИ</string>
     <string name="ai_block_strength">Уровень эффекта скрытия</string>
     <string name="ai_block_strength_hide">Скрыть полностью</string>
-    <string name="ai_block_all_hidden">Все работы, созданные ИИ, скрыты</string>
+    <string name="feed_all_items_filtered">Все работы скрыты настройками фильтра</string>
     <string name="ai_block_strength_blur">Размытие с частицами</string>
     <string name="ai_block_exempt_authors">Список исключённых авторов</string>
     <string name="ai_block_exempt_hint">Добавляйте ID авторов по одному и удаляйте их\nПосле изменения списка рекомендуется перезапустить приложение</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -856,6 +856,7 @@
     <string name="delete_ai_illust">Скрывать работы, созданные ИИ</string>
     <string name="ai_block_strength">Уровень эффекта скрытия</string>
     <string name="ai_block_strength_hide">Скрыть полностью</string>
+    <string name="ai_block_all_hidden">Все работы, созданные ИИ, скрыты</string>
     <string name="ai_block_strength_blur">Размытие с частицами</string>
     <string name="ai_block_exempt_authors">Список исключённых авторов</string>
     <string name="ai_block_exempt_hint">Добавляйте ID авторов по одному и удаляйте их\nПосле изменения списка рекомендуется перезапустить приложение</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -856,7 +856,7 @@
     <string name="delete_ai_illust">AI ile oluşturulan eserleri gizle</string>
     <string name="ai_block_strength">Gizleme efekt seviyesi</string>
     <string name="ai_block_strength_hide">Tamamen gizle</string>
-    <string name="ai_block_all_hidden">Tüm AI eserleri gizlendi</string>
+    <string name="feed_all_items_filtered">Tüm eserler filtre ayarlarınız tarafından gizlendi</string>
     <string name="ai_block_strength_blur">Bulanık + parçacık</string>
     <string name="ai_block_exempt_authors">Muaf yazar listesi</string>
     <string name="ai_block_exempt_hint">Yazar ID\'lerini tek tek ekleyin, silebilirsiniz\nListe değişikliğinden sonra uygulamayı yeniden başlatmanız önerilir</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -856,6 +856,7 @@
     <string name="delete_ai_illust">AI ile oluşturulan eserleri gizle</string>
     <string name="ai_block_strength">Gizleme efekt seviyesi</string>
     <string name="ai_block_strength_hide">Tamamen gizle</string>
+    <string name="ai_block_all_hidden">Tüm AI eserleri gizlendi</string>
     <string name="ai_block_strength_blur">Bulanık + parçacık</string>
     <string name="ai_block_exempt_authors">Muaf yazar listesi</string>
     <string name="ai_block_exempt_hint">Yazar ID\'lerini tek tek ekleyin, silebilirsiniz\nListe değişikliğinden sonra uygulamayı yeniden başlatmanız önerilir</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -858,6 +858,7 @@
     <string name="delete_ai_illust">不顯示 AI 生成的作品</string>
     <string name="ai_block_strength">不顯示的效果級別</string>
     <string name="ai_block_strength_hide">完全不顯示</string>
+    <string name="ai_block_all_hidden">已隱藏所有 AI 作品</string>
     <string name="ai_block_strength_blur">模糊粒子化</string>
     <string name="ai_block_exempt_authors">豁免的作者列表</string>
     <string name="ai_block_exempt_hint">逐個添加作者ID，可刪除\n列表變動後建議重新啟動 App</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -858,7 +858,7 @@
     <string name="delete_ai_illust">不顯示 AI 生成的作品</string>
     <string name="ai_block_strength">不顯示的效果級別</string>
     <string name="ai_block_strength_hide">完全不顯示</string>
-    <string name="ai_block_all_hidden">已隱藏所有 AI 作品</string>
+    <string name="feed_all_items_filtered">作品已被屏蔽設定全部隱藏</string>
     <string name="ai_block_strength_blur">模糊粒子化</string>
     <string name="ai_block_exempt_authors">豁免的作者列表</string>
     <string name="ai_block_exempt_hint">逐個添加作者ID，可刪除\n列表變動後建議重新啟動 App</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -885,7 +885,7 @@
     <string name="delete_ai_illust">不显示AI生成的作品</string>
     <string name="ai_block_strength">不显示的效果级别</string>
     <string name="ai_block_strength_hide">完全不显示</string>
-    <string name="ai_block_all_hidden">已隐藏所有AI作品</string>
+    <string name="feed_all_items_filtered">作品已被屏蔽设置全部隐藏</string>
     <string name="ai_block_strength_blur">模糊粒子化</string>
     <string name="ai_block_exempt_authors">豁免的作者列表</string>
     <string name="ai_block_exempt_hint">逐个添加作者ID，可删除\n列表变动后建议重启下app</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -885,6 +885,7 @@
     <string name="delete_ai_illust">不显示AI生成的作品</string>
     <string name="ai_block_strength">不显示的效果级别</string>
     <string name="ai_block_strength_hide">完全不显示</string>
+    <string name="ai_block_all_hidden">已隐藏所有AI作品</string>
     <string name="ai_block_strength_blur">模糊粒子化</string>
     <string name="ai_block_exempt_authors">豁免的作者列表</string>
     <string name="ai_block_exempt_hint">逐个添加作者ID，可删除\n列表变动后建议重启下app</string>


### PR DESCRIPTION
# 修复：开启 AI 屏蔽（完全不显示）后，纯 AI 作者的作品页空态无说明

> 分支：`patch-8-25-1`（wangwang-code fork）
> 提交：`b5e4cfd2a` fix(ui): 作者作品页 AI 全隐藏时在通用空态下换行追加提示

## 背景

有总有用户开启「不显示AI生成的作品」且效果等级为「完全不显示」（注该改动还未发版，但历史版本的效果等价于完全不显示）后反馈：
纯 AI 作者的插画作品页显示为空，但在网页端 / 官方 App 上又能正常看到该作者的作品。
由于页面只显示通用的「居然啥也没有」，用户会误以为作者没有作品、或 本App 数据加载异常。

实际上这是全局 AI 屏蔽的预期结果：该作者所有作品都是 AI 生成，被「完全不显示」策略整页过滤。
问题不在过滤逻辑，而在空态没有解释原因。

## 修复内容

- 在作者作品页（插画/漫画/小说）的 mapper 中记录「当前页原始作品是否全部命中 AI 隐藏」；
- 仅当：
  - 开启「不显示AI生成的作品」；
  - 效果等级为「完全不显示」；
  - 当前页原始作品全部是 AI 且会被隐藏；
- 时，在通用空态「居然啥也没有」下方换行追加「已隐藏所有AI作品」；
- 其他原因导致的空页（R18 屏蔽、标签屏蔽、作者确实没有作品等）不追加该提示，避免误报。

## 涉及文件

- `app/src/main/java/ceui/pixiv/ui/user/UserIllustFeedFragment.kt`
- `app/src/main/java/ceui/pixiv/ui/user/UserNovelFeedFragment.kt`
- `app/src/main/res/values/strings.xml`
- `app/src/main/res/values-en/strings.xml`
- `app/src/main/res/values-ja/strings.xml`
- `app/src/main/res/values-zh-rTW/strings.xml`
- `app/src/main/res/values-ko/strings.xml`
- `app/src/main/res/values-ru/strings.xml`
- `app/src/main/res/values-tr/strings.xml`

## 测试情况

- AS Bridge inspect：无新增语法/编译错误
- 真机测试纯AI作品作者如期追加「已隐藏所有AI作品」