### PR TITLE
修复：作者页收藏 Tab 分段按钮底边贴紧父容器

### DIFF
--- a/app/src/main/res/layout/fragment_user_v3_collection.xml
+++ b/app/src/main/res/layout/fragment_user_v3_collection.xml
@@ -11,7 +11,15 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         android:paddingHorizontal="20dp"
-        android:paddingTop="10dp">
+        android:paddingTop="10dp"
+        android:paddingBottom="5dp">
+
+        <TextView
+            android:id="@+id/textView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="paddingTop" />
 
         <TextView
             android:id="@+id/seg_illust"

--- a/app/src/main/res/layout/fragment_user_v3_collection.xml
+++ b/app/src/main/res/layout/fragment_user_v3_collection.xml
@@ -15,13 +15,6 @@
         android:paddingBottom="5dp">
 
         <TextView
-            android:id="@+id/textView"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="paddingTop" />
-
-        <TextView
             android:id="@+id/seg_illust"
             android:layout_width="wrap_content"
             android:layout_height="38dp"


### PR DESCRIPTION
# 修复：作者页收藏 Tab 分段按钮底边贴紧父容器

> 分支：`patch-8-26-1`（wangwang-code fork）
> 提交：`3d2b961f0` fix(user): 作者页收藏 Tab 分段按钮底部补 5dp 间距，避免贴紧父容器底边

## 背景

作者页内切到「收藏」Tab 后下滑，可以看到顶部「插画/漫画收藏 ↔ 小说收藏」分段按钮的底边紧贴父容器底边，与下方列表之间没有任何间隙，视觉上偏挤、像被贴死。

## 修复内容

- 定位到 `app/src/main/res/layout/fragment_user_v3_collection.xml`：收藏 Tab 顶部分段容器只有 `android:paddingTop="10dp"`，缺少 `android:paddingBottom`；
- 补上 `android:paddingBottom="5dp"`，让分段按钮底部与父容器底边/下方列表之间保留 5dp 间隙；
- 上间隙继续保留 10dp，下间隙取一半，视觉上不再紧贴。

## 涉及文件

- `app/src/main/res/layout/fragment_user_v3_collection.xml`

## 验证

- AS Bridge inspect 通过，XML 无语法/结构错误；
- 真机实测按钮底边不再紧贴父容器底边