### PR TITLE
快照管理卡片补左上角 R 级与页数角标

### DIFF
--- a/app/src/main/java/ceui/pixiv/snapshot/SnapshotGenerator.kt
+++ b/app/src/main/java/ceui/pixiv/snapshot/SnapshotGenerator.kt
@@ -124,6 +124,8 @@ object SnapshotGenerator {
                 includeOriginal = includeOriginal,
                 isBookmarked = bean.isBookmarked,
                 isFollowed = bean.user?.is_followed ?: false,
+                xRestrict = bean.x_restrict,
+                pageCount = pageCount,
                 title = bean.title,
                 authorName = bean.user?.name,
                 authorId = bean.user?.id,

--- a/app/src/main/java/ceui/pixiv/snapshot/SnapshotListFragment.kt
+++ b/app/src/main/java/ceui/pixiv/snapshot/SnapshotListFragment.kt
@@ -338,6 +338,16 @@ private class SnapshotViewHolder(
         binding.commentTag.isVisible = summary.manifest.includeComments
         binding.originalTag.isVisible = summary.manifest.includeOriginal
 
+        val isR18 = (summary.manifest.xRestrict ?: 0) > 0
+        val pageCount = summary.manifest.pageCount ?: 1
+        binding.r18Badge.isVisible = isR18
+        binding.pSize.isVisible = pageCount > 1
+        if (pageCount > 1) {
+            binding.pSize.text = String.format(Locale.getDefault(), "%dP", pageCount)
+        }
+        // 多选勾标固定在左上角；进入多选态时隐藏角标行，避免和勾标叠在一起。
+        binding.badgeRow.isVisible = !selectionMode
+
         HistorySelectBadge.bindSelection(binding.selectCheck, binding.deleteButton, selectionMode, selected)
         if (selectionMode) {
             binding.root.setOnClickListener { onToggleSelection() }

--- a/app/src/main/java/ceui/pixiv/snapshot/SnapshotModels.kt
+++ b/app/src/main/java/ceui/pixiv/snapshot/SnapshotModels.kt
@@ -23,6 +23,8 @@ data class SnapshotManifest(
     val includeOriginal: Boolean = false,
     val isBookmarked: Boolean = false,
     val isFollowed: Boolean = false,
+    val xRestrict: Int? = null,
+    val pageCount: Int? = null,
     val title: String? = null,
     val authorName: String? = null,
     val authorId: Long? = null,

--- a/app/src/main/java/ceui/pixiv/snapshot/SnapshotRepository.kt
+++ b/app/src/main/java/ceui/pixiv/snapshot/SnapshotRepository.kt
@@ -82,7 +82,10 @@ object SnapshotRepository {
                 // 都拿 manifest.snapshotId 反解目录。名字对不上的目录(导入中途掉电留下的
                 // 备份等)必须当作不存在，否则会出现一张指向别人的重复卡片,删它删掉的是正主。
                 if (snapshotDir.name != manifest.snapshotId) return@mapNotNull null
-                val coverFile = manifest.coverPath?.let { rel -> runCatching { safeResolve(snapshotDir, rel) }.getOrNull()?.takeIf { f -> f.isFile } }
+                // 早期快照/手改 manifest 可能没记 R 级和页数；用 illust.json 回补，
+                // 保证老卡片也能显示左上角 R 级与 P 角标（fileCount 是整目录文件数，不是页数）。
+                val displayManifest = manifest.backfillDisplayFields(snapshotDir)
+                val coverFile = displayManifest.coverPath?.let { rel -> runCatching { safeResolve(snapshotDir, rel) }.getOrNull()?.takeIf { f -> f.isFile } }
                 // 文件数/体积生成时就写进 manifest 了，列表页(三个 Tab、每次 onResume 都刷)
                 // 没必要再把每个快照目录整个 walk 一遍 —— 那是 O(全库文件数) 次 stat。
                 // 只有老快照/manifest 没记的情况才退回真扫。
@@ -98,7 +101,7 @@ object SnapshotRepository {
                         }
                     }
                 }
-                SnapshotSummary(manifest, fileCount, totalSize, coverFile)
+                SnapshotSummary(displayManifest, fileCount, totalSize, coverFile)
             }
             ?.sortedByDescending { it.manifest.createdAt }
             ?: emptyList()
@@ -213,6 +216,19 @@ object SnapshotRepository {
         root(context).listFiles()
             ?.filter { it.isDirectory && it.name.startsWith(BACKUP_PREFIX) }
             ?.forEach { it.deleteRecursively() }
+    }
+
+    /**
+     * 老快照的 manifest 可能没记 R 级/页数；从快照自带的 illust.json 回补显示字段。
+     * 只影响列表展示、不落盘，避免在只读 list() 里产生写副作用。
+     */
+    private fun SnapshotManifest.backfillDisplayFields(snapshotDir: File): SnapshotManifest {
+        if (xRestrict != null && pageCount != null && pageCount > 0) return this
+        val illust = SnapshotValidator.readJson<Illust>(File(snapshotDir, SNAPSHOT_ILLUST_JSON)) ?: return this
+        return copy(
+            xRestrict = xRestrict ?: illust.x_restrict,
+            pageCount = if (pageCount != null && pageCount > 0) pageCount else illust.page_count.coerceAtLeast(1)
+        )
     }
 
     private const val BACKUP_PREFIX = ".backup_"

--- a/app/src/main/res/layout/item_snapshot.xml
+++ b/app/src/main/res/layout/item_snapshot.xml
@@ -9,7 +9,7 @@
     android:layout_marginBottom="8dp"
     android:foreground="?attr/selectableItemBackground"
     app:cardBackgroundColor="@color/v3_bg"
-    app:cardCornerRadius="18dp"
+    app:cardCornerRadius="@dimen/eight_dp"
     app:cardElevation="1.5dp">
 
     <LinearLayout
@@ -30,6 +30,51 @@
                 android:contentDescription="@string/snapshot_cover"
                 android:scaleType="centerCrop"
                 tools:src="@mipmap/ic_launcher" />
+
+            <LinearLayout
+                android:id="@+id/badgeRow"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="top|start"
+                android:orientation="horizontal"
+                android:padding="@dimen/six_dp">
+
+                <TextView
+                    android:id="@+id/r18Badge"
+                    style="@style/textBlack"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/tag_stroke"
+                    android:includeFontPadding="false"
+                    android:layout_marginEnd="@dimen/six_dp"
+                    android:paddingStart="@dimen/four_dp"
+                    android:paddingTop="@dimen/two_dp"
+                    android:paddingEnd="@dimen/four_dp"
+                    android:paddingBottom="2dp"
+                    android:text="@string/v3_novel_r18"
+                    android:textColor="@color/always_white"
+                    android:textSize="11sp"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
+                <TextView
+                    android:id="@+id/pSize"
+                    style="@style/textBlack"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/tag_stroke"
+                    android:includeFontPadding="false"
+                    android:layout_marginEnd="@dimen/six_dp"
+                    android:paddingStart="@dimen/four_dp"
+                    android:paddingTop="@dimen/two_dp"
+                    android:paddingEnd="@dimen/four_dp"
+                    android:paddingBottom="2dp"
+                    android:textColor="@color/always_white"
+                    android:textSize="11sp"
+                    android:visibility="gone"
+                    tools:text="3P"
+                    tools:visibility="visible" />
+            </LinearLayout>
 
             <ImageView
                 android:id="@+id/selectCheck"


### PR DESCRIPTION
# 快照管理卡片补左上角 R 级与页数角标

> 分支：`patch-8-26-2`（wangwang-code fork）
> 目标：`classic`
> 最新提交：`8518787d6` feat(snapshot): 快照卡片补左上角 R 级与页数角标

## 背景

离线快照管理页的卡片目前只展示封面、标题、作者、大小/时间等信息，缺少作品本身的 R 级与页数提示。与项目整体惯性不符，本次工作补回缺失的两个角标。

## 修改内容

- `SnapshotManifest` 新增 `xRestrict`、`pageCount` 字段（可空，兼容已有快照 manifest）；
- 新快照生成时写入 R 级与页数；
- 老快照列表读取时若 manifest 缺失这些字段，从快照内 `illust.json` 回补显示；只影响列表展示、不落盘，避免在只读 `list()` 里产生写副作用；
- 卡片左上角新增角标行：
  - R-18：`tag_stroke` + 白色 11sp，与瀑布流卡片一致；
  - 多页：`%dP`，仅 `pageCount > 1` 显示，样式同上；
- 卡片圆角使用 `@dimen/eight_dp`，与收藏页/瀑布流卡片一致；
- 多选勾标保持在左上角，进入多选态时隐藏角标行，避免与勾标重叠。

## 涉及文件

- `app/src/main/java/ceui/pixiv/snapshot/SnapshotModels.kt`
- `app/src/main/java/ceui/pixiv/snapshot/SnapshotGenerator.kt`
- `app/src/main/java/ceui/pixiv/snapshot/SnapshotRepository.kt`
- `app/src/main/java/ceui/pixiv/snapshot/SnapshotListFragment.kt`
- `app/src/main/res/layout/item_snapshot.xml`

## 验证

- AS Bridge inspect：所有改动文件无新增语法/未解析问题；
- 真机实测新老快照都如期在卡片左上角显示角标，多选态正常隐匿角标