### PR TITLE
fix(back): 部分 Activity 显式声明 enableOnBackInvokedCallback（OriginOS 5 妥协方案）

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -109,9 +109,11 @@
             android:windowSoftInputMode="adjustPan" />
         <activity
             android:name=".activities.RankActivity"
+            android:enableOnBackInvokedCallback="true"
             android:theme="@style/SplashTheme" />
         <activity
             android:name=".activities.ImageDetailActivity"
+            android:enableOnBackInvokedCallback="true"
             android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation"
             android:theme="@style/ImageViewerTheme" />
         <activity
@@ -195,10 +197,12 @@
 
         <activity
             android:name=".activities.SearchActivity"
+            android:enableOnBackInvokedCallback="true"
             android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation"
             android:theme="@style/SplashTheme"
             android:windowSoftInputMode="stateHidden" />
-        <activity android:name=".activities.VActivity" />
+        <activity android:name=".activities.VActivity"
+            android:enableOnBackInvokedCallback="true" />
         <activity
             android:name=".activities.UActivity"
             android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation"
@@ -222,6 +226,7 @@
         </activity>
         <activity
             android:name=".activities.VPActivity"
+            android:enableOnBackInvokedCallback="true"
             android:theme="@style/SplashTheme" />
         <activity
             android:name="ceui.pixiv.ui.slideshow.SlideshowActivity"


### PR DESCRIPTION
# fix(back): 部分 Activity 显式声明 enableOnBackInvokedCallback（OriginOS 5 妥协方案）

> 分支：`patch-8-26-3`（wangwang-code fork）
> 目标：`classic`
> 最新提交：`8b1ea1988` fix(back): 部分 Activity 显式声明 enableOnBackInvokedCallback

## 背景与研究结果

在 OriginOS 5（vivo V2361A，Android 15）上验证预测式返回时发现，尽管项目已经 `targetSdk 36`，系统并没有按 AOSP 规则真正启用预测式返回：

- 不显式声明 `android:enableOnBackInvokedCallback="true"` 时，应用只能收到 `handleOnBackPressed`，收不到 `handleOnBackStarted / handleOnBackProgressed`；
- 显式声明后，系统才会把 `BackEventCompat` 进度回调交给应用；
- 但 OriginOS 5 的系统预测返回动画并不可靠：出现底层页面急于盖上、底层页面一起缩放/移动、从侧边栏进入的页面返回时把“侧边栏展开的主页”当成底页等异常；
- 期间还尝试了应用完全自绘返回动画（统一右滑缩小、自定义 exit 过渡等），但在该 ROM 上体感仍不理想，且改动面较大。

因此本次采取**妥协方案**：不大面积开启预测返回，也不接管全部返回动画，为实测动画体验还行的 Activity 显式声明系统开关。

## 修改内容

- `app/src/main/AndroidManifest.xml`
- 为以下 Activity 显式添加 `android:enableOnBackInvokedCallback="true"`：
  - `RankActivity`
  - `ImageDetailActivity`
  - `SearchActivity`
  - `VActivity`
  - `VPActivity`
- 不全局声明，避免 OriginOS 5 的系统预测动画影响主页/普通列表/详情等不稳定场景。

## 验证

- vivo V2361A / Android 15 真机：
- 显式声明后，插画二级页、排行榜、搜索结果页有预测返回动画，ImageDetailActivity虽有ImageDetail.handleOnBackStarted但无任何动画
- 底层页面急于盖上、底层页面一起缩放/移动慢动作和仔细观察仍存在（定制系统自身问题）

## 妥协说明

- 其他未声明 Activity 在 OriginOS 5 上仍没有预测返回动画；
- OriginOS 5 的系统预测返回动画本身仍不稳定，本次只是选择“局部可用的系统能力”；
- 后续如果要统一返回体验，需要重新评估自行控制预测返回动画的完整方案。