### PR TITLE
feat(snapshot): 收藏确认后事件驱动自动快照并支持转正

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -73,6 +73,7 @@
 -keepclassmembers class ceui.pixiv.snapshot.SnapshotAssets { <fields>; }
 -keepclassmembers class ceui.pixiv.snapshot.SnapshotComments { <fields>; }
 -keepclassmembers class ceui.pixiv.snapshot.SnapshotCommentThread { <fields>; }
+-keepclassmembers class ceui.pixiv.snapshot.AutoSnapshotManifest { <fields>; }
 -keepclassmembers class ceui.pixiv.ui.prime.PrimeTagIndexItem { <fields>; }
 -keepclassmembers class ceui.pixiv.ui.account.EmailBackupV3ViewModel$ErrorBody { <fields>; }
 -keepclassmembers class ceui.pixiv.ui.debug.PopularTagExportViewModel$Envelope { <fields>; }
@@ -95,6 +96,7 @@
 -keep,allowobfuscation class ceui.pixiv.snapshot.SnapshotAssets
 -keep,allowobfuscation class ceui.pixiv.snapshot.SnapshotComments
 -keep,allowobfuscation class ceui.pixiv.snapshot.SnapshotCommentThread
+-keep,allowobfuscation class ceui.pixiv.snapshot.AutoSnapshotManifest
 -keep,allowobfuscation class ceui.pixiv.ui.synonym.SynonymDictBackup$*Json
 -keep,allowobfuscation class ceui.pixiv.ui.history.BrowseHistoryBackup$Payload
 -keep,allowobfuscation class ceui.pixiv.ui.history.BrowseHistoryBackup$RawBackup

--- a/app/src/main/java/ceui/lisa/activities/ImageDetailActivity.kt
+++ b/app/src/main/java/ceui/lisa/activities/ImageDetailActivity.kt
@@ -61,6 +61,7 @@ import ceui.pixiv.ui.upscale.UpscaleTask
 import ceui.pixiv.ui.upscale.UpscaleTaskPool
 import ceui.pixiv.ui.works.ToggleToolnarViewModel
 import ceui.pixiv.witstudio.theme.V3Palette
+import ceui.pixiv.snapshot.AutoSnapshotRepository
 import ceui.pixiv.snapshot.SnapshotManagerFragment
 import ceui.pixiv.snapshot.SnapshotRepository
 import ceui.pixiv.snapshot.SnapshotRuntimeCache
@@ -361,6 +362,7 @@ class ImageDetailActivity : BaseActivity<ActivityImageDetailBinding?>() {
             finish()
             return
         }
+        val snapshotIsAuto = intent.getBooleanExtra(SnapshotManagerFragment.ARG_SNAPSHOT_IS_AUTO, false)
         val cached = SnapshotRuntimeCache.get(snapshotId)
         if (cached != null) {
             bindSnapshotViewer(cached)
@@ -371,7 +373,11 @@ class ImageDetailActivity : BaseActivity<ActivityImageDetailBinding?>() {
             // 裸 launch 里逃逸的异常直接崩进程,这里就地兜住:提示 + 关页。
             val data = try {
                 withContext(Dispatchers.IO) {
-                    SnapshotRepository.loadViewerData(applicationContext, snapshotId)
+                    if (snapshotIsAuto) {
+                        AutoSnapshotRepository.loadAutoViewerData(applicationContext, snapshotId)
+                    } else {
+                        SnapshotRepository.loadViewerData(applicationContext, snapshotId)
+                    }
                 }
             } catch (ce: kotlinx.coroutines.CancellationException) {
                 throw ce

--- a/app/src/main/java/ceui/lisa/activities/TemplateActivity.java
+++ b/app/src/main/java/ceui/lisa/activities/TemplateActivity.java
@@ -531,7 +531,10 @@ public class TemplateActivity extends BaseActivity<ActivityFragmentBinding> impl
                 case "快照查看": {
                     String snapshotId = intent.getStringExtra(
                             ceui.pixiv.snapshot.SnapshotManagerFragment.ARG_SNAPSHOT_ID);
-                    return ceui.pixiv.ui.detail.ArtworkV3Fragment.Companion.newInstanceSnapshot(snapshotId);
+                    boolean snapshotIsAuto = intent.getBooleanExtra(
+                            ceui.pixiv.snapshot.SnapshotManagerFragment.ARG_SNAPSHOT_IS_AUTO, false);
+                    return ceui.pixiv.ui.detail.ArtworkV3Fragment.Companion.newInstanceSnapshot(
+                            snapshotId, snapshotIsAuto);
                 }
                 case "快照经典查看": {
                     ceui.lisa.fragments.FragmentIllust classic =
@@ -542,6 +545,10 @@ public class TemplateActivity extends BaseActivity<ActivityFragmentBinding> impl
                             ceui.pixiv.snapshot.SnapshotManagerFragment.ARG_SNAPSHOT_ID,
                             intent.getStringExtra(
                                     ceui.pixiv.snapshot.SnapshotManagerFragment.ARG_SNAPSHOT_ID));
+                    classicSnapshotArgs.putBoolean(
+                            ceui.pixiv.snapshot.SnapshotManagerFragment.ARG_SNAPSHOT_IS_AUTO,
+                            intent.getBooleanExtra(
+                                    ceui.pixiv.snapshot.SnapshotManagerFragment.ARG_SNAPSHOT_IS_AUTO, false));
                     classic.setArguments(classicSnapshotArgs);
                     return classic;
                 }
@@ -559,6 +566,10 @@ public class TemplateActivity extends BaseActivity<ActivityFragmentBinding> impl
                             ceui.pixiv.snapshot.SnapshotManagerFragment.ARG_SNAPSHOT_ID,
                             intent.getStringExtra(
                                     ceui.pixiv.snapshot.SnapshotManagerFragment.ARG_SNAPSHOT_ID));
+                    snapshotCommentArgs.putBoolean(
+                            ceui.pixiv.snapshot.SnapshotManagerFragment.ARG_SNAPSHOT_IS_AUTO,
+                            intent.getBooleanExtra(
+                                    ceui.pixiv.snapshot.SnapshotManagerFragment.ARG_SNAPSHOT_IS_AUTO, false));
                     comments.setArguments(snapshotCommentArgs);
                     return comments;
                 }

--- a/app/src/main/java/ceui/lisa/adapters/AbstractIllustAdapter.java
+++ b/app/src/main/java/ceui/lisa/adapters/AbstractIllustAdapter.java
@@ -25,8 +25,14 @@ public abstract class AbstractIllustAdapter<VH extends RecyclerView.ViewHolder>
      */
     protected volatile String snapshotId = null;
 
+    protected volatile boolean snapshotIsAuto = false;
+
     public void setSnapshotId(String snapshotId) {
         this.snapshotId = snapshotId;
+    }
+
+    public void setSnapshotIsAuto(boolean snapshotIsAuto) {
+        this.snapshotIsAuto = snapshotIsAuto;
     }
 
     /**
@@ -56,6 +62,7 @@ public abstract class AbstractIllustAdapter<VH extends RecyclerView.ViewHolder>
             intent.putExtra("dataType", snapshotId != null ? "快照大图" : "二级详情");
             if (snapshotId != null) {
                 intent.putExtra(ceui.pixiv.snapshot.SnapshotManagerFragment.ARG_SNAPSHOT_ID, snapshotId);
+                intent.putExtra(ceui.pixiv.snapshot.SnapshotManagerFragment.ARG_SNAPSHOT_IS_AUTO, snapshotIsAuto);
             }
             intent.putExtra("index", position);
             // 点击处的屏幕矩形:大图页(透明窗口)从这里展开进场,下拉收掉时缩回同一位置

--- a/app/src/main/java/ceui/lisa/fragments/FragmentIllust.kt
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentIllust.kt
@@ -68,6 +68,7 @@ import ceui.loxia.combineLatest
 import ceui.loxia.toTagsBeans
 import ceui.loxia.User
 import ceui.loxia.flag.FlagDescFragment
+import ceui.pixiv.snapshot.AutoSnapshotRepository
 import ceui.pixiv.snapshot.SnapshotManagerFragment
 import ceui.pixiv.snapshot.SnapshotRepository
 import ceui.pixiv.snapshot.SnapshotRuntimeCache
@@ -98,6 +99,8 @@ class FragmentIllust : BaseLazyFragment<FragmentIllustBinding>() {
     private val safeArgs by lazy { IllustArgs(requireArguments()) }
 
     private val snapshotId: String? get() = arguments?.getString(SnapshotManagerFragment.ARG_SNAPSHOT_ID)
+    private val snapshotIsAuto: Boolean
+        get() = arguments?.getBoolean(SnapshotManagerFragment.ARG_SNAPSHOT_IS_AUTO, false) ?: false
     private val isSnapshotMode: Boolean get() = snapshotId != null
     private var snapshotViewerData: SnapshotViewerData? = null
     private var snapshotBean: Illust? = null
@@ -194,7 +197,13 @@ class FragmentIllust : BaseLazyFragment<FragmentIllustBinding>() {
             // 快照可能已被管理页删掉 / manifest 损坏 —— loadViewerData 会抛。
             // 裸 launch 里逃逸的异常直接崩进程,这里就地兜住:提示 + 关页。
             val loaded = try {
-                withContext(Dispatchers.IO) { SnapshotRepository.loadViewerData(appContext, id) }
+                withContext(Dispatchers.IO) {
+                    if (snapshotIsAuto) {
+                        AutoSnapshotRepository.loadAutoViewerData(appContext, id)
+                    } else {
+                        SnapshotRepository.loadViewerData(appContext, id)
+                    }
+                }
             } catch (ce: kotlinx.coroutines.CancellationException) {
                 throw ce
             } catch (e: Exception) {
@@ -256,6 +265,7 @@ class FragmentIllust : BaseLazyFragment<FragmentIllustBinding>() {
         intent.putExtra("objectArthurId", data.illust.user?.id ?: 0L)
         intent.putExtra("objectType", ceui.loxia.ObjectType.ILLUST)
         intent.putExtra(SnapshotManagerFragment.ARG_SNAPSHOT_ID, snapshotId)
+        intent.putExtra(SnapshotManagerFragment.ARG_SNAPSHOT_IS_AUTO, snapshotIsAuto)
         startActivity(intent)
     }
 
@@ -811,6 +821,7 @@ class FragmentIllust : BaseLazyFragment<FragmentIllustBinding>() {
                         baseBind.recyclerView.adapter = adapter
                         if (isSnapshotMode) {
                             adapter.setSnapshotId(snapshotId)
+                            adapter.setSnapshotIsAuto(snapshotIsAuto)
                             applySnapshotLocalPages(adapter)
                         } else {
                             vm.pageDimensions.value?.let { adapter.seedPageDimensions(it) }

--- a/app/src/main/java/ceui/lisa/fragments/FragmentSettingsExperimental.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSettingsExperimental.java
@@ -24,6 +24,19 @@ public class FragmentSettingsExperimental extends SettingsPageFragment<FragmentS
     protected void initData() {
         bindWitGalleryRows();
 
+        // 自动快照是本地离线能力，不涉及站外 UGC，所有渠道都显示。
+        baseBind.autoSnapshotOnBookmark.setChecked(Shaft.sSettings.isAutoSnapshotOnBookmark());
+        baseBind.autoSnapshotOnBookmark.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                Shaft.sSettings.setAutoSnapshotOnBookmark(isChecked);
+                Local.setSettings(Shaft.sSettings);
+                Common.showToast(getString(R.string.string_428));
+            }
+        });
+        baseBind.autoSnapshotOnBookmarkRela.setOnClickListener(v ->
+                baseBind.autoSnapshotOnBookmark.performClick());
+
         // google(Play)渠道:聊天室 / 广场是站外 UGC 入口,合规起见整组不出现。认 IS_LITE
         // 而不是 debug 口径 —— lite 的 debug 包同样没有,与 SettingsCatalog 索引一致。
         if (ceui.lisa.BuildConfig.IS_LITE) {

--- a/app/src/main/java/ceui/lisa/fragments/SettingsCatalog.kt
+++ b/app/src/main/java/ceui/lisa/fragments/SettingsCatalog.kt
@@ -201,6 +201,7 @@ object SettingsCatalog {
             add(Entry(EXPERIMENTAL, "show_chat_room_push_banner_rela", R.string.setting_show_chat_room_push_banner, keywords = "推送 横幅 新消息 通知 banner push"))
             add(Entry(EXPERIMENTAL, "show_plaza_entry_rela", R.string.setting_show_plaza_entry, keywords = "广场 侧边栏 plaza"))
         }
+        add(Entry(EXPERIMENTAL, "auto_snapshot_on_bookmark_rela", R.string.setting_auto_snapshot_on_bookmark, R.string.setting_auto_snapshot_on_bookmark_desc, keywords = "自动快照 离线快照 收藏 静默 后台 snapshot bookmark auto"))
         add(Entry(EXPERIMENTAL, "is_firebase_enable_rela", R.string.string_367, keywords = "统计 分析 隐私 数据收集 遥测 firebase analytics"))
     }
 

--- a/app/src/main/java/ceui/lisa/utils/Settings.java
+++ b/app/src/main/java/ceui/lisa/utils/Settings.java
@@ -331,6 +331,8 @@ public class Settings {
 
     private boolean autoDownloadAfterStar = false; // 收藏后自动下载
 
+    private boolean autoSnapshotOnBookmark = false; // 试验性：收藏时生成离线快照
+
     private boolean r18FilterDefaultEnable = false; // 默认开启R18内容过滤
 
     private boolean toastDownloadResult = true; // 默认提示下载结果
@@ -961,6 +963,14 @@ public class Settings {
 
     public void setAutoDownloadAfterStar(boolean autoDownloadAfterStar) {
         this.autoDownloadAfterStar = autoDownloadAfterStar;
+    }
+
+    public boolean isAutoSnapshotOnBookmark() {
+        return autoSnapshotOnBookmark;
+    }
+
+    public void setAutoSnapshotOnBookmark(boolean autoSnapshotOnBookmark) {
+        this.autoSnapshotOnBookmark = autoSnapshotOnBookmark;
     }
 
     public boolean isShowOriginalPreviewImage() {

--- a/app/src/main/java/ceui/loxia/IllustDetailSupport.kt
+++ b/app/src/main/java/ceui/loxia/IllustDetailSupport.kt
@@ -40,8 +40,9 @@ fun Illust.hasTrustedCaption(): Boolean {
  * 回 v1/illust/detail 拉完整版,整体覆盖(isFullVersion)进 ObjectPool 并返回。
  * app-api 判作品不可见时走网页 ajax 兜底(#592);已删 / 兜底也拿不到 / 网络失败返回
  * null —— 此时不覆盖,保留池里已有数据,由调用方降级处理。
+ * `toUpdate` 可选，不传入时仍保持进 ObjectPool。
  */
-suspend fun fetchFullIllustDetail(illustId: Long): Illust? {
+suspend fun fetchFullIllustDetail(illustId: Long, toUpdate: Boolean = true): Illust? {
     val fresh = try {
         Retro.getAppApi().getIllustByID(illustId).illust
     } catch (ce: CancellationException) {
@@ -58,8 +59,10 @@ suspend fun fetchFullIllustDetail(illustId: Long): Illust? {
         // 同样 error,自然落回 null。
         fetchIllustViaWebApi(illustId) ?: return null
     }
-    ObjectPool.update(usable, isFullVersion = true)
-    usable.user?.let { ObjectPool.update(it) }
+    if (toUpdate) {
+        ObjectPool.update(usable, isFullVersion = true)
+        usable.user?.let { ObjectPool.update(it) }
+    }
     return usable
 }
 

--- a/app/src/main/java/ceui/pixiv/actions/PixivActionHandlers.kt
+++ b/app/src/main/java/ceui/pixiv/actions/PixivActionHandlers.kt
@@ -31,6 +31,8 @@ internal data class BookmarkPayload(
     val bookmark: Boolean,
     val restrict: String,
     val tags: List<String>? = null,
+    /** 是否在收藏成功确认后触发自动快照（单点收藏/按标签收藏为 true，批量收藏为 false）。 */
+    val autoSnapshot: Boolean = false,
 )
 
 /** @param follow true = 关注，false = 取关 */

--- a/app/src/main/java/ceui/pixiv/actions/PixivActionQueue.kt
+++ b/app/src/main/java/ceui/pixiv/actions/PixivActionQueue.kt
@@ -16,6 +16,7 @@ import ceui.pixiv.actionqueue.PendingAction
 import ceui.pixiv.actionqueue.QueuePolicy
 import ceui.pixiv.events.EventReporter
 import ceui.pixiv.session.SessionManager
+import ceui.pixiv.snapshot.AutoSnapshotEngine
 import ceui.pixiv.websocket.AppNetworkMonitor
 import ceui.pixiv.websocket.NetworkMonitor
 import kotlinx.coroutines.CancellationException
@@ -250,6 +251,16 @@ class PixivActionQueue(app: Context) {
                 // 补发的那条本来就没有 bean 可读，漏一次画像强化远好过为它多打一次网络。
                 if (payload.bookmark) {
                     ObjectPool.get<Illust>(payload.id).value?.let(profileManager::onBookmarkIllust)
+                }
+
+                // 事件驱动：收藏被服务端确认成功后再触发自动快照。
+                // 此时读取 ObjectPool 里的值已经是“本地乐观态 == 服务端确认态”，
+                // 不再与队列竞争数据；只有单点收藏/按标签收藏的 payload 才带 autoSnapshot。
+                if (payload.bookmark && payload.autoSnapshot) {
+                    val confirmed = ObjectPool.get<Illust>(payload.id).value
+                        ?.takeIf { it.is_bookmarked == true }
+                        ?: (illust ?: fetched)?.takeIf { it.is_bookmarked == true }
+                    confirmed?.let(AutoSnapshotEngine::onBookmarkConfirmed)
                 }
             }
 

--- a/app/src/main/java/ceui/pixiv/actions/PixivActions.kt
+++ b/app/src/main/java/ceui/pixiv/actions/PixivActions.kt
@@ -92,6 +92,15 @@ object PixivActions {
         bookmark: Boolean,
         restrict: String = defaultBookmarkRestrict(),
     ) {
+        setIllustBookmark(illust, bookmark, restrict, autoSnapshot = true)
+    }
+
+    private fun setIllustBookmark(
+        illust: Illust,
+        bookmark: Boolean,
+        restrict: String,
+        autoSnapshot: Boolean,
+    ) {
         if (illust.isBookmarked == bookmark) return
         applyIllustBookmark(
             illustId = illust.id,
@@ -100,7 +109,10 @@ object PixivActions {
             illust = illust,
             authorId = illust.user?.id,
             authorFollowed = illust.user?.is_followed,
+            autoSnapshot = autoSnapshot,
         )
+        // 自动快照不再在点击时触发，改为 ActionQueue Succeeded 事件后触发，
+        // 避免与收藏/关注写操作“竞争”ObjectPool 数据。
     }
 
     // ── 批量收藏 / 取消收藏 ──────────────────────────────────────────────────
@@ -163,7 +175,7 @@ object PixivActions {
             todo.chunked(BULK_CHUNK).forEach { chunk ->
                 chunk.forEach { illust ->
                     try {
-                        setIllustBookmark(illust, bookmark, restrict)
+                        setIllustBookmark(illust, bookmark, restrict, autoSnapshot = false)
                     } catch (ce: CancellationException) {
                         throw ce
                     } catch (t: Throwable) {
@@ -231,6 +243,7 @@ object PixivActions {
         illust: Illust?,
         authorId: Long?,
         authorFollowed: Boolean?,
+        autoSnapshot: Boolean,
     ) {
         writeIllustBookmarkLocally(illustId, bookmark, illust)
         if (bookmark) RateAppManager.onUserEngaged()
@@ -239,7 +252,9 @@ object PixivActions {
             ActionRequest(
                 type = PixivActionTypes.ILLUST_BOOKMARK,
                 dedupeKey = "${PixivActionTypes.ILLUST_BOOKMARK}:$illustId",
-                payload = Shaft.sGson.toJson(BookmarkPayload(illustId, bookmark, restrict)),
+                payload = Shaft.sGson.toJson(
+                    BookmarkPayload(illustId, bookmark, restrict, autoSnapshot = autoSnapshot)
+                ),
             )
         )
 
@@ -278,13 +293,14 @@ object PixivActions {
     @JvmStatic
     fun bookmarkIllustWithTags(illustId: Long, restrict: String, tags: List<String>) {
         writeIllustBookmarkLocally(illustId, true)
+        // 自动快照统一由 ActionQueue Succeeded 事件触发。
         RateAppManager.onUserEngaged()
         actionQueue.enqueue(
             ActionRequest(
                 type = PixivActionTypes.ILLUST_BOOKMARK,
                 dedupeKey = "${PixivActionTypes.ILLUST_BOOKMARK}:$illustId",
                 payload = Shaft.sGson.toJson(
-                    BookmarkPayload(illustId, true, restrict, tags.ifEmpty { null })
+                    BookmarkPayload(illustId, true, restrict, tags.ifEmpty { null }, autoSnapshot = true)
                 ),
             )
         )

--- a/app/src/main/java/ceui/pixiv/snapshot/AutoSnapshotEngine.kt
+++ b/app/src/main/java/ceui/pixiv/snapshot/AutoSnapshotEngine.kt
@@ -1,0 +1,60 @@
+package ceui.pixiv.snapshot
+
+import ceui.lisa.activities.Shaft
+import ceui.loxia.Illust
+import ceui.loxia.appServices
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * 自动快照引擎：目前只响应“收藏时生成离线快照”这一种信号。
+ *
+ * 静默生成：不弹窗、不 toast；失败只记日志，不重试轰炸。
+ */
+object AutoSnapshotEngine {
+
+    private const val TAG = "AutoSnapshot"
+
+    private val scope = CoroutineScope(
+        SupervisorJob() + Dispatchers.IO +
+            CoroutineExceptionHandler { _, e -> Timber.tag(TAG).e(e, "auto snapshot scope crashed") }
+    )
+
+    private val inFlight = java.util.Collections.synchronizedSet(mutableSetOf<Long>())
+
+    /** 由 PixivActionQueue 在收藏请求被服务端确认成功后调用（事件驱动）。 */
+    fun onBookmarkConfirmed(illust: Illust) {
+        if (!Shaft.sSettings.isAutoSnapshotOnBookmark) return
+        val id = illust.id
+        if (id <= 0L) return
+        if (!inFlight.add(id)) return
+
+        scope.launch {
+            try {
+                val appContext = Shaft.getContext()
+                // 无网/弱网不硬拉，静默跳过。
+                if (appContext.appServices().networkStateManager.networkState.value?.isOnline != true) return@launch
+                // 已有正式快照时不生成；已有同作品自动快照时不重复生成。
+                val formalExists = SnapshotRepository.list(appContext).any { it.manifest.illustId == id }
+                if (formalExists) return@launch
+                val autoExists = AutoSnapshotRepository.listAuto(appContext).any { it.manifest.illustId == id }
+                if (autoExists) return@launch
+
+                SnapshotGenerator.generateAuto(appContext, illust)
+                AutoSnapshotRepository.enforceAutoQuota(appContext)
+                Timber.tag(TAG).i("auto snapshot generated, illustId=%d", id)
+            } catch (ce: CancellationException) {
+                throw ce
+            } catch (e: Exception) {
+                Timber.tag(TAG).w(e, "auto snapshot failed, illustId=%d", id)
+            } finally {
+                inFlight.remove(id)
+            }
+        }
+    }
+}

--- a/app/src/main/java/ceui/pixiv/snapshot/AutoSnapshotRepository.kt
+++ b/app/src/main/java/ceui/pixiv/snapshot/AutoSnapshotRepository.kt
@@ -1,0 +1,77 @@
+package ceui.pixiv.snapshot
+
+import android.content.Context
+import java.io.File
+
+/**
+ * 自动快照仓储：与正式快照共用 ShaftSnapshots 根目录，但只认 auto_manifest.json。
+ *
+ * 自动快照没有正式 manifest.json，因此 SnapshotRepository.list() 天然忽略；
+ * 转正后由 SnapshotPromoter 写入 manifest.json 并删除 auto_manifest.json。
+ */
+object AutoSnapshotRepository {
+
+    /** 本次试验硬编码的自动快照总大小上限。 */
+    private const val AUTO_SNAPSHOT_MAX_BYTES = 200L * 1024 * 1024
+
+    fun listAuto(context: Context): List<AutoSnapshotSummary> {
+        return SnapshotRepository.root(context).listFiles()
+            ?.filter { it.isDirectory }
+            ?.mapNotNull { snapshotDir ->
+                // 已经是正式快照（manifest.json 存在）就不再作为自动快照展示，避免转正后重复卡。
+                if (File(snapshotDir, SNAPSHOT_MANIFEST).isFile) return@mapNotNull null
+                val manifest = SnapshotValidator.readJson<AutoSnapshotManifest>(
+                    File(snapshotDir, AUTO_SNAPSHOT_MANIFEST)
+                ) ?: return@mapNotNull null
+                // 与正式库同一不变式：目录名必须等于 manifest.snapshotId。
+                if (snapshotDir.name != manifest.snapshotId) return@mapNotNull null
+
+                var fileCount = manifest.fileCount
+                var totalSize = manifest.totalSize
+                if (fileCount <= 0 || totalSize <= 0L) {
+                    fileCount = 0
+                    totalSize = 0L
+                    snapshotDir.walkTopDown().forEach { file ->
+                        if (file.isFile) {
+                            fileCount++
+                            totalSize += file.length()
+                        }
+                    }
+                }
+                val coverFile = manifest.coverPath?.let { rel ->
+                    runCatching { safeResolve(snapshotDir, rel) }.getOrNull()?.takeIf { f -> f.isFile }
+                }
+                AutoSnapshotSummary(manifest, fileCount, totalSize, coverFile)
+            }
+            ?.sortedByDescending { it.manifest.createdAt }
+            ?: emptyList()
+    }
+
+    fun readAutoManifest(context: Context, snapshotId: String): AutoSnapshotManifest? =
+        SnapshotValidator.readJson(File(SnapshotRepository.dir(context, snapshotId), AUTO_SNAPSHOT_MANIFEST))
+
+    /**
+     * 复用 SnapshotRepository.loadViewerData，只把 manifest 来源换成 auto_manifest.json。
+     * 内存中转换成 SnapshotManifest 仅用于渲染，不写盘、不保留自动来源痕迹。
+     */
+    fun loadAutoViewerData(context: Context, snapshotId: String): SnapshotViewerData {
+        val manifest = readAutoManifest(context, snapshotId)
+            ?: throw SnapshotException("自动快照不存在或 auto_manifest 损坏: $snapshotId")
+        return SnapshotRepository.loadViewerData(context, snapshotId, manifest.toSnapshotManifest())
+    }
+
+    fun deleteAuto(context: Context, snapshotId: String): Boolean =
+        SnapshotRepository.delete(context, snapshotId)
+
+    /** 统计所有自动快照大小，超过硬编码阈值后按 createdAt 从旧到新淘汰，直到总大小低于阈值。 */
+    fun enforceAutoQuota(context: Context) {
+        var autos = listAuto(context)
+        while (autos.isNotEmpty()) {
+            val total = autos.sumOf { it.totalSize }
+            if (total <= AUTO_SNAPSHOT_MAX_BYTES) break
+            val oldest = autos.minByOrNull { it.manifest.createdAt } ?: break
+            deleteAuto(context, oldest.manifest.snapshotId)
+            autos = listAuto(context)
+        }
+    }
+}

--- a/app/src/main/java/ceui/pixiv/snapshot/AutoSnapshotRepository.kt
+++ b/app/src/main/java/ceui/pixiv/snapshot/AutoSnapshotRepository.kt
@@ -70,7 +70,9 @@ object AutoSnapshotRepository {
             val total = autos.sumOf { it.totalSize }
             if (total <= AUTO_SNAPSHOT_MAX_BYTES) break
             val oldest = autos.minByOrNull { it.manifest.createdAt } ?: break
-            deleteAuto(context, oldest.manifest.snapshotId)
+            // 删除失败（deleteRecursively 半途出错等）必须退出：这一份下轮还会被选中，
+            // 继续循环就是永不推进的全库扫描死循环。宁可本轮超额，等下次生成再收。
+            if (!deleteAuto(context, oldest.manifest.snapshotId)) break
             autos = listAuto(context)
         }
     }

--- a/app/src/main/java/ceui/pixiv/snapshot/SnapshotArtworkFeedSource.kt
+++ b/app/src/main/java/ceui/pixiv/snapshot/SnapshotArtworkFeedSource.kt
@@ -1,5 +1,6 @@
 package ceui.pixiv.snapshot
 
+import android.content.Context
 import ceui.lisa.activities.Shaft
 import ceui.loxia.Illust
 import ceui.loxia.Comment
@@ -20,11 +21,14 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 /**
- * 快照详情页的 feeds 数据源：读私有快照库，产出与在线 ArtworkV3 相同的 Page/Header 条目。
+ * 快照详情页的 feeds 数据源：读快照库，产出与在线 ArtworkV3 相同的 Page/Header 条目。
  * 不产出作者作品 / 相关作品等需要联网的区块。
+ *
+ * [isAuto] 用于 cache miss 时路由到 AutoSnapshotRepository 或 SnapshotRepository。
  */
 class SnapshotArtworkFeedSource(
     private val snapshotId: String,
+    private val isAuto: Boolean,
 ) : FeedSource<String> {
 
     // FeedSource 契约要求实现 main-safe：load 在主线程被调用，磁盘读、Gson 深拷贝、
@@ -33,12 +37,20 @@ class SnapshotArtworkFeedSource(
         if (cursor != null) return@withContext FeedPage(emptyList(), null)
         // 快照是不可变的，缓存里有就别再读一遍磁盘 + 解一遍整份 JSON(含全部评论)。
         val data = SnapshotRuntimeCache.get(snapshotId)
-            ?: SnapshotRepository.loadViewerData(Shaft.getContext(), snapshotId)
+            ?: loadViewerData(Shaft.getContext())
         SnapshotRuntimeCache.put(snapshotId, data)
         val localized = data.localizeIllust()
         val pageItems = ArtworkV3FeedSource.buildArtworkPageItems(localized)
         val headerItems = buildLocalHeaderItems(data, localized)
         FeedPage(pageItems + headerItems, null)
+    }
+
+    private fun loadViewerData(context: Context): SnapshotViewerData {
+        return if (isAuto) {
+            AutoSnapshotRepository.loadAutoViewerData(context, snapshotId)
+        } else {
+            SnapshotRepository.loadViewerData(context, snapshotId)
+        }
     }
 
     private fun buildLocalHeaderItems(

--- a/app/src/main/java/ceui/pixiv/snapshot/SnapshotCommentsFeedSource.kt
+++ b/app/src/main/java/ceui/pixiv/snapshot/SnapshotCommentsFeedSource.kt
@@ -1,5 +1,6 @@
 package ceui.pixiv.snapshot
 
+import android.content.Context
 import ceui.lisa.activities.Shaft
 import ceui.pixiv.feeds.FeedPage
 import ceui.pixiv.feeds.FeedSource
@@ -14,13 +15,14 @@ import kotlinx.coroutines.withContext
 class SnapshotCommentsFeedSource(
     private val snapshotId: String,
     private val illustArthurId: Long,
+    private val isAuto: Boolean,
 ) : FeedSource<String> {
 
     // 同 SnapshotArtworkFeedSource：整段留在 IO 上，逐条评论的本地化不回主线程做。
     override suspend fun load(cursor: String?): FeedPage<String> = withContext(Dispatchers.IO) {
         if (cursor != null) return@withContext FeedPage(emptyList(), null)
         val data = SnapshotRuntimeCache.get(snapshotId)
-            ?: SnapshotRepository.loadViewerData(Shaft.getContext(), snapshotId)
+            ?: loadViewerData(Shaft.getContext())
                 .also { SnapshotRuntimeCache.put(snapshotId, it) }
         val items = data.comments?.threads?.map { thread ->
             CommentFeedItem(
@@ -31,5 +33,13 @@ class SnapshotCommentsFeedSource(
             )
         }.orEmpty()
         FeedPage(items, null)
+    }
+
+    private fun loadViewerData(context: Context): SnapshotViewerData {
+        return if (isAuto) {
+            AutoSnapshotRepository.loadAutoViewerData(context, snapshotId)
+        } else {
+            SnapshotRepository.loadViewerData(context, snapshotId)
+        }
     }
 }

--- a/app/src/main/java/ceui/pixiv/snapshot/SnapshotGenerator.kt
+++ b/app/src/main/java/ceui/pixiv/snapshot/SnapshotGenerator.kt
@@ -17,10 +17,12 @@ import java.io.File
 import java.util.UUID
 
 /**
- * 从在线详情页生成一份 v1 手动快照。
+ * 从在线详情页生成一份离线快照。
  *
  * 数据源优先级：ObjectPool 已有完整元数据 -> 缺失时回 v1/illust/detail 补齐；
  * 图片优先复用 ImageLoaderV3 已下好的共享文件，缺失时由它联网拉取。
+ *
+ * 正式快照写 manifest.json；自动快照写 auto_manifest.json（内部格式，转正后才成为正式快照）。
  */
 object SnapshotGenerator {
 
@@ -31,6 +33,66 @@ object SnapshotGenerator {
         includeOriginal: Boolean,
         onProgress: suspend (String) -> Unit = {},
     ): SnapshotManifest = withContext(Dispatchers.IO) {
+        val content = generateContent(
+            context = context,
+            illust = illust,
+            includeComments = includeComments,
+            includeOriginal = includeOriginal,
+            onProgress = onProgress,
+        )
+        try {
+            val manifest = content.toSnapshotManifest(includeComments, includeOriginal)
+            writeJson(content.snapshotDir, SNAPSHOT_MANIFEST, manifest)
+            manifest
+        } catch (e: Exception) {
+            content.snapshotDir.deleteRecursively()
+            throw e
+        }
+    }
+
+    suspend fun generateAuto(
+        context: Context,
+        illust: Illust,
+        includeOriginal: Boolean = false,
+        onProgress: suspend (String) -> Unit = {},
+    ): AutoSnapshotManifest = withContext(Dispatchers.IO) {
+        val content = generateContent(
+            context = context,
+            illust = illust,
+            includeComments = false,
+            includeOriginal = includeOriginal,
+            onProgress = onProgress,
+        )
+        try {
+            val manifest = content.toAutoSnapshotManifest(includeOriginal)
+            writeJson(content.snapshotDir, AUTO_SNAPSHOT_MANIFEST, manifest)
+            manifest
+        } catch (e: Exception) {
+            content.snapshotDir.deleteRecursively()
+            throw e
+        }
+    }
+
+    private data class SnapshotContent(
+        val snapshotDir: File,
+        val snapshotId: String,
+        val bean: Illust,
+        val pageCount: Int,
+        val assets: Map<String, String>,
+        val pagePaths: List<String>,
+        val comments: SnapshotComments?,
+        val fileCount: Int,
+        val totalSize: Long,
+        val createdAt: Long,
+    )
+
+    private suspend fun generateContent(
+        context: Context,
+        illust: Illust,
+        includeComments: Boolean,
+        includeOriginal: Boolean,
+        onProgress: suspend (String) -> Unit,
+    ): SnapshotContent = withContext(Dispatchers.IO) {
         val appContext = context.applicationContext
         if (illust.isGif()) {
             throw SnapshotException(appContext.getString(R.string.snapshot_unsupported_ugoira))
@@ -46,7 +108,8 @@ object SnapshotGenerator {
             val bean = if (illust.isFullDetail() && illust.hasTrustedCaption()) {
                 illust
             } else {
-                fetchFullIllustDetail(illust.id.toLong()) ?: illust
+                // toUpdate = false：快照生成只是读取完整元数据，不应改动 ObjectPool。
+                fetchFullIllustDetail(illust.id, false) ?: illust
             }
 
             val assets = linkedMapOf<String, String>()
@@ -115,31 +178,66 @@ object SnapshotGenerator {
 
             val fileCount = snapshotDir.walkTopDown().count { it.isFile }
             val totalSize = snapshotDir.walkTopDown().filter { it.isFile }.sumOf { it.length() }
-            val manifest = SnapshotManifest(
+            SnapshotContent(
+                snapshotDir = snapshotDir,
                 snapshotId = snapshotId,
-                createdAt = System.currentTimeMillis(),
-                illustId = bean.id,
-                type = bean.type ?: "illust",
-                includeComments = includeComments,
-                includeOriginal = includeOriginal,
-                isBookmarked = bean.isBookmarked,
-                isFollowed = bean.user?.is_followed ?: false,
-                xRestrict = bean.x_restrict,
+                bean = bean,
                 pageCount = pageCount,
-                title = bean.title,
-                authorName = bean.user?.name,
-                authorId = bean.user?.id,
-                coverPath = pagePaths.firstOrNull(),
+                assets = assets,
+                pagePaths = pagePaths,
+                comments = commentData,
                 fileCount = fileCount,
                 totalSize = totalSize,
+                createdAt = System.currentTimeMillis(),
             )
-            writeJson(snapshotDir, SNAPSHOT_MANIFEST, manifest)
-            manifest
         } catch (e: Exception) {
             snapshotDir.deleteRecursively()
             throw e
         }
     }
+
+    private fun SnapshotContent.toSnapshotManifest(
+        includeComments: Boolean,
+        includeOriginal: Boolean,
+    ): SnapshotManifest = SnapshotManifest(
+        snapshotId = snapshotId,
+        createdAt = createdAt,
+        illustId = bean.id,
+        type = bean.type ?: "illust",
+        includeComments = includeComments,
+        includeOriginal = includeOriginal,
+        isBookmarked = bean.isBookmarked,
+        isFollowed = bean.user?.is_followed ?: false,
+        xRestrict = bean.x_restrict,
+        pageCount = pageCount,
+        title = bean.title,
+        authorName = bean.user?.name,
+        authorId = bean.user?.id,
+        coverPath = pagePaths.firstOrNull(),
+        fileCount = fileCount,
+        totalSize = totalSize,
+    )
+
+    private fun SnapshotContent.toAutoSnapshotManifest(
+        includeOriginal: Boolean,
+    ): AutoSnapshotManifest = AutoSnapshotManifest(
+        snapshotId = snapshotId,
+        createdAt = createdAt,
+        illustId = bean.id,
+        type = bean.type ?: "illust",
+        includeComments = false,
+        includeOriginal = includeOriginal,
+        isBookmarked = bean.isBookmarked,
+        isFollowed = bean.user?.is_followed ?: false,
+        xRestrict = bean.x_restrict,
+        pageCount = pageCount,
+        title = bean.title,
+        authorName = bean.user?.name,
+        authorId = bean.user?.id,
+        coverPath = pagePaths.firstOrNull(),
+        fileCount = fileCount,
+        totalSize = totalSize,
+    )
 
     private suspend fun downloadCommentAssets(
         context: Context,

--- a/app/src/main/java/ceui/pixiv/snapshot/SnapshotListFragment.kt
+++ b/app/src/main/java/ceui/pixiv/snapshot/SnapshotListFragment.kt
@@ -95,6 +95,8 @@ class SnapshotListFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
+        // 例行刷新:不清空、不回顶。看完一个快照返回时列表内容通常一模一样,
+        // Diff 出来是零变更,滚动位置原样保留。
         reload()
     }
 
@@ -103,6 +105,13 @@ class SnapshotListFragment : Fragment() {
         _binding = null
     }
 
+    /**
+     * [resetScroll] 只在导入/删除这类**结构性变更**后传 true。
+     *
+     * 「先清空再提交 + 回顶」是为了让双列瀑布流按新顺序重新布局(否则新卡会被 Diff 塞进
+     * 右列/旧列错位)——那是新卡进来时才需要付的代价。onResume 的例行刷新也这么干的话,
+     * 每次从详情页返回列表都要整个闪一下并跳回顶部,快照一多就再也找不回刚才看到哪了。
+     */
     fun reload(resetScroll: Boolean = false) {
         val appContext = requireContext().applicationContext
         lifecycleScope.launch {

--- a/app/src/main/java/ceui/pixiv/snapshot/SnapshotListFragment.kt
+++ b/app/src/main/java/ceui/pixiv/snapshot/SnapshotListFragment.kt
@@ -36,6 +36,9 @@ import java.util.Locale
 /**
  * 离线快照管理页的单个 Tab：双列瀑布流卡片，按 manifest.type 过滤。
  * filter == null 表示“全部”。
+ *
+ * 列表由正式快照（SnapshotSummary）和自动快照（AutoSnapshotSummary）合并而成：
+ * 自动快照带“自动”标记，长按弹窗可转正/删除，多选模式下不显示勾选框。
  */
 class SnapshotListFragment : Fragment() {
 
@@ -50,6 +53,7 @@ class SnapshotListFragment : Fragment() {
         onOpen = { openSnapshot(it) },
         onExport = { exportSnapshot(it) },
         onDelete = { confirmDelete(it) },
+        onLongPress = { onLongPress(it) },
     ).also { adapter ->
         adapter.onSelectionToggle = { onSelectionCountChanged?.invoke(adapter.selectedIds.size) }
     }
@@ -91,8 +95,6 @@ class SnapshotListFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
-        // 例行刷新:不清空、不回顶。看完一个快照返回时列表内容通常一模一样,
-        // Diff 出来是零变更,滚动位置原样保留。
         reload()
     }
 
@@ -101,35 +103,33 @@ class SnapshotListFragment : Fragment() {
         _binding = null
     }
 
-    /**
-     * [resetScroll] 只在导入/删除这类**结构性变更**后传 true。
-     *
-     * 「先清空再提交 + 回顶」是为了让双列瀑布流按新顺序重新布局(否则新卡会被 Diff 塞进
-     * 右列/旧列错位)——那是新卡进来时才需要付的代价。onResume 的例行刷新也这么干的话,
-     * 每次从详情页返回列表都要整个闪一下并跳回顶部,快照一多就再也找不回刚才看到哪了。
-     */
     fun reload(resetScroll: Boolean = false) {
         val appContext = requireContext().applicationContext
         lifecycleScope.launch {
             val all = try {
-                withContext(Dispatchers.IO) { SnapshotRepository.list(appContext) }
+                withContext(Dispatchers.IO) {
+                    val formal = SnapshotRepository.list(appContext).map { FormalSnapshotCard(it) }
+                    val auto = AutoSnapshotRepository.listAuto(appContext).map { AutoSnapshotCard(it) }
+                    (formal + auto)
+                        .filter { filter == null || it.type == filter }
+                        .sortedByDescending { it.createdAt }
+                }
             } catch (ce: CancellationException) {
                 throw ce
             } catch (e: Exception) {
                 Timber.w(e, "[Snapshot] list failed")
                 return@launch
             }
-            val list = if (filter == null) all else all.filter { it.manifest.type == filter }
             if (_binding == null) return@launch
             if (resetScroll) adapter.submitList(null)
-            adapter.submitList(list)
-            binding.emptyHint.isVisible = list.isEmpty()
+            adapter.submitList(all)
+            binding.emptyHint.isVisible = all.isEmpty()
             if (resetScroll) binding.snapshotList.scrollToPosition(0)
         }
     }
 
     fun enterSelectionMode() {
-        if (adapter.currentList.isEmpty()) return
+        if (!hasItems()) return
         adapter.setSelectionMode(true)
         onSelectionCountChanged?.invoke(0)
     }
@@ -139,12 +139,17 @@ class SnapshotListFragment : Fragment() {
         onSelectionCountChanged?.invoke(0)
     }
 
+    /** 批量操作只包含正式快照；自动快照不可多选、不可批量导出/删除。 */
     fun selectedSnapshots(): List<SnapshotSummary> =
-        adapter.currentList.filter { it.manifest.snapshotId in adapter.selectedIds }
+        adapter.currentList
+            .filterIsInstance<FormalSnapshotCard>()
+            .filter { it.snapshotId in adapter.selectedIds }
+            .map { it.summary }
 
     fun selectedCount(): Int = adapter.selectedIds.size
 
-    fun hasItems(): Boolean = adapter.currentList.isNotEmpty()
+    /** 批量选择只对正式快照有效；自动快照隐匿勾选框，不参与批量操作。 */
+    fun hasItems(): Boolean = adapter.currentList.any { !it.isAuto }
 
     fun isAllSelected(): Boolean = adapter.isAllSelected()
 
@@ -157,18 +162,19 @@ class SnapshotListFragment : Fragment() {
         onSelectionCountChanged?.invoke(adapter.selectedIds.size)
     }
 
-    private fun openSnapshot(summary: SnapshotSummary) {
-        val snapshotId = summary.manifest.snapshotId
+    private fun openSnapshot(card: SnapshotCard) {
+        val snapshotId = card.snapshotId
+        val isAuto = card.isAuto
         val appContext = requireContext().applicationContext
         lifecycleScope.launch {
-            // 先确保内存缓存有完整快照数据，详情页/大图页直接同步消费，避免异步加载竞态。
-            // loadViewerData 对「目录已被删 / illust.json 损坏」是会抛的(卡片可能是上一次
-            // 列表快照,点下去时那份快照已经不在了)——裸 launch 里逃逸出去就是崩进程,
-            // 和 FragmentIllust / ImageDetailActivity 那两个入口一样就地兜住:提示 + 刷新列表。
             try {
                 withContext(Dispatchers.IO) {
                     if (SnapshotRuntimeCache.get(snapshotId) == null) {
-                        val data = SnapshotRepository.loadViewerData(appContext, snapshotId)
+                        val data = if (isAuto) {
+                            AutoSnapshotRepository.loadAutoViewerData(appContext, snapshotId)
+                        } else {
+                            SnapshotRepository.loadViewerData(appContext, snapshotId)
+                        }
                         SnapshotRuntimeCache.put(snapshotId, data)
                     }
                 }
@@ -188,25 +194,82 @@ class SnapshotListFragment : Fragment() {
                 intent.putExtra(TemplateActivity.EXTRA_FRAGMENT, "快照经典查看")
             }
             intent.putExtra(SnapshotManagerFragment.ARG_SNAPSHOT_ID, snapshotId)
+            intent.putExtra(SnapshotManagerFragment.ARG_SNAPSHOT_IS_AUTO, isAuto)
             startActivity(intent)
         }
     }
 
-    private fun exportSnapshot(summary: SnapshotSummary) {
-        pendingExportId = summary.manifest.snapshotId
-        exportLauncher.launch(summary.manifest.safeExportFileName())
+    private fun onLongPress(card: SnapshotCard) {
+        when (card) {
+            is AutoSnapshotCard -> showAutoActions(card)
+            is FormalSnapshotCard -> exportSnapshot(card)
+        }
     }
 
-    private fun confirmDelete(summary: SnapshotSummary) {
+    private fun showAutoActions(card: AutoSnapshotCard) {
+        WitDialog.MessageDialogBuilder(requireContext())
+            .setTitle(card.title ?: getString(R.string.snapshot_untitled))
+            .addAction(R.string.snapshot_promote) { dialog, _ ->
+                dialog.dismiss()
+                confirmPromote(card)
+            }
+            .addAction(0, R.string.snapshot_delete, WitDialogAction.ACTION_PROP_NEGATIVE) { dialog, _ ->
+                dialog.dismiss()
+                confirmDelete(card)
+            }
+            .show()
+    }
+
+    private fun confirmPromote(card: AutoSnapshotCard) {
+        WitDialog.MessageDialogBuilder(requireContext())
+            .setTitle(R.string.snapshot_promote_title)
+            .setMessage(R.string.snapshot_promote_confirm)
+            .addAction(R.string.cancel) { dialog, _ -> dialog.dismiss() }
+            .addAction(R.string.snapshot_promote) { dialog, _ ->
+                dialog.dismiss()
+                val appContext = requireContext().applicationContext
+                lifecycleScope.launch {
+                    try {
+                        withContext(Dispatchers.IO) {
+                            SnapshotPromoter.promote(appContext, card.snapshotId)
+                        }
+                        Common.showToast(getString(R.string.snapshot_promote_success))
+                        reload()
+                    } catch (ce: CancellationException) {
+                        throw ce
+                    } catch (e: Exception) {
+                        Timber.w(e, "[Snapshot] promote failed, id=%s", card.snapshotId)
+                        Common.showToast(getString(R.string.snapshot_promote_failed, e.message ?: ""))
+                    }
+                }
+            }
+            .show()
+    }
+
+    private fun exportSnapshot(card: SnapshotCard) {
+        // 自动快照不允许导出，只有转正为 SnapshotManifest 后才可导出。
+        if (card is AutoSnapshotCard) return
+        val formal = card as FormalSnapshotCard
+        pendingExportId = formal.snapshotId
+        exportLauncher.launch(formal.summary.manifest.safeExportFileName())
+    }
+
+    private fun confirmDelete(card: SnapshotCard) {
         WitDialog.MessageDialogBuilder(requireContext())
             .setTitle(R.string.snapshot_delete)
-            .setMessage(getString(R.string.snapshot_delete_confirm, summary.manifest.title ?: summary.manifest.snapshotId))
+            .setMessage(getString(R.string.snapshot_delete_confirm, card.title ?: card.snapshotId))
             .addAction(R.string.cancel) { dialog, _ -> dialog.dismiss() }
             .addAction(0, R.string.snapshot_delete, WitDialogAction.ACTION_PROP_NEGATIVE) { dialog, _ ->
                 dialog.dismiss()
                 val appContext = requireContext().applicationContext
                 lifecycleScope.launch {
-                    val ok = withContext(Dispatchers.IO) { SnapshotRepository.delete(appContext, summary.manifest.snapshotId) }
+                    val ok = withContext(Dispatchers.IO) {
+                        if (card.isAuto) {
+                            AutoSnapshotRepository.deleteAuto(appContext, card.snapshotId)
+                        } else {
+                            SnapshotRepository.delete(appContext, card.snapshotId)
+                        }
+                    }
                     if (ok) Common.showToast(getString(R.string.snapshot_delete_success)) else Common.showToast(getString(R.string.snapshot_delete_failed))
                     reload(resetScroll = true)
                 }
@@ -228,16 +291,17 @@ class SnapshotListFragment : Fragment() {
 }
 
 private class SnapshotAdapter(
-    private val onOpen: (SnapshotSummary) -> Unit,
-    private val onExport: (SnapshotSummary) -> Unit,
-    private val onDelete: (SnapshotSummary) -> Unit,
-) : ListAdapter<SnapshotSummary, SnapshotViewHolder>(DIFF) {
+    private val onOpen: (SnapshotCard) -> Unit,
+    private val onExport: (SnapshotCard) -> Unit,
+    private val onDelete: (SnapshotCard) -> Unit,
+    private val onLongPress: (SnapshotCard) -> Unit,
+) : ListAdapter<SnapshotCard, SnapshotViewHolder>(DIFF) {
 
     var selectionMode: Boolean = false
         private set
 
     val selectedIds = linkedSetOf<String>()
-    var onSelectionToggle: ((SnapshotSummary) -> Unit)? = null
+    var onSelectionToggle: ((SnapshotCard) -> Unit)? = null
 
     fun setSelectionMode(enabled: Boolean) {
         if (selectionMode == enabled) return
@@ -246,19 +310,19 @@ private class SnapshotAdapter(
         notifyDataSetChanged()
     }
 
-    fun toggleSelection(summary: SnapshotSummary) {
-        if (!selectionMode) return
-        if (!selectedIds.add(summary.manifest.snapshotId)) {
-            selectedIds.remove(summary.manifest.snapshotId)
+    fun toggleSelection(card: SnapshotCard) {
+        if (!selectionMode || card.isAuto) return
+        if (!selectedIds.add(card.snapshotId)) {
+            selectedIds.remove(card.snapshotId)
         }
-        onSelectionToggle?.invoke(summary)
+        onSelectionToggle?.invoke(card)
         notifyDataSetChanged()
     }
 
     fun selectAll() {
         if (!selectionMode) return
         selectedIds.clear()
-        selectedIds.addAll(currentList.map { it.manifest.snapshotId })
+        selectedIds.addAll(currentList.filter { !it.isAuto }.map { it.snapshotId })
         notifyDataSetChanged()
     }
 
@@ -267,8 +331,10 @@ private class SnapshotAdapter(
         notifyDataSetChanged()
     }
 
-    fun isAllSelected(): Boolean =
-        currentList.isNotEmpty() && selectedIds.size == currentList.size
+    fun isAllSelected(): Boolean {
+        val selectable = currentList.count { !it.isAuto }
+        return selectable > 0 && selectedIds.size == selectable
+    }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SnapshotViewHolder {
         val binding = ItemSnapshotBinding.inflate(LayoutInflater.from(parent.context), parent, false)
@@ -276,24 +342,25 @@ private class SnapshotAdapter(
     }
 
     override fun onBindViewHolder(holder: SnapshotViewHolder, position: Int) {
-        val summary = getItem(position)
+        val card = getItem(position)
         holder.bind(
-            summary = summary,
+            card = card,
             onOpen = onOpen,
             onExport = onExport,
             onDelete = onDelete,
+            onLongPress = onLongPress,
             selectionMode = selectionMode,
-            selected = summary.manifest.snapshotId in selectedIds,
-            onToggleSelection = { toggleSelection(summary) },
+            selected = card.snapshotId in selectedIds,
+            onToggleSelection = { toggleSelection(card) },
         )
     }
 
     companion object {
-        private val DIFF = object : DiffUtil.ItemCallback<SnapshotSummary>() {
-            override fun areItemsTheSame(oldItem: SnapshotSummary, newItem: SnapshotSummary): Boolean =
-                oldItem.manifest.snapshotId == newItem.manifest.snapshotId
+        private val DIFF = object : DiffUtil.ItemCallback<SnapshotCard>() {
+            override fun areItemsTheSame(oldItem: SnapshotCard, newItem: SnapshotCard): Boolean =
+                oldItem.snapshotId == newItem.snapshotId
 
-            override fun areContentsTheSame(oldItem: SnapshotSummary, newItem: SnapshotSummary): Boolean =
+            override fun areContentsTheSame(oldItem: SnapshotCard, newItem: SnapshotCard): Boolean =
                 oldItem == newItem
         }
     }
@@ -304,42 +371,42 @@ private class SnapshotViewHolder(
 ) : RecyclerView.ViewHolder(binding.root) {
 
     private companion object {
-        // 只在主线程 bind 里用,一份即可:每格现构造一个 SimpleDateFormat 等于每次滑动
-        // 都重新解析一遍 pattern + 查一遍 Locale/TimeZone,而格式是常量。
         val TIME_FORMAT = SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.getDefault())
     }
 
     fun bind(
-        summary: SnapshotSummary,
-        onOpen: (SnapshotSummary) -> Unit,
-        onExport: (SnapshotSummary) -> Unit,
-        onDelete: (SnapshotSummary) -> Unit,
+        card: SnapshotCard,
+        onOpen: (SnapshotCard) -> Unit,
+        onExport: (SnapshotCard) -> Unit,
+        onDelete: (SnapshotCard) -> Unit,
+        onLongPress: (SnapshotCard) -> Unit,
         selectionMode: Boolean,
         selected: Boolean,
         onToggleSelection: () -> Unit,
     ) {
         val context = binding.root.context
-        if (summary.coverFile != null) {
-            Glide.with(binding.cover).load(summary.coverFile).into(binding.cover)
+        if (card.coverFile != null) {
+            Glide.with(binding.cover).load(card.coverFile).into(binding.cover)
         } else {
             Glide.with(binding.cover).clear(binding.cover)
         }
-        binding.title.text = summary.manifest.title ?: context.getString(R.string.snapshot_untitled)
+        binding.title.text = card.title ?: context.getString(R.string.snapshot_untitled)
         binding.author.text = listOfNotNull(
-            summary.manifest.authorName,
-            "ID ${summary.manifest.authorId ?: summary.manifest.illustId}",
+            card.authorName,
+            "ID ${card.authorId ?: card.illustId}",
         ).joinToString(" · ")
-        val time = TIME_FORMAT.format(Date(summary.manifest.createdAt))
+        val time = TIME_FORMAT.format(Date(card.createdAt))
         binding.time.text = context.getString(
             R.string.snapshot_meta_format,
             time,
-            Formatter.formatShortFileSize(context, summary.totalSize),
+            Formatter.formatShortFileSize(context, card.totalSize),
         )
-        binding.commentTag.isVisible = summary.manifest.includeComments
-        binding.originalTag.isVisible = summary.manifest.includeOriginal
+        binding.autoTag.isVisible = card.isAuto
+        binding.commentTag.isVisible = card.includeComments
+        binding.originalTag.isVisible = card.includeOriginal
 
-        val isR18 = (summary.manifest.xRestrict ?: 0) > 0
-        val pageCount = summary.manifest.pageCount ?: 1
+        val isR18 = (card.xRestrict ?: 0) > 0
+        val pageCount = card.pageCount ?: 1
         binding.r18Badge.isVisible = isR18
         binding.pSize.isVisible = pageCount > 1
         if (pageCount > 1) {
@@ -349,17 +416,26 @@ private class SnapshotViewHolder(
         binding.badgeRow.isVisible = !selectionMode
 
         HistorySelectBadge.bindSelection(binding.selectCheck, binding.deleteButton, selectionMode, selected)
+        // 自动快照在多选态隐匿勾选框，且不可被点选进入批量操作。
+        binding.selectCheck.isVisible = selectionMode && !card.isAuto
+
         if (selectionMode) {
-            binding.root.setOnClickListener { onToggleSelection() }
-            binding.root.setOnLongClickListener(null)
-            binding.deleteButton.setOnClickListener(null)
+            if (card.isAuto) {
+                binding.root.setOnClickListener(null)
+                binding.root.setOnLongClickListener(null)
+                binding.deleteButton.setOnClickListener(null)
+            } else {
+                binding.root.setOnClickListener { onToggleSelection() }
+                binding.root.setOnLongClickListener(null)
+                binding.deleteButton.setOnClickListener(null)
+            }
         } else {
-            binding.root.setOnClickListener { onOpen(summary) }
+            binding.root.setOnClickListener { onOpen(card) }
             binding.root.setOnLongClickListener {
-                onExport(summary)
+                if (card.isAuto) onLongPress(card) else onExport(card)
                 true
             }
-            binding.deleteButton.setOnClickListener { onDelete(summary) }
+            binding.deleteButton.setOnClickListener { onDelete(card) }
         }
     }
 }

--- a/app/src/main/java/ceui/pixiv/snapshot/SnapshotManagerFragment.kt
+++ b/app/src/main/java/ceui/pixiv/snapshot/SnapshotManagerFragment.kt
@@ -338,5 +338,6 @@ class SnapshotManagerFragment : Fragment() {
 
     companion object {
         const val ARG_SNAPSHOT_ID = "snapshotId"
+        const val ARG_SNAPSHOT_IS_AUTO = "snapshotIsAuto"
     }
 }

--- a/app/src/main/java/ceui/pixiv/snapshot/SnapshotModels.kt
+++ b/app/src/main/java/ceui/pixiv/snapshot/SnapshotModels.kt
@@ -11,6 +11,8 @@ const val SNAPSHOT_MANIFEST = "manifest.json"
 const val SNAPSHOT_ILLUST_JSON = "illust.json"
 const val SNAPSHOT_COMMENTS_JSON = "comments.json"
 const val SNAPSHOT_ASSETS_JSON = "assets.json"
+const val AUTO_SNAPSHOT_MANIFEST = "auto_manifest.json"
+const val AUTO_SNAPSHOT_SCHEMA_VERSION = 1
 
 /** 单个离线快照的 manifest，v1 只含手动快照所需的字段。 */
 data class SnapshotManifest(
@@ -31,6 +33,111 @@ data class SnapshotManifest(
     val coverPath: String? = null,
     val fileCount: Int = 0,
     val totalSize: Long = 0L,
+)
+
+/** 自动快照的 manifest，v1 只收录自动生成所需的展示/转正字段。 */
+data class AutoSnapshotManifest(
+    val schemaVersion: Int = AUTO_SNAPSHOT_SCHEMA_VERSION,
+    val snapshotId: String,
+    val createdAt: Long = System.currentTimeMillis(),
+    val illustId: Long,
+    val type: String = "illust",
+    val includeComments: Boolean = false,
+    val includeOriginal: Boolean = false,
+    val isBookmarked: Boolean = false,
+    val isFollowed: Boolean = false,
+    val xRestrict: Int? = null,
+    val pageCount: Int? = null,
+    val title: String? = null,
+    val authorName: String? = null,
+    val authorId: Long? = null,
+    val coverPath: String? = null,
+    val fileCount: Int = 0,
+    val totalSize: Long = 0L,
+)
+
+/** 管理页展示自动快照时使用的轻量摘要。 */
+data class AutoSnapshotSummary(
+    val manifest: AutoSnapshotManifest,
+    val fileCount: Int,
+    val totalSize: Long,
+    val coverFile: File?,
+)
+
+/** 管理页列表统一模型：正式快照或自动快照。 */
+sealed interface SnapshotCard {
+    val snapshotId: String
+    val isAuto: Boolean
+    val createdAt: Long
+    val illustId: Long
+    val type: String
+    val title: String?
+    val authorName: String?
+    val authorId: Long?
+    val xRestrict: Int?
+    val pageCount: Int?
+    val includeComments: Boolean
+    val includeOriginal: Boolean
+    val coverFile: File?
+    val fileCount: Int
+    val totalSize: Long
+}
+
+data class FormalSnapshotCard(val summary: SnapshotSummary) : SnapshotCard {
+    override val snapshotId get() = summary.manifest.snapshotId
+    override val isAuto get() = false
+    override val createdAt get() = summary.manifest.createdAt
+    override val illustId get() = summary.manifest.illustId
+    override val type get() = summary.manifest.type
+    override val title get() = summary.manifest.title
+    override val authorName get() = summary.manifest.authorName
+    override val authorId get() = summary.manifest.authorId
+    override val xRestrict get() = summary.manifest.xRestrict
+    override val pageCount get() = summary.manifest.pageCount
+    override val includeComments get() = summary.manifest.includeComments
+    override val includeOriginal get() = summary.manifest.includeOriginal
+    override val coverFile get() = summary.coverFile
+    override val fileCount get() = summary.fileCount
+    override val totalSize get() = summary.totalSize
+}
+
+data class AutoSnapshotCard(val summary: AutoSnapshotSummary) : SnapshotCard {
+    override val snapshotId get() = summary.manifest.snapshotId
+    override val isAuto get() = true
+    override val createdAt get() = summary.manifest.createdAt
+    override val illustId get() = summary.manifest.illustId
+    override val type get() = summary.manifest.type
+    override val title get() = summary.manifest.title
+    override val authorName get() = summary.manifest.authorName
+    override val authorId get() = summary.manifest.authorId
+    override val xRestrict get() = summary.manifest.xRestrict
+    override val pageCount get() = summary.manifest.pageCount
+    override val includeComments get() = summary.manifest.includeComments
+    override val includeOriginal get() = summary.manifest.includeOriginal
+    override val coverFile get() = summary.coverFile
+    override val fileCount get() = summary.fileCount
+    override val totalSize get() = summary.totalSize
+}
+
+/** 自动快照在内存中转为正式 manifest 的轻量映射；不写盘、不保留自动来源痕迹。 */
+fun AutoSnapshotManifest.toSnapshotManifest(): SnapshotManifest = SnapshotManifest(
+    schemaVersion = SNAPSHOT_SCHEMA_VERSION,
+    snapshotId = snapshotId,
+    createdAt = createdAt,
+    illustId = illustId,
+    type = type,
+    includeComments = includeComments,
+    includeOriginal = includeOriginal,
+    isBookmarked = isBookmarked,
+    isFollowed = isFollowed,
+    xRestrict = xRestrict,
+    pageCount = pageCount,
+    title = title,
+    authorName = authorName,
+    authorId = authorId,
+    coverPath = coverPath,
+    fileCount = fileCount,
+    totalSize = totalSize,
 )
 
 /** assets.json：URL -> 快照目录内相对路径。渲染只允许读这些本地文件。 */

--- a/app/src/main/java/ceui/pixiv/snapshot/SnapshotPromoter.kt
+++ b/app/src/main/java/ceui/pixiv/snapshot/SnapshotPromoter.kt
@@ -1,0 +1,40 @@
+package ceui.pixiv.snapshot
+
+import android.content.Context
+import ceui.lisa.activities.Shaft
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.File
+
+/**
+ * 自动快照转正：在同一个目录里写入正式 manifest.json、删除 auto_manifest.json。
+ *
+ * 转正是完整流程：校验资源 → 写正式 Manifest → 清掉自动来源 → 刷新缓存 →
+ * 列表重载。转正后不保留任何“来自自动快照”的痕迹。
+ */
+object SnapshotPromoter {
+
+    suspend fun promote(context: Context, autoId: String): SnapshotManifest = withContext(Dispatchers.IO) {
+        val appContext = context.applicationContext
+        val snapshotDir = SnapshotRepository.dir(appContext, autoId)
+        val auto = AutoSnapshotRepository.readAutoManifest(appContext, autoId)
+            ?: throw SnapshotException("自动快照不存在或 auto_manifest 损坏: $autoId")
+        val formal = auto.toSnapshotManifest()
+
+        // 必须先做完整资源校验，不能把残缺目录变成正式快照。
+        SnapshotValidator.validateContents(snapshotDir, formal)
+
+        File(snapshotDir, SNAPSHOT_MANIFEST).writeText(Shaft.sGson.toJson(formal))
+        File(snapshotDir, AUTO_SNAPSHOT_MANIFEST).delete()
+
+        // 缓存先尝试更新；失败降级为移除，避免继续读到转正前的 auto 数据。
+        runCatching {
+            val fresh = SnapshotRepository.loadViewerData(appContext, autoId)
+            SnapshotRuntimeCache.put(autoId, fresh)
+        }.onFailure {
+            SnapshotRuntimeCache.remove(autoId)
+        }
+
+        formal
+    }
+}

--- a/app/src/main/java/ceui/pixiv/snapshot/SnapshotRepository.kt
+++ b/app/src/main/java/ceui/pixiv/snapshot/SnapshotRepository.kt
@@ -121,6 +121,15 @@ object SnapshotRepository {
         val snapshotDir = dir(context, snapshotId)
         val manifest = SnapshotValidator.readJson<SnapshotManifest>(File(snapshotDir, SNAPSHOT_MANIFEST))
             ?: throw SnapshotException("快照不存在或 manifest 损坏: $snapshotId")
+        return loadViewerData(context, snapshotId, manifest)
+    }
+
+    internal fun loadViewerData(
+        context: Context,
+        snapshotId: String,
+        manifest: SnapshotManifest,
+    ): SnapshotViewerData {
+        val snapshotDir = dir(context, snapshotId)
         val illust = SnapshotValidator.readJson<Illust>(File(snapshotDir, SNAPSHOT_ILLUST_JSON))
             ?: throw SnapshotException("快照缺少 illust.json: $snapshotId")
         val assets = SnapshotValidator.readJson<SnapshotAssets>(File(snapshotDir, SNAPSHOT_ASSETS_JSON))?.assets ?: emptyMap()

--- a/app/src/main/java/ceui/pixiv/snapshot/SnapshotValidator.kt
+++ b/app/src/main/java/ceui/pixiv/snapshot/SnapshotValidator.kt
@@ -16,6 +16,12 @@ object SnapshotValidator {
         if (!File(snapshotDir, SNAPSHOT_MANIFEST).isFile) {
             throw SnapshotException("缺少 manifest.json")
         }
+        validateContents(snapshotDir, manifest)
+    }
+
+    /** 校验快照目录内已解析的 manifest 对应的内容，不要求 manifest.json 已落盘。 */
+    internal fun validateContents(snapshotDir: File, manifest: SnapshotManifest) {
+        requireSnapshotId(manifest.snapshotId)
         val illust = readJson<Illust>(File(snapshotDir, SNAPSHOT_ILLUST_JSON))
             ?: throw SnapshotException("缺少或无法解析 illust.json")
         val assets = readJson<SnapshotAssets>(File(snapshotDir, SNAPSHOT_ASSETS_JSON))

--- a/app/src/main/java/ceui/pixiv/ui/comments/CommentsFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/comments/CommentsFragment.kt
@@ -63,6 +63,7 @@ class CommentsFragment : FeedFragment(R.layout.fragment_comments_feed), CommentA
         val objectArthurId: Long = b.getLong("objectArthurId")
         val objectType: String = b.getString("objectType").orEmpty()
         val snapshotId: String? = b.getString(SnapshotManagerFragment.ARG_SNAPSHOT_ID)
+        val snapshotIsAuto: Boolean = b.getBoolean(SnapshotManagerFragment.ARG_SNAPSHOT_IS_AUTO, false)
     }
 
     internal val isSnapshotMode: Boolean get() = args.snapshotId != null
@@ -79,8 +80,9 @@ class CommentsFragment : FeedFragment(R.layout.fragment_comments_feed), CommentA
         val objectType = args.objectType
         val illustArthurId = args.objectArthurId
         val snapshotId = args.snapshotId
+        val snapshotIsAuto = args.snapshotIsAuto
         if (snapshotId != null) {
-            SnapshotCommentsFeedSource(snapshotId, illustArthurId)
+            SnapshotCommentsFeedSource(snapshotId, illustArthurId, snapshotIsAuto)
         } else {
             pixivFeedSource(
                 initialFetch = {

--- a/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/detail/ArtworkV3Fragment.kt
@@ -104,6 +104,9 @@ class ArtworkV3Fragment : IllustFeedFragment(R.layout.fragment_artwork_v3) {
 
     internal val snapshotId: String? get() = arguments?.getString(SnapshotManagerFragment.ARG_SNAPSHOT_ID)
 
+    internal val snapshotIsAuto: Boolean
+        get() = arguments?.getBoolean(SnapshotManagerFragment.ARG_SNAPSHOT_IS_AUTO, false) ?: false
+
     internal val isSnapshotMode: Boolean get() = snapshotId != null
 
     private val illustId: Long by lazy(LazyThreadSafetyMode.NONE) {
@@ -111,10 +114,11 @@ class ArtworkV3Fragment : IllustFeedFragment(R.layout.fragment_artwork_v3) {
     }
 
     override val feedViewModel by feedViewModels {
-        // 零捕获:只把 id/快照 id 读进局部值交给长命 VM 持有的数据源,不钉 Fragment。
+        // 零捕获:只把 id/快照 id/是否自动 读进局部值交给长命 VM 持有的数据源,不钉 Fragment。
         val snapshot = arguments?.getString(SnapshotManagerFragment.ARG_SNAPSHOT_ID)
+        val snapshotAuto = arguments?.getBoolean(SnapshotManagerFragment.ARG_SNAPSHOT_IS_AUTO, false) ?: false
         if (snapshot != null) {
-            SnapshotArtworkFeedSource(snapshot)
+            SnapshotArtworkFeedSource(snapshot, snapshotAuto)
         } else {
             ArtworkV3FeedSource(requireArguments().getInt("illust_id").toLong())
         }
@@ -550,6 +554,7 @@ class ArtworkV3Fragment : IllustFeedFragment(R.layout.fragment_artwork_v3) {
         // 必须先打快照标记再喂本地页:adapter 构造时已经发出一趟「已下载文件」后台扫描,
         // 标记会让它回主线程合并时整个作废,避免同 ID 的下载文件顶掉快照里的那一份。
         adapter.setSnapshotId(snapshotId)
+        adapter.setSnapshotIsAuto(snapshotIsAuto)
         val pageCount = illust.page_count.coerceAtLeast(1)
         for (i in 0 until pageCount) {
             data.pageFile(i)?.let { file -> adapter.putLocalPageUri(i, Uri.fromFile(file)) }
@@ -1349,10 +1354,12 @@ class ArtworkV3Fragment : IllustFeedFragment(R.layout.fragment_artwork_v3) {
         fun newInstance(illustId: Long): ArtworkV3Fragment = newInstance(illustId.toInt())
 
         @JvmStatic
-        fun newInstanceSnapshot(snapshotId: String): ArtworkV3Fragment {
+        @JvmOverloads
+        fun newInstanceSnapshot(snapshotId: String, isAuto: Boolean = false): ArtworkV3Fragment {
             return ArtworkV3Fragment().apply {
                 arguments = Bundle().apply {
                     putString(SnapshotManagerFragment.ARG_SNAPSHOT_ID, snapshotId)
+                    putBoolean(SnapshotManagerFragment.ARG_SNAPSHOT_IS_AUTO, isAuto)
                 }
             }
         }

--- a/app/src/main/res/layout/fragment_settings_experimental.xml
+++ b/app/src/main/res/layout/fragment_settings_experimental.xml
@@ -118,6 +118,29 @@
                 </RelativeLayout>
 
                 <RelativeLayout
+                    android:id="@+id/auto_snapshot_on_bookmark_rela"
+                    style="@style/M3SetRow"
+                    android:layout_marginTop="14dp"
+                    android:background="@drawable/wit_row_single">
+
+                    <LinearLayout style="@style/M3SetTexts">
+
+                        <TextView
+                            style="@style/M3SetTitle"
+                            android:text="@string/setting_auto_snapshot_on_bookmark" />
+
+                        <TextView
+                            style="@style/M3SetDesc"
+                            android:text="@string/setting_auto_snapshot_on_bookmark_desc" />
+                    </LinearLayout>
+
+                    <androidx.appcompat.widget.SwitchCompat
+                        android:id="@+id/auto_snapshot_on_bookmark"
+                        style="@style/M3SetSwitch" />
+
+                </RelativeLayout>
+
+                <RelativeLayout
                     android:id="@+id/is_firebase_enable_rela"
                     style="@style/M3SetRow"
                     android:layout_marginTop="14dp"

--- a/app/src/main/res/layout/item_snapshot.xml
+++ b/app/src/main/res/layout/item_snapshot.xml
@@ -152,6 +152,21 @@
                 android:orientation="horizontal">
 
                 <TextView
+                    android:id="@+id/autoTag"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="4dp"
+                    android:background="@drawable/bg_v3_pill"
+                    android:includeFontPadding="false"
+                    android:paddingHorizontal="6dp"
+                    android:paddingVertical="2dp"
+                    android:text="@string/snapshot_auto_badge"
+                    android:textColor="@color/v3_text_2"
+                    android:textSize="10sp"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
+
+                <TextView
                     android:id="@+id/commentTag"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -2785,4 +2785,14 @@
     <string name="snapshot_unsupported_ugoira">Ugoira is not supported for offline snapshots yet</string>
     <string name="snapshot_error_page_url_missing">No usable URL for image %1$d</string>
     <string name="snapshot_error_image_download">Image download failed: %1$s</string>
+
+    <!-- Auto snapshot (experimental) -->
+    <string name="setting_auto_snapshot_on_bookmark">Create offline snapshot on bookmark</string>
+    <string name="setting_auto_snapshot_on_bookmark_desc">Quietly create a lightweight offline snapshot after you bookmark a work (experimental)</string>
+    <string name="snapshot_auto_badge">Auto</string>
+    <string name="snapshot_promote">Convert to regular snapshot</string>
+    <string name="snapshot_promote_title">Convert to Regular Snapshot</string>
+    <string name="snapshot_promote_confirm">After conversion, this snapshot will be kept as a regular snapshot and can be exported. Continue?</string>
+    <string name="snapshot_promote_success">Converted to regular snapshot</string>
+    <string name="snapshot_promote_failed">Conversion failed: %1$s</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -2785,4 +2785,14 @@
     <string name="snapshot_unsupported_ugoira">うごイラ / ugoira はオフラインスナップショットに未対応です</string>
     <string name="snapshot_error_page_url_missing">%1$d 枚目の画像に利用可能な URL がありません</string>
     <string name="snapshot_error_image_download">画像のダウンロードに失敗しました：%1$s</string>
+
+    <!-- 自動スナップショット（試験的） -->
+    <string name="setting_auto_snapshot_on_bookmark">ブックマーク時にオフラインスナップショットを作成</string>
+    <string name="setting_auto_snapshot_on_bookmark_desc">作品をブックマークした後、バックグラウンドで軽量なオフラインスナップショットを静かに作成します（試験的）</string>
+    <string name="snapshot_auto_badge">自動</string>
+    <string name="snapshot_promote">正式スナップショットに変換</string>
+    <string name="snapshot_promote_title">正式スナップショットに変換</string>
+    <string name="snapshot_promote_confirm">変換後は通常のスナップショットとして保存され、書き出しが可能になります。変換しますか？</string>
+    <string name="snapshot_promote_success">正式スナップショットに変換しました</string>
+    <string name="snapshot_promote_failed">変換に失敗しました：%1$s</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2785,4 +2785,14 @@
     <string name="snapshot_unsupported_ugoira">우고이라(ugoira)는 아직 오프라인 스냅샷을 지원하지 않습니다</string>
     <string name="snapshot_error_page_url_missing">%1$d번째 이미지의 사용 가능한 URL이 없습니다</string>
     <string name="snapshot_error_image_download">이미지 다운로드 실패: %1$s</string>
+
+    <!-- 자동 스냅샷 (실험 기능) -->
+    <string name="setting_auto_snapshot_on_bookmark">북마크 시 오프라인 스냅샷 생성</string>
+    <string name="setting_auto_snapshot_on_bookmark_desc">작품을 북마크한 후 백그라운드에서 가벼운 오프라인 스냅샷을 자동 생성합니다 (실험 기능)</string>
+    <string name="snapshot_auto_badge">자동</string>
+    <string name="snapshot_promote">일반 스냅샷으로 전환</string>
+    <string name="snapshot_promote_title">일반 스냅샷으로 전환</string>
+    <string name="snapshot_promote_confirm">전환하면 일반 스냅샷으로 유지되며 내보낼 수 있습니다. 전환하시겠습니까?</string>
+    <string name="snapshot_promote_success">일반 스냅샷으로 전환됨</string>
+    <string name="snapshot_promote_failed">전환 실패: %1$s</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2785,4 +2785,14 @@
     <string name="snapshot_unsupported_ugoira">Ugoira пока не поддерживается для офлайн-снимков</string>
     <string name="snapshot_error_page_url_missing">Нет доступного URL для изображения %1$d</string>
     <string name="snapshot_error_image_download">Не удалось загрузить изображение: %1$s</string>
+
+    <!-- Автоматический снимок (экспериментально) -->
+    <string name="setting_auto_snapshot_on_bookmark">Создавать офлайн-снимок при добавлении в закладки</string>
+    <string name="setting_auto_snapshot_on_bookmark_desc">Тихо создавать лёгкий офлайн-снимок после добавления работы в закладки (экспериментально)</string>
+    <string name="snapshot_auto_badge">Авто</string>
+    <string name="snapshot_promote">Преобразовать в обычный снимок</string>
+    <string name="snapshot_promote_title">Преобразовать в обычный снимок</string>
+    <string name="snapshot_promote_confirm">После преобразования снимок будет сохранён как обычный и его можно будет экспортировать. Продолжить?</string>
+    <string name="snapshot_promote_success">Преобразовано в обычный снимок</string>
+    <string name="snapshot_promote_failed">Не удалось преобразовать: %1$s</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -2785,4 +2785,14 @@
     <string name="snapshot_unsupported_ugoira">Ugoira için çevrimdışı anlık görüntü henüz desteklenmiyor</string>
     <string name="snapshot_error_page_url_missing">%1$d. resim için kullanılabilir URL yok</string>
     <string name="snapshot_error_image_download">Resim indirilemedi: %1$s</string>
+
+    <!-- Otomatik anlık görüntü (deneysel) -->
+    <string name="setting_auto_snapshot_on_bookmark">Yer imine eklendiğinde çevrimdışı anlık görüntü oluştur</string>
+    <string name="setting_auto_snapshot_on_bookmark_desc">Bir eseri yer imine ekledikten sonra arka planda sessizce hafif bir çevrimdışı anlık görüntü oluşturur (deneysel)</string>
+    <string name="snapshot_auto_badge">Otomatik</string>
+    <string name="snapshot_promote">Normal anlık görüntüye dönüştür</string>
+    <string name="snapshot_promote_title">Normal Anlık Görüntüye Dönüştür</string>
+    <string name="snapshot_promote_confirm">Dönüştürdükten sonra bu anlık görüntü normal bir anlık görüntü olarak saklanır ve dışa aktarılabilir. Dönüştürülsün mü?</string>
+    <string name="snapshot_promote_success">Normal anlık görüntüye dönüştürüldü</string>
+    <string name="snapshot_promote_failed">Dönüştürme başarısız: %1$s</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -2787,4 +2787,14 @@
     <string name="snapshot_unsupported_ugoira">動圖 / ugoira 暫不支援離線快照</string>
     <string name="snapshot_error_page_url_missing">作品第 %1$d 張圖缺少可用 URL</string>
     <string name="snapshot_error_image_download">圖片下載失敗：%1$s</string>
+
+    <!-- 自動快照（實驗性） -->
+    <string name="setting_auto_snapshot_on_bookmark">收藏時產生離線快照</string>
+    <string name="setting_auto_snapshot_on_bookmark_desc">收藏作品後在背景靜默產生一份輕量離線快照（實驗性）</string>
+    <string name="snapshot_auto_badge">自動</string>
+    <string name="snapshot_promote">轉為正式快照</string>
+    <string name="snapshot_promote_title">轉為正式快照</string>
+    <string name="snapshot_promote_confirm">轉為正式快照後，它將作為一般快照保留，並且可以匯出。確定轉正嗎？</string>
+    <string name="snapshot_promote_success">已轉為正式快照</string>
+    <string name="snapshot_promote_failed">轉正失敗：%1$s</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3043,6 +3043,17 @@
     <string name="snapshot_unsupported_ugoira">动图 / ugoira 暂不支持离线快照</string>
     <string name="snapshot_error_page_url_missing">作品第 %1$d 张图缺少可用 URL</string>
     <string name="snapshot_error_image_download">图片下载失败：%1$s</string>
+
+    <!-- 自动快照（试验性） -->
+    <string name="setting_auto_snapshot_on_bookmark">收藏时生成离线快照</string>
+    <string name="setting_auto_snapshot_on_bookmark_desc">收藏作品后在后台静默生成一份轻量离线快照（试验性）</string>
+    <string name="snapshot_auto_badge">自动</string>
+    <string name="snapshot_promote">转为正式快照</string>
+    <string name="snapshot_promote_title">转为正式快照</string>
+    <string name="snapshot_promote_confirm">转为正式快照后，它将作为普通快照保留，并且可以导出。确定转正吗？</string>
+    <string name="snapshot_promote_success">已转为正式快照</string>
+    <string name="snapshot_promote_failed">转正失败：%1$s</string>
+
     <!-- 应用内推送（付费用户公告，pixshaft 控制台下发，只弹一次） -->
     <string name="inapp_push_dismiss">知道了</string>
     <string name="inapp_push_default_action">去看看</string>


### PR DESCRIPTION
# 自动快照：收藏确认后事件驱动生成 + 自动快照管理/转正

> 分支：`patch-8-27`（wangwang-code fork）
> 目标：`classic`
> 最新提交：`d7ba6901a`

## 背景

离线快照 v1（手动生成 / 管理 / 离线详情 / 本地大图 / 评论）已经稳定落地。本次在 v1 基础上加入“自动快照”扩展，目标是：

- 用户没有主动点“离线化”时，也能静默保留值得保存的作品；
- 自动快照与正式快照在格式上彻底隔离，只允许“转正”后的 SnapshotManifest 被导出/导入；
- 本次只做试验性开关“收藏时生成离线快照”，跑通收藏确认后的静默生成链路。

## 功能概览

### 1. 试验性开关

```text
设置 → 试验性 → 收藏时生成离线快照
```

默认关闭。开启后，**单点收藏 / 按标签收藏**在服务端确认成功后会静默生成一份轻量自动快照；批量收藏不触发。

### 2. 事件驱动，不与 ObjectPool 竞争

自动快照不再在点击收藏时立即触发，而是等 `PixivActionQueue` 发出 `ActionEvent.Succeeded` 后，再读取 ObjectPool 中已确认的收藏态并生成：

```text
点击收藏 / 按标签收藏
  → 本地乐观更新 + 入队
  → 不触发自动快照

PixivActionQueue 执行成功
  → ActionEvent.Succeeded
  → PixivActionQueue.report()
  → 读取 ObjectPool 当前状态
  → AutoSnapshotEngine.onBookmarkConfirmed()
  → 静默生成自动快照
```

- 批量收藏通过 `BookmarkPayload.autoSnapshot = false` 排除；
- 若用户快速取消收藏导致本地状态已变回 `false`，则不会生成；
- 收藏失败不会生成自动快照。

### 3. 自动快照独立 Manifest

自动快照与正式快照共用 `files/ShaftSnapshots/<snapshotId>/`，但写入的是 `auto_manifest.json`：

```text
files/ShaftSnapshots/<snapshotId>/
├── auto_manifest.json   # 自动快照内部 Manifest
├── illust.json
├── assets.json
├── images/
└── avatars/
```

正式快照仍只认 `manifest.json`，因此：

- `SnapshotRepository.list()` 天然忽略自动快照；
- 自动快照不能导出为 `.shaftsnap`；
- 导入方永远只处理 SnapshotManifest；
- 转正后写入 `manifest.json` 并删除 `auto_manifest.json`，不留自动来源痕迹。

### 4. 管理页自动快照卡片

- 自动快照在管理页可见，卡片带“自动”标记；
- 长按自动快照弹出操作：
  - 转为正式快照；
  - 删除；
  - 不提供导出入口。
- 多选模式下自动快照隐藏勾选框，不参与批量导出/批量删除。

### 5. 完整转正流程 `SnapshotPromoter`

转正不是简单写一个 manifest，而是完整流程：

1. 读取并校验 `auto_manifest.json`；
2. 完整校验 illust / assets / 图片文件；
3. 写入正式 `manifest.json`；
4. 删除 `auto_manifest.json`；
5. `createdAt` 保留自动生成时间；
6. 缓存先尝试更新，失败则移除；
7. 刷新列表，卡片变为普通正式快照，可导出/批量操作。

转正后不保留“来自自动快照”的任何痕迹。

### 6. 自动快照存储上限

本次先硬编码：

```kotlin
private const val AUTO_SNAPSHOT_MAX_BYTES = 200L * 1024 * 1024
```

自动快照生成成功后统计所有自动快照大小，超过阈值按 `createdAt` 从旧到新淘汰，直到总大小低于阈值。

### 7. `isAuto` 路由打通

自动快照从管理页打开时，会携带 `ARG_SNAPSHOT_IS_AUTO` 标志，并在 cache miss 时路由到 `AutoSnapshotRepository`：

- V3 详情页 / 经典详情页；
- 评论页；
- 二级大图查看器；
- `shaftsnap://` 本地图片加载。

## 关键设计

- `fetchFullIllustDetail(illustId, toUpdate = false)`：快照生成只读取完整元数据，不写 ObjectPool；
- `SnapshotGenerator` 对 ObjectPool 完全只读，不再污染收藏态/关注态；
- `AutoSnapshotRepository.listAuto()` 跳过已有 `manifest.json` 的目录，避免转正后重复卡片；
- 自动快照默认不含评论，保持轻量；
- 已有正式快照时不会重复生成自动快照。

## 已知限制

- 自动快照配额为硬编码 200MB；若单份自动快照本身超过阈值，会按“删到低于阈值”的规则被淘汰；
- 自动快照不支持评论；
- 自动快照字符串目前只加了默认 `values/strings.xml`，其他语言回退默认值；
- 本次仍属试验性，后续可扩展观看时长 / 反复观看等更多触发信号。