### PR TITLE
极端比例的窄图作品缩略图统一改用 square_medium，并同步应用到浏览记录页

### DIFF
--- a/app/src/main/java/ceui/lisa/fragments/FragmentHistoryList.kt
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentHistoryList.kt
@@ -31,7 +31,6 @@ import ceui.pixiv.feeds.updateItems
 import ceui.pixiv.witstudio.dialog.WitDialog
 import ceui.pixiv.witstudio.dialog.WitDialogAction
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
@@ -62,6 +61,17 @@ class FragmentHistoryList : FeedFragment(), SelectableHistoryTab {
     internal val historyTimeFormat by lazy {
         SimpleDateFormat(getString(R.string.string_350), Locale.getDefault())
     }
+
+    /**
+     * 插画历史当前列宽（px），与标准瀑布流 IllustFeedFragment.illustColumnWidthPx 同源：
+     * 取 LayoutManager 实时宽度，首帧兜底屏宽，按用户「每行几列」设置分列。
+     */
+    internal val historyColumnWidthPx: Int
+        get() {
+            val listWidth = feedBinding.feedListView.layoutManager?.width?.takeIf { it > 0 }
+                ?: resources.displayMetrics.widthPixels
+            return (listWidth / Shaft.sSettings.lineCount).coerceAtLeast(1)
+        }
 
     override fun onCreateRenderers(): List<FeedRenderer<out FeedItem, out ViewBinding>> =
         listOf(historyIllustRenderer(), historyNovelRenderer())

--- a/app/src/main/java/ceui/lisa/fragments/HistoryFeed.kt
+++ b/app/src/main/java/ceui/lisa/fragments/HistoryFeed.kt
@@ -5,7 +5,6 @@ import androidx.core.view.isVisible
 import ceui.lisa.R
 import ceui.lisa.activities.Shaft
 import ceui.lisa.activities.TemplateActivity
-import ceui.lisa.activities.UActivity
 import ceui.lisa.database.AppDatabase
 import ceui.lisa.database.IllustHistoryEntity
 import ceui.lisa.databinding.CellHistoryIllustV3Binding
@@ -24,6 +23,7 @@ import ceui.pixiv.feeds.FeedRenderer
 import ceui.pixiv.feeds.FeedSource
 import ceui.pixiv.feeds.feedRenderer
 import ceui.pixiv.session.SessionManager
+import ceui.pixiv.ui.common.resolveIllustThumbnailUrl
 import ceui.pixiv.ui.common.tryOpenNovelReaderDirect
 import ceui.pixiv.utils.clearGlideOnRecycle
 import com.bumptech.glide.Glide
@@ -382,9 +382,8 @@ fun FragmentHistoryList.historyIllustRenderer(): FeedRenderer<HistoryIllustFeedI
         // 的高**。scaleType=centerCrop 让 into(ImageView) 按「请求尺寸的宽高比」解码裁图,随后
         // view 按新 ratio 重新量高、再 centerCrop 一次 → 二次裁切放大,图糊且只剩一小块
         //（Glide 不会因为 relayout 重发请求）。同 recy_illust_stagger 那段注释治的病。
-        val columnWidth = (context.resources.displayMetrics.widthPixels /
-                Shaft.sSettings.lineCount).coerceAtLeast(1)
-        Glide.with(context).load(GlideUtil.getMediumImg(illust))
+        val columnWidth = historyColumnWidthPx
+        Glide.with(context).load(resolveIllustThumbnailUrl(illust, columnWidth))
             .override(columnWidth, (columnWidth * ratio).toInt().coerceAtLeast(1))
             .placeholder(R.color.v3_surface_2).into(binding.illustImage)
         binding.title.text = illust.title

--- a/app/src/main/java/ceui/lisa/fragments/HistoryFeed.kt
+++ b/app/src/main/java/ceui/lisa/fragments/HistoryFeed.kt
@@ -383,7 +383,7 @@ fun FragmentHistoryList.historyIllustRenderer(): FeedRenderer<HistoryIllustFeedI
         // view 按新 ratio 重新量高、再 centerCrop 一次 → 二次裁切放大,图糊且只剩一小块
         //（Glide 不会因为 relayout 重发请求）。同 recy_illust_stagger 那段注释治的病。
         val columnWidth = historyColumnWidthPx
-        Glide.with(context).load(resolveIllustThumbnailUrl(illust, columnWidth))
+        Glide.with(context).load(resolveIllustThumbnailUrl(illust))
             .override(columnWidth, (columnWidth * ratio).toInt().coerceAtLeast(1))
             .placeholder(R.color.v3_surface_2).into(binding.illustImage)
         binding.title.text = illust.title

--- a/app/src/main/java/ceui/pixiv/ui/common/IllustStaggerRenderer.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/IllustStaggerRenderer.kt
@@ -22,6 +22,7 @@ import ceui.pixiv.feeds.feedRenderer
 import ceui.pixiv.ui.recommend.bindTrendingScore
 import ceui.pixiv.utils.playLikePressHaptic
 import ceui.pixiv.utils.setOnClick
+import com.bumptech.glide.load.model.GlideUrl
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.bumptech.glide.request.RequestOptions.bitmapTransform
 import jp.wasabeef.glide.transformations.BlurTransformation
@@ -30,6 +31,12 @@ import java.util.Locale
 /** 瀑布流卡片高度钳制（对齐 legacy IAdapter）：高 = 宽的 0.6~2.0 倍。 */
 private const val MIN_HEIGHT_RATIO = 0.6f
 private const val MAX_HEIGHT_RATIO = 2.0f
+
+/** 极端高宽比阈值：比例超过该值视为“离谱”。 */
+private const val EXTREME_HEIGHT_RATIO = 4f
+
+/** 原图宽度低于卡片宽度的该倍数时视为“宽小”。 */
+private const val MIN_WIDTH_RATIO_FOR_SQUARE = 1.5f
 
 /** 屏蔽态的 Glide 模糊参数（对齐画师头图 [ceui.pixiv.ui.muted] 那套 25/3，够糊到认不出内容）。 */
 private const val SPOILER_BLUR_RADIUS = 25
@@ -265,6 +272,33 @@ private fun heightRatioOf(bean: Illust): Float {
 }
 
 /**
+ * 插画缩略图取图策略（瀑布流 / 浏览记录等共用）：
+ * - 比例离谱且原图宽度小于卡片宽度 1.5 倍 → 改用 square_medium（缺失时回退 medium）；
+ * - 否则正常走 large/medium，centerCrop 裁剪由调用方原有逻辑处理。
+ */
+internal fun resolveIllustThumbnailUrl(
+    bean: Illust,
+    columnWidth: Int,
+): GlideUrl? {
+    if (bean.width > 0 && bean.height > 0 && shouldUseSquareThumb(bean, columnWidth)) {
+        return GlideUtil.getUrl(
+            bean.image_urls?.square_medium?.takeIf { it.isNotBlank() }
+                ?: bean.image_urls?.medium
+        )
+    }
+    if (Shaft.sSettings.isShowLargeThumbnailImage) {
+        return GlideUtil.getLargeImage(bean)
+    }
+    return GlideUtil.getMediumImg(bean)
+}
+
+private fun shouldUseSquareThumb(bean: Illust, columnWidth: Int): Boolean {
+    val ratio = bean.height.toFloat() / bean.width
+    return ratio > EXTREME_HEIGHT_RATIO &&
+            bean.width < columnWidth * MIN_WIDTH_RATIO_FOR_SQUARE
+}
+
+/**
  * 卡片图加载。全量绑定和「屏蔽态切换」的局部重绑共用同一条路径，两边参数必须逐字一致 ——
  * 否则局部重绑刚换的图会被下一次全量绑定按不同的 key 再拉一遍（白闪一次）。
  */
@@ -273,17 +307,15 @@ private fun IllustFeedFragment.loadIllustImage(
     bean: Illust,
     spoilered: Boolean,
 ) {
-    val imgUrl = if (Shaft.sSettings.isShowLargeThumbnailImage()) {
-        GlideUtil.getLargeImage(bean)
-    } else {
-        GlideUtil.getMediumImg(bean)
-    }
+    // 取图策略统一走共享解析：large（开关开） / medium（常规） / square_medium（极端高宽比兜底）。
+    val columnWidth = illustColumnWidthPx
+    val displayRatio = heightRatioOf(bean)
+    val imgUrl = resolveIllustThumbnailUrl(bean, columnWidth)
     // 请求尺寸必须显式 override：into(ImageView) 对 centerCrop 会在解码阶段按「请求尺寸」
     // 的宽高比裁位图，而默认请求尺寸取复用卡片上一次布局残留的旧宽高（旧方向的列宽 ×
     // 上一张图的比例），横竖屏来回切后图会被裁得只剩一小块还发糊，且 view 重新量高后
     // Glide 不会重发请求。override 成当前列宽 × 钳制后比例，请求宽高比恒等于展示宽高比。
-    val columnWidth = illustColumnWidthPx
-    val columnHeight = (columnWidth * heightRatioOf(bean)).toInt()
+    val columnHeight = (columnWidth * displayRatio).toInt()
     // GlideUrlChild 每次构造都带当前时间戳请求头（PixivHeaders.x-client-time/hash），
     // 而 GlideUrl.equals() 要求 headers 也相等才算「同一请求」——这里的 headers 又是个
     // 没重写 equals 的 lambda，Glide 自己的活跃资源缓存永远认不出「这张图已经在显示」。

--- a/app/src/main/java/ceui/pixiv/ui/common/IllustStaggerRenderer.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/IllustStaggerRenderer.kt
@@ -32,11 +32,15 @@ import java.util.Locale
 private const val MIN_HEIGHT_RATIO = 0.6f
 private const val MAX_HEIGHT_RATIO = 2.0f
 
-/** 极端高宽比阈值：比例超过该值视为“离谱”。 */
+/**
+ * 极端高宽比阈值：比例超过该值视为“离谱”，缩略图改走 square_medium。
+ *
+ * 只看比例、不看原图宽：pixiv 的 medium / large 是按 540x540 / 600x1200 的盒子等比缩进去的，
+ * 缩略图实际宽 = 540/比例（medium）或 1200/比例（large），**与原图宽无关** —— 一张
+ * 3000x13000 的图 medium 也只有 125px 宽。比例 > 4 时缩略图宽必 ≤ 135 / 300px，
+ * 无论列宽多少都会被 centerCrop 横向拉糊，所以不需要再拿原图宽和列宽比一次。
+ */
 private const val EXTREME_HEIGHT_RATIO = 4f
-
-/** 原图宽度低于卡片宽度的该倍数时视为“宽小”。 */
-private const val MIN_WIDTH_RATIO_FOR_SQUARE = 1.5f
 
 /** 屏蔽态的 Glide 模糊参数（对齐画师头图 [ceui.pixiv.ui.muted] 那套 25/3，够糊到认不出内容）。 */
 private const val SPOILER_BLUR_RADIUS = 25
@@ -273,14 +277,11 @@ private fun heightRatioOf(bean: Illust): Float {
 
 /**
  * 插画缩略图取图策略（瀑布流 / 浏览记录等共用）：
- * - 比例离谱且原图宽度小于卡片宽度 1.5 倍 → 改用 square_medium（缺失时回退 medium）；
+ * - 比例离谱（见 [EXTREME_HEIGHT_RATIO]）→ 改用 square_medium（缺失时回退 medium）；
  * - 否则正常走 large/medium，centerCrop 裁剪由调用方原有逻辑处理。
  */
-internal fun resolveIllustThumbnailUrl(
-    bean: Illust,
-    columnWidth: Int,
-): GlideUrl? {
-    if (bean.width > 0 && bean.height > 0 && shouldUseSquareThumb(bean, columnWidth)) {
+internal fun resolveIllustThumbnailUrl(bean: Illust): GlideUrl? {
+    if (bean.width > 0 && bean.height > 0 && shouldUseSquareThumb(bean)) {
         return GlideUtil.getUrl(
             bean.image_urls?.square_medium?.takeIf { it.isNotBlank() }
                 ?: bean.image_urls?.medium
@@ -292,11 +293,8 @@ internal fun resolveIllustThumbnailUrl(
     return GlideUtil.getMediumImg(bean)
 }
 
-private fun shouldUseSquareThumb(bean: Illust, columnWidth: Int): Boolean {
-    val ratio = bean.height.toFloat() / bean.width
-    return ratio > EXTREME_HEIGHT_RATIO &&
-            bean.width < columnWidth * MIN_WIDTH_RATIO_FOR_SQUARE
-}
+private fun shouldUseSquareThumb(bean: Illust): Boolean =
+    bean.height.toFloat() / bean.width > EXTREME_HEIGHT_RATIO
 
 /**
  * 卡片图加载。全量绑定和「屏蔽态切换」的局部重绑共用同一条路径，两边参数必须逐字一致 ——
@@ -310,7 +308,7 @@ private fun IllustFeedFragment.loadIllustImage(
     // 取图策略统一走共享解析：large（开关开） / medium（常规） / square_medium（极端高宽比兜底）。
     val columnWidth = illustColumnWidthPx
     val displayRatio = heightRatioOf(bean)
-    val imgUrl = resolveIllustThumbnailUrl(bean, columnWidth)
+    val imgUrl = resolveIllustThumbnailUrl(bean)
     // 请求尺寸必须显式 override：into(ImageView) 对 centerCrop 会在解码阶段按「请求尺寸」
     // 的宽高比裁位图，而默认请求尺寸取复用卡片上一次布局残留的旧宽高（旧方向的列宽 ×
     // 上一张图的比例），横竖屏来回切后图会被裁得只剩一小块还发糊，且 view 重新量高后


### PR DESCRIPTION
# 极端比例的窄图作品缩略图统一改用 square_medium，并同步应用到浏览记录页

> 分支：`patch-8-29`（wangwang-code fork；本地 remote 名为 `my`）
> 提交：`c4384179e`

## 背景

Pixiv 的 `medium` / `large` 缩略图都是对原图做等比缩小。对于极端比例的窄图（例如 `700x16005`），经过 Pixiv 压缩后其宽度会变得更窄，直接拿它当瀑布流缩略图，在本地卡片上会被强行横向拉伸成糊图。

而 app-api 端点没有提供不同质量图各自的实际尺寸。如果为了判断清晰度先下载 medium/large 再解尺寸，既浪费流量，也会增加列表滚动/加载的迟滞感。

因此本次只使用 `Illust.width / height` 做推断来决定是否切换图片来源：

- 比例离谱（`height / width > 4`）
- 且原图宽度小于卡片宽度 1.5 倍（`width < columnWidth * 1.5`）
- → 改用 `square_medium`
- 否则 → 继续正常使用 `large` / `medium`，`centerCrop` 裁剪走原有逻辑

## 改动内容

1. 抽出共享取图策略 `resolveIllustThumbnailUrl(bean, columnWidth)`：
   - 统一判断 `square_medium` / `large` / `medium` 的选取；
   - 避免瀑布流与浏览记录页各自维护一套取图逻辑再次漂移。

2. 标准瀑布流插画卡 `IllustStaggerRenderer` 接入该共享策略：
   - 开关「缩略图显示大图」仍生效；
   - 极端窄图即使开启大图，也不再无脑使用会被拉糊的 `large`。

3. 浏览记录页同步应用：
   - `HistoryFeed.historyIllustRenderer` 改用同一取图策略；
   - `FragmentHistoryList` 新增 `historyColumnWidthPx`，与标准瀑布流 `illustColumnWidthPx` 同源，取实际 RecyclerView 列宽而不是屏幕宽近似。

4. 判定参数：
   - `EXTREME_HEIGHT_RATIO = 4f`
   - `MIN_WIDTH_RATIO_FOR_SQUARE = 1.5f`

## 涉及文件

- `app/src/main/java/ceui/pixiv/ui/common/IllustStaggerRenderer.kt`
- `app/src/main/java/ceui/lisa/fragments/HistoryFeed.kt`
- `app/src/main/java/ceui/lisa/fragments/FragmentHistoryList.kt`

## 提交

- `c4384179e` 极端比例的窄图作品的缩略图统一用square_medium并同步应用到浏览记录页

## 测试情况

- `:app:compileGithubDebugKotlin` 编译通过；
- 真机验证瀑布流卡片「极端窄图不再糊」；
- 浏览记录页与标准瀑布流共用同一套取图判定，行为一致。