### PR TITLE
备份导出遵循 Backup 桶模板路径/文件名，修正默认 .json 扩展名并强制重命名

### DIFF
--- a/app/src/main/java/ceui/lisa/download/IllustDownload.java
+++ b/app/src/main/java/ceui/lisa/download/IllustDownload.java
@@ -301,7 +301,7 @@ public class IllustDownload {
                 try {
                     fileWriter.doSomething(textFile);
                     Common.showLog("downloadBackupFile displayName " + textFile.getName());
-                    OutPut.outPutBackupFile(activity, textFile);
+                    OutPut.outPutBackupFile(activity, textFile, displayName);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/app/src/main/java/ceui/lisa/download/IllustDownload.java
+++ b/app/src/main/java/ceui/lisa/download/IllustDownload.java
@@ -301,7 +301,7 @@ public class IllustDownload {
                 try {
                     fileWriter.doSomething(textFile);
                     Common.showLog("downloadBackupFile displayName " + textFile.getName());
-                    OutPut.outPutBackupFile(activity, textFile, textFile.getName());
+                    OutPut.outPutBackupFile(activity, textFile);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/app/src/main/java/ceui/lisa/file/OutPut.kt
+++ b/app/src/main/java/ceui/lisa/file/OutPut.kt
@@ -51,14 +51,11 @@ object OutPut {
     }
 
     @JvmStatic
-    fun outPutBackupFile(context: Context, from: File, fileName: String) {
+    fun outPutBackupFile(context: Context, from: File) {
         // 备份文件本身就是 JSON（Shaft-Backup.json），之前写成 application/zip 会让
         // MediaStore 按 MIME 给文件补一个 .zip 后缀，看起来像压缩包实则不是（#949）。
-        writeRaw(Bucket.Backup, "ShaftBackups/$fileName", "application/json", from, R.string.save_backup_failed)
-    }
-
-    private fun writeRaw(bucket: Bucket, rawPath: String, mime: String, from: File, failedMsgId: Int) {
-        writeRawPath(bucket, RelativePath.parse(rawPath), mime, from, failedMsgId)
+        // 目录和文件名都按用户在「下载路径」里给 Backup 桶配的模板走，不再硬编码。
+        writeRawPath(Bucket.Backup, DownloadItems.backupDestination(), "application/json", from, R.string.save_backup_failed)
     }
 
     private fun writeRawPath(bucket: Bucket, path: RelativePath, mime: String, from: File, failedMsgId: Int) {

--- a/app/src/main/java/ceui/lisa/file/OutPut.kt
+++ b/app/src/main/java/ceui/lisa/file/OutPut.kt
@@ -51,11 +51,12 @@ object OutPut {
     }
 
     @JvmStatic
-    fun outPutBackupFile(context: Context, from: File) {
+    fun outPutBackupFile(context: Context, from: File, fileName: String) {
         // 备份文件本身就是 JSON（Shaft-Backup.json），之前写成 application/zip 会让
         // MediaStore 按 MIME 给文件补一个 .zip 后缀，看起来像压缩包实则不是（#949）。
-        // 目录和文件名都按用户在「下载路径」里给 Backup 桶配的模板走，不再硬编码。
-        writeRawPath(Bucket.Backup, DownloadItems.backupDestination(), "application/json", from, R.string.save_backup_failed)
+        // 目录和文件名都按用户在「下载路径」里给 Backup 桶配的模板走，不再硬编码；
+        // [fileName] 只作为模板的 {title}（区分设置备份 / 浏览历史 / 屏蔽记录 / 词典）。
+        writeRawPath(Bucket.Backup, DownloadItems.backupDestination(fileName), "application/json", from, R.string.save_backup_failed)
     }
 
     private fun writeRawPath(bucket: Bucket, path: RelativePath, mime: String, from: File, failedMsgId: Int) {

--- a/app/src/main/java/ceui/lisa/fragments/FragmentHistoryTabs.kt
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentHistoryTabs.kt
@@ -13,6 +13,7 @@ import android.widget.EditText
 import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.widget.SearchView
 import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
 import androidx.core.view.MenuItemCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentPagerAdapter
@@ -356,8 +357,9 @@ class FragmentHistoryTabs : Fragment(R.layout.viewpager_with_tablayout) {
     }
 
     /**
-     * 导出全部本地浏览历史(插画/漫画/小说/用户)到 Download/ShaftBackups/Shaft-BrowseHistory.json。
-     * 读库在 IO,落盘复用 [IllustDownload.downloadBackupFile](走 MediaStore + 分享同设置页备份)。
+     * 导出全部本地浏览历史(插画/漫画/小说/用户)到 Backup 桶模板目录（默认 Download/ShaftBackups，
+     * 文件名由 Backup 桶模板决定）。读库在 IO,落盘复用 [IllustDownload.downloadBackupFile]
+     * (走 MediaStore + 分享同设置页备份)。
      */
     private fun exportHistory() {
         val act = activity as? BaseActivity<*> ?: return
@@ -391,10 +393,8 @@ class FragmentHistoryTabs : Fragment(R.layout.viewpager_with_tablayout) {
             addCategory(Intent.CATEGORY_OPENABLE)
             type = "*/*"
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                val initialUri = Uri.parse(
-                    "content://com.android.externalstorage.documents/document/primary:" +
-                        "Download%2fShaftBackups%2f" + BROWSE_HISTORY_FILE_NAME,
-                )
+                val initialUri =
+                    "content://com.android.externalstorage.documents/document/primary:Download".toUri()
                 putExtra(DocumentsContract.EXTRA_INITIAL_URI, initialUri)
             }
         }

--- a/app/src/main/java/ceui/lisa/fragments/FragmentSettingsData.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSettingsData.java
@@ -47,6 +47,9 @@ import ceui.pixiv.ui.bulk.UgoiraEngine;
 /** 设置 · 备份与缓存 */
 public class FragmentSettingsData extends SettingsPageFragment<FragmentSettingsDataBinding> {
 
+    /** 设置备份的名字：临时文件名，同时是 Backup 桶模板里的 {title}。 */
+    private static final String BACKUP_FILE_NAME = "Shaft-Backup.json";
+
     @Override
     public void initLayout() {
         mLayoutID = R.layout.fragment_settings_data;
@@ -72,7 +75,7 @@ public class FragmentSettingsData extends SettingsPageFragment<FragmentSettingsD
                             final boolean backupViewHistory = builder.isChecked();
                             // 走 fileWriter 流式导出:读库 + 序列化 + 落盘全在 IO 线程逐批直写文件,
                             // 不再在主线程把整张历史表 toJson 成巨型 String(大历史库 OOM/ANR,#981)。
-                            IllustDownload.downloadBackupFile((BaseActivity<?>) mActivity, "Shaft-Backup.json", (Callback<File>) textFile -> {
+                            IllustDownload.downloadBackupFile((BaseActivity<?>) mActivity, BACKUP_FILE_NAME, (Callback<File>) textFile -> {
                                 try {
                                     BackupUtils.writeBackupToFile(mContext, backupViewHistory, textFile);
                                 } catch (IOException e) {
@@ -220,7 +223,7 @@ public class FragmentSettingsData extends SettingsPageFragment<FragmentSettingsD
 
     private String backupTemplateFolder() {
         try {
-            RelativePath rel = DownloadItems.backupDestination();
+            RelativePath rel = DownloadItems.backupDestination(BACKUP_FILE_NAME);
             return TextUtils.join("/", rel.getDirectory());
         } catch (Throwable t) {
             return "ShaftBackups";

--- a/app/src/main/java/ceui/lisa/fragments/FragmentSettingsData.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSettingsData.java
@@ -39,6 +39,8 @@ import ceui.lisa.utils.Params;
 import ceui.lisa.utils.Settings;
 import ceui.loxia.MoonSync;
 import ceui.pixiv.download.DownloadsRegistry;
+import ceui.pixiv.download.config.DownloadItems;
+import ceui.pixiv.download.model.RelativePath;
 import ceui.pixiv.session.SessionManager;
 import ceui.pixiv.ui.bulk.UgoiraEngine;
 
@@ -95,7 +97,7 @@ public class FragmentSettingsData extends SettingsPageFragment<FragmentSettingsD
             intent.addCategory(Intent.CATEGORY_OPENABLE);//必须
             intent.setType("*/*");//必须
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                Uri backupFileUri = Uri.parse("content://com.android.externalstorage.documents/document/primary:" + "Download%2fShaftBackups%2fShaft-Backup.json");
+                Uri backupFileUri = Uri.parse("content://com.android.externalstorage.documents/document/primary:Download");
                 intent.putExtra(EXTRA_INITIAL_URI, backupFileUri);
             }
             startActivityForResult(intent, Params.REQUEST_CODE_CHOOSE);
@@ -183,17 +185,20 @@ public class FragmentSettingsData extends SettingsPageFragment<FragmentSettingsD
 
     /**
      * 备份成功提示里要展示的目录路径。备份文件经 OutPut.outPutBackupFile 走
-     * Bucket.Backup + "ShaftBackups/…",最终落点由当前存储配置决定,不再固定在
-     * Download:非 SAF(图库/下载)是 Download/ShaftBackups(Settings.FILE_PATH_BACKUP);
-     * SAF 则落在用户所选 tree 下的 ShaftBackups。SAF 分支能解析出真实文件系统路径
-     * 就显示路径,否则退回文件夹显示名,绝不拼一个不存在的 /storage/… 误导用户(#940)。
+     * [Bucket.Backup] 模板,最终落点由当前存储配置决定:非 SAF(图库/下载)是
+     * Download + 模板目录;SAF 则落在用户所选 tree 下的模板目录。SAF 分支能解析出
+     * 真实文件系统路径就显示路径,否则退回文件夹显示名,绝不拼一个不存在的
+     * /storage/… 误导用户(#940)。
      */
     private String backupTargetFolder() {
+        String relDir = backupTemplateFolder();
         // 用 DownloadsRegistry.isSaf()(读实时配置)而不是 Shaft.sSettings.getDownloadWay():
         // 后者切换到图库/下载时不会被回写,是过时字段。SAF 是全局一刀切,
         // 图片存储是 SAF ⟺ 备份桶也是 SAF。
         if (!DownloadsRegistry.isSaf()) {
-            return Settings.FILE_PATH_BACKUP;
+            String downloads = Environment.getExternalStoragePublicDirectory(
+                    Environment.DIRECTORY_DOWNLOADS).getAbsolutePath();
+            return TextUtils.isEmpty(relDir) ? downloads : downloads + "/" + relDir;
         }
         String rootUri = Shaft.sSettings.getRootPathUri();
         if (TextUtils.isEmpty(rootUri)) {
@@ -202,12 +207,24 @@ public class FragmentSettingsData extends SettingsPageFragment<FragmentSettingsD
         Uri treeUri = Uri.parse(rootUri);
         String fsPath = safTreeToFsPath(treeUri);
         if (fsPath != null) {
-            return fsPath + "/ShaftBackups";
+            return TextUtils.isEmpty(relDir) ? fsPath : fsPath + "/" + relDir;
         }
         // 云端/非外部存储 provider 解析不出真实路径 —— 显示文件夹名而不是假路径
         DocumentFile tree = DocumentFile.fromTreeUri(mContext, treeUri);
         String name = tree != null ? tree.getName() : null;
-        return TextUtils.isEmpty(name) ? "" : name + "/ShaftBackups";
+        if (TextUtils.isEmpty(name)) {
+            return TextUtils.isEmpty(relDir) ? "" : relDir;
+        }
+        return TextUtils.isEmpty(relDir) ? name : name + "/" + relDir;
+    }
+
+    private String backupTemplateFolder() {
+        try {
+            RelativePath rel = DownloadItems.backupDestination();
+            return TextUtils.join("/", rel.getDirectory());
+        } catch (Throwable t) {
+            return "ShaftBackups";
+        }
     }
 
     /**

--- a/app/src/main/java/ceui/lisa/fragments/FragmentViewPager.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentViewPager.java
@@ -268,8 +268,7 @@ public class FragmentViewPager extends BaseFragment<ViewpagerWithTablayoutBindin
         intent.addCategory(Intent.CATEGORY_OPENABLE);
         intent.setType("*/*");
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            Uri initialUri = Uri.parse("content://com.android.externalstorage.documents/document/primary:"
-                    + "Download%2fShaftBackups%2f" + MUTE_RECORDS_FILE_NAME);
+            Uri initialUri = Uri.parse("content://com.android.externalstorage.documents/document/primary:Download");
             intent.putExtra(EXTRA_INITIAL_URI, initialUri);
         }
         startActivityForResult(intent, REQUEST_CODE_IMPORT_MUTE);

--- a/app/src/main/java/ceui/pixiv/download/config/DownloadConfig.kt
+++ b/app/src/main/java/ceui/pixiv/download/config/DownloadConfig.kt
@@ -47,9 +47,12 @@ data class DownloadConfig(
             Bucket.NovelSeries, Bucket.Caption -> perBucket[Bucket.Novel]
             else -> null
         }
+        // [Bucket.Backup] 同理：「全部重置」会把 perBucket 清空，备份若掉回 defaults.template
+        // 就会按插画模板渲染成 ShaftImages/_0.json，所以模板缺省固定用备份自己的默认值。
         val fallbackTemplate = when (bucket) {
             Bucket.NovelSeries -> DefaultTemplates.NOVEL_SERIES
             Bucket.Caption -> DefaultTemplates.CAPTION
+            Bucket.Backup -> DefaultTemplates.BACKUP
             else -> defaults.template
         }
         // 备份文件是 JSON 快照，冲突时不能覆盖也不能跳过：强制重命名，避免旧备份被静默替换。

--- a/app/src/main/java/ceui/pixiv/download/config/DownloadConfig.kt
+++ b/app/src/main/java/ceui/pixiv/download/config/DownloadConfig.kt
@@ -52,10 +52,17 @@ data class DownloadConfig(
             Bucket.Caption -> DefaultTemplates.CAPTION
             else -> defaults.template
         }
+        // 备份文件是 JSON 快照，冲突时不能覆盖也不能跳过：强制重命名，避免旧备份被静默替换。
+        // SAF 下由系统 provider 自动追加 (1)；MediaStore 下由 Downloads.nextFreePath 生成 (1)。
+        val overwrite = if (bucket == Bucket.Backup) {
+            OverwritePolicy.Rename
+        } else {
+            override?.overwrite ?: inherited?.overwrite ?: defaults.overwrite
+        }
         return ResolvedBucket(
             template  = override?.template  ?: fallbackTemplate,
             storage   = override?.storage   ?: inherited?.storage   ?: defaults.storage,
-            overwrite = override?.overwrite ?: inherited?.overwrite ?: defaults.overwrite,
+            overwrite = overwrite,
         )
     }
 

--- a/app/src/main/java/ceui/pixiv/download/config/DownloadConfigJson.kt
+++ b/app/src/main/java/ceui/pixiv/download/config/DownloadConfigJson.kt
@@ -1,6 +1,8 @@
 package ceui.pixiv.download.config
 
 import android.net.Uri
+import ceui.pixiv.download.model.Bucket
+import ceui.pixiv.download.template.DefaultTemplates
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonDeserializationContext
@@ -40,10 +42,20 @@ object DownloadConfigJson {
         // 前向兼容：更新的版本可能已往 perBucket 写入本版本不认识的 Bucket 名，
         // Gson 会把未知枚举键反序列化成 null —— 下游 mapValues/copy 一碰就 NPE
         // （applyGlobalStorage 在带 NovelSeries 配置的旧 base 构建上真炸过）。
-        // 读入时直接丢弃未知桶，让老版本按「没配置过」回退到 defaults。
+        // 读入时直接丢弃未知桶 / null 桶配置，让老版本按「没配置过」回退到 defaults。
         @Suppress("SENSELESS_COMPARISON", "USELESS_CAST")
-        val known = parsed.perBucket.filterKeys { it != null }
-        return if (known.size == parsed.perBucket.size) parsed else parsed.copy(perBucket = known)
+        val known = parsed.perBucket.filterKeys { it != null }.filterValues { it != null }
+        val sanitized = known.mapValues { (bucket, bc) ->
+            if (bucket == Bucket.Backup && bc.template != null &&
+                (bc.template.contains("{ext}") || !bc.template.endsWith(".json"))
+            ) {
+                bc.copy(template = DefaultTemplates.BACKUP)
+            } else {
+                bc
+            }
+        }
+        val changed = known.size != parsed.perBucket.size || sanitized != known
+        return if (changed) parsed.copy(perBucket = sanitized) else parsed
     }
 
     private object StorageChoiceAdapter : JsonSerializer<StorageChoice>, JsonDeserializer<StorageChoice> {

--- a/app/src/main/java/ceui/pixiv/download/config/DownloadItems.kt
+++ b/app/src/main/java/ceui/pixiv/download/config/DownloadItems.kt
@@ -328,23 +328,28 @@ object DownloadItems {
     /**
      * 备份导出落盘路径：完整使用 [Bucket.Backup] 模板渲染出的目录 + 文件名，
      * 不再用调用方的临时文件名覆盖。备份文件永远是 JSON，因此渲染时固定 ext=json。
+     *
+     * [fileName] 是调用方的备份名（`Shaft-Backup.json` / `Shaft-BrowseHistory.json` /
+     * `Shaft-MuteRecords.json` / `Shaft-SynonymDict.json`），去掉后缀后作为 `{title}`
+     * 喂给模板 —— 四种导出走同一个桶，文件名里必须还能看出来是哪一种。
      */
     @JvmStatic
     @JvmOverloads
     fun backupDestination(
+        fileName: String,
         config: DownloadConfig = DownloadsRegistry.store.loadOrFallback(),
     ): RelativePath {
         val resolved = config.resolve(Bucket.Backup)
         return FsSanitizer.clean(
             SafeTemplateRender.render(
-                resolved.template, Bucket.Backup, backupMeta(), "json", config.pageNumbering,
+                resolved.template, Bucket.Backup, backupMeta(fileName), "json", config.pageNumbering,
             ),
         )
     }
 
-    private fun backupMeta(): ItemMeta = ItemMeta(
+    private fun backupMeta(fileName: String): ItemMeta = ItemMeta(
         id = 0L,
-        title = "",
+        title = fileName.substringBeforeLast('.'),
         author = Author(0L, ""),
         createdAt = Instant.now(),
     )

--- a/app/src/main/java/ceui/pixiv/download/config/DownloadItems.kt
+++ b/app/src/main/java/ceui/pixiv/download/config/DownloadItems.kt
@@ -326,6 +326,30 @@ object DownloadItems {
     }
 
     /**
+     * 备份导出落盘路径：完整使用 [Bucket.Backup] 模板渲染出的目录 + 文件名，
+     * 不再用调用方的临时文件名覆盖。备份文件永远是 JSON，因此渲染时固定 ext=json。
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun backupDestination(
+        config: DownloadConfig = DownloadsRegistry.store.loadOrFallback(),
+    ): RelativePath {
+        val resolved = config.resolve(Bucket.Backup)
+        return FsSanitizer.clean(
+            SafeTemplateRender.render(
+                resolved.template, Bucket.Backup, backupMeta(), "json", config.pageNumbering,
+            ),
+        )
+    }
+
+    private fun backupMeta(): ItemMeta = ItemMeta(
+        id = 0L,
+        title = "",
+        author = Author(0L, ""),
+        createdAt = Instant.now(),
+    )
+
+    /**
      * 合并下载的兜底：模板里把后缀写死成 `.txt`（或干脆不写后缀）时，导出 EPUB /
      * PDF 会得到一个打不开的假文件。只在结尾是**已知导出后缀**时替换、没有后缀时
      * 追加——不能无脑按最后一个点切，系列名里带点（`Vol.1 合集`）会被腰斩。

--- a/app/src/main/java/ceui/pixiv/download/template/DefaultTemplates.kt
+++ b/app/src/main/java/ceui/pixiv/download/template/DefaultTemplates.kt
@@ -36,7 +36,9 @@ object DefaultTemplates {
 
     // Caption txt for illustration/manga: separate ShaftDescriptions/ folder.
     const val CAPTION = "ShaftDescriptions/{title}_{id}.txt"
-    const val BACKUP  = "ShaftBackups/Shaft-Backup_{created:yyyyMMdd_HHmmss}.json"
+    // {title} = 备份类型名（Shaft-Backup / Shaft-BrowseHistory / Shaft-MuteRecords /
+    // Shaft-SynonymDict），见 DownloadItems.backupDestination。
+    const val BACKUP  = "ShaftBackups/{title}_{created:yyyyMMdd_HHmmss}.json"
     const val LOG     = "Shaft/Logs/{created:yyyyMMdd_HHmmss}.txt"
     const val TEMP    = "ugoira/{id}/{title} {id}.{ext}"
 

--- a/app/src/main/java/ceui/pixiv/download/template/DefaultTemplates.kt
+++ b/app/src/main/java/ceui/pixiv/download/template/DefaultTemplates.kt
@@ -36,7 +36,7 @@ object DefaultTemplates {
 
     // Caption txt for illustration/manga: separate ShaftDescriptions/ folder.
     const val CAPTION = "ShaftDescriptions/{title}_{id}.txt"
-    const val BACKUP  = "Shaft/Backups/{created:yyyyMMdd_HHmmss}.zip"
+    const val BACKUP  = "ShaftBackups/Shaft-Backup_{created:yyyyMMdd_HHmmss}.json"
     const val LOG     = "Shaft/Logs/{created:yyyyMMdd_HHmmss}.txt"
     const val TEMP    = "ugoira/{id}/{title} {id}.{ext}"
 

--- a/app/src/main/java/ceui/pixiv/download/template/TemplateSamples.kt
+++ b/app/src/main/java/ceui/pixiv/download/template/TemplateSamples.kt
@@ -62,6 +62,14 @@ object TemplateSamples {
         flags = setOf(Flag.Animated),
     )
 
+    /** 备份桶：`{title}` 是备份类型名，不是作品标题（见 DownloadItems.backupDestination）。 */
+    val BACKUP_SAMPLE = ItemMeta(
+        id = 0L,
+        title = "Shaft-Backup",
+        author = Author(0L, ""),
+        createdAt = CREATED,
+    )
+
     private val DEFAULT_EXT: Map<Bucket, String> = mapOf(
         Bucket.Illust      to "jpg",
         Bucket.Ugoira      to "gif",
@@ -77,6 +85,7 @@ object TemplateSamples {
         Bucket.Novel -> NOVEL_SAMPLE
         Bucket.NovelSeries -> NOVEL_SERIES_SAMPLE
         Bucket.Ugoira -> UGOIRA_SAMPLE
+        Bucket.Backup -> BACKUP_SAMPLE
         else -> ILLUST_SAMPLE
     }
 

--- a/app/src/main/java/ceui/pixiv/download/template/TemplateSamples.kt
+++ b/app/src/main/java/ceui/pixiv/download/template/TemplateSamples.kt
@@ -68,7 +68,7 @@ object TemplateSamples {
         Bucket.Novel       to "txt",
         Bucket.NovelSeries to "txt",
         Bucket.Caption     to "txt",
-        Bucket.Backup      to "zip",
+        Bucket.Backup      to "json",
         Bucket.Log         to "txt",
         Bucket.TempCache   to "bin",
     )

--- a/app/src/main/java/ceui/pixiv/download/template/TemplateValidator.kt
+++ b/app/src/main/java/ceui/pixiv/download/template/TemplateValidator.kt
@@ -83,7 +83,22 @@ object TemplateValidator {
     }
 
     private fun applyBucketRules(source: String, bucket: Bucket, issues: MutableList<Issue>) {
-        val needsExtension = bucket != Bucket.Novel && bucket != Bucket.Backup && bucket != Bucket.Log
+        if (bucket == Bucket.Backup) {
+            if (source.contains("{ext}")) {
+                issues += Issue(
+                    Severity.Error,
+                    "Backup template must not contain {ext} — backup files are always .json",
+                )
+            }
+            if (!source.endsWith(".json")) {
+                issues += Issue(
+                    Severity.Error,
+                    "Backup template must end with .json",
+                )
+            }
+            return
+        }
+        val needsExtension = bucket != Bucket.Novel && bucket != Bucket.Log
         if (needsExtension && !source.contains("{ext}") && !source.matches(Regex(".*\\.[A-Za-z0-9]+$"))) {
             issues += Issue(
                 Severity.Warning,

--- a/app/src/main/java/ceui/pixiv/ui/settings/DownloadPathSettingsFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/settings/DownloadPathSettingsFragment.kt
@@ -607,12 +607,8 @@ class DownloadPathSettingsFragment : Fragment(R.layout.fragment_download_path_se
         cell.findViewById<TextView>(R.id.bucket_storage).text = storageLabel(resolved.storage)
 
         val policyView = cell.findViewById<TextView>(R.id.bucket_policy)
-        // 备份桶固定使用「已存在则重命名」（复用现有文案），与 DownloadConfig.resolve 的强制策略保持一致。
-        policyView.text = if (bucket == Bucket.Backup) {
-            getString(R.string.download_path_policy_rename)
-        } else {
-            policyLabel(resolved.overwrite)
-        }
+        // 备份桶的「已存在则重命名」由 DownloadConfig.resolve 强制，这里只照实显示，不再写第二份规则。
+        policyView.text = policyLabel(resolved.overwrite)
 
         val templateEdit = cell.findViewById<EditText>(R.id.bucket_template)
         val previewView = cell.findViewById<TextView>(R.id.bucket_preview)

--- a/app/src/main/java/ceui/pixiv/ui/settings/DownloadPathSettingsFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/settings/DownloadPathSettingsFragment.kt
@@ -607,7 +607,12 @@ class DownloadPathSettingsFragment : Fragment(R.layout.fragment_download_path_se
         cell.findViewById<TextView>(R.id.bucket_storage).text = storageLabel(resolved.storage)
 
         val policyView = cell.findViewById<TextView>(R.id.bucket_policy)
-        policyView.text = policyLabel(resolved.overwrite)
+        // 备份桶固定使用「已存在则重命名」（复用现有文案），与 DownloadConfig.resolve 的强制策略保持一致。
+        policyView.text = if (bucket == Bucket.Backup) {
+            getString(R.string.download_path_policy_rename)
+        } else {
+            policyLabel(resolved.overwrite)
+        }
 
         val templateEdit = cell.findViewById<EditText>(R.id.bucket_template)
         val previewView = cell.findViewById<TextView>(R.id.bucket_preview)

--- a/app/src/main/java/ceui/pixiv/ui/synonym/SynonymDictFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/synonym/SynonymDictFragment.kt
@@ -21,6 +21,7 @@ import android.widget.EditText
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
@@ -304,10 +305,8 @@ class SynonymDictFragment : Fragment(R.layout.fragment_synonym_dict) {
             addCategory(Intent.CATEGORY_OPENABLE)
             type = "*/*"
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                val initialUri = Uri.parse(
-                    "content://com.android.externalstorage.documents/document/primary:" +
-                        "Download%2fShaftBackups%2f" + SynonymDictBackup.FILE_NAME,
-                )
+                val initialUri =
+                    "content://com.android.externalstorage.documents/document/primary:Download".toUri()
                 putExtra(DocumentsContract.EXTRA_INITIAL_URI, initialUri)
             }
         }

--- a/app/src/test/java/ceui/pixiv/download/BackupDestinationTest.kt
+++ b/app/src/test/java/ceui/pixiv/download/BackupDestinationTest.kt
@@ -6,7 +6,9 @@ import ceui.pixiv.download.config.DownloadConfig
 import ceui.pixiv.download.config.DownloadItems
 import ceui.pixiv.download.config.StorageChoice
 import ceui.pixiv.download.model.Bucket
+import ceui.pixiv.download.template.DefaultTemplates
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class BackupDestinationTest {
@@ -20,6 +22,7 @@ class BackupDestinationTest {
 
     @Test fun `backup destination uses full Backup bucket template path`() {
         val path = DownloadItems.backupDestination(
+            "Shaft-Backup.json",
             config("ShaftBackups/Shaft-Backup.json"),
         )
         assertEquals(listOf("ShaftBackups", "Shaft-Backup.json"), path.segments)
@@ -27,8 +30,37 @@ class BackupDestinationTest {
 
     @Test fun `backup destination uses template filename instead of caller name`() {
         val path = DownloadItems.backupDestination(
+            "Shaft-BrowseHistory.json",
             config("MyBackups/MyBackup.json"),
         )
         assertEquals(listOf("MyBackups", "MyBackup.json"), path.segments)
+    }
+
+    @Test fun `caller file name is exposed to the template as title`() {
+        // 设置备份 / 浏览历史 / 屏蔽记录 / 词典四种导出共用 Backup 桶，默认模板靠 {title}
+        // 把它们区分开，否则全都叫 Shaft-Backup_<时间>.json。
+        val history = DownloadItems.backupDestination(
+            "Shaft-BrowseHistory.json",
+            config("ShaftBackups/{title}_{created:yyyyMMdd}.json"),
+        )
+        assertEquals("ShaftBackups", history.directory.single())
+        assertTrue(history.filename, history.filename.startsWith("Shaft-BrowseHistory_"))
+        assertTrue(history.filename, history.filename.endsWith(".json"))
+
+        val mute = DownloadItems.backupDestination(
+            "Shaft-MuteRecords.json",
+            config(DefaultTemplates.BACKUP),
+        )
+        assertTrue(mute.filename, mute.filename.startsWith("Shaft-MuteRecords_"))
+    }
+
+    @Test fun `backup falls back to its own default template when perBucket is empty`() {
+        // 设置页「全部重置」会把 perBucket 清空；备份不能掉到 defaults 的插画模板。
+        val cfg = DownloadConfig(
+            defaults = BucketDefaults(template = "ShaftImages/{title}_{id}.{ext}", storage = storage),
+        )
+        val path = DownloadItems.backupDestination("Shaft-Backup.json", cfg)
+        assertEquals("ShaftBackups", path.directory.single())
+        assertTrue(path.filename, path.filename.startsWith("Shaft-Backup_"))
     }
 }

--- a/app/src/test/java/ceui/pixiv/download/BackupDestinationTest.kt
+++ b/app/src/test/java/ceui/pixiv/download/BackupDestinationTest.kt
@@ -1,0 +1,34 @@
+package ceui.pixiv.download
+
+import ceui.pixiv.download.config.BucketConfig
+import ceui.pixiv.download.config.BucketDefaults
+import ceui.pixiv.download.config.DownloadConfig
+import ceui.pixiv.download.config.DownloadItems
+import ceui.pixiv.download.config.StorageChoice
+import ceui.pixiv.download.model.Bucket
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BackupDestinationTest {
+
+    private val storage = StorageChoice.MediaStore(StorageChoice.MediaStore.Collection.Downloads)
+
+    private fun config(backupTemplate: String) = DownloadConfig(
+        defaults = BucketDefaults(template = "default/{id}.{ext}", storage = storage),
+        perBucket = mapOf(Bucket.Backup to BucketConfig(template = backupTemplate)),
+    )
+
+    @Test fun `backup destination uses full Backup bucket template path`() {
+        val path = DownloadItems.backupDestination(
+            config("ShaftBackups/Shaft-Backup.json"),
+        )
+        assertEquals(listOf("ShaftBackups", "Shaft-Backup.json"), path.segments)
+    }
+
+    @Test fun `backup destination uses template filename instead of caller name`() {
+        val path = DownloadItems.backupDestination(
+            config("MyBackups/MyBackup.json"),
+        )
+        assertEquals(listOf("MyBackups", "MyBackup.json"), path.segments)
+    }
+}

--- a/app/src/test/java/ceui/pixiv/download/DefaultTemplatesTest.kt
+++ b/app/src/test/java/ceui/pixiv/download/DefaultTemplatesTest.kt
@@ -51,7 +51,7 @@ class DefaultTemplatesTest {
     }
 
     @Test fun `backup default template uses ShaftBackups and json filename`() {
-        assertTrue(DefaultTemplates.BACKUP.startsWith("ShaftBackups/Shaft-Backup_"))
+        assertTrue(DefaultTemplates.BACKUP.startsWith("ShaftBackups/{title}_"))
         assertTrue(DefaultTemplates.BACKUP.endsWith(".json"))
     }
 

--- a/app/src/test/java/ceui/pixiv/download/DefaultTemplatesTest.kt
+++ b/app/src/test/java/ceui/pixiv/download/DefaultTemplatesTest.kt
@@ -32,7 +32,7 @@ class DefaultTemplatesTest {
                 Bucket.Illust, Bucket.TempCache -> "jpg"
                 Bucket.Ugoira -> "gif"
                 Bucket.Novel, Bucket.NovelSeries, Bucket.Caption, Bucket.Log -> "txt"
-                Bucket.Backup -> "zip"
+                Bucket.Backup -> "json"
             }
             val rendered = compiled.render(META, ext)
             val cleaned = FsSanitizer.clean(rendered)
@@ -48,6 +48,11 @@ class DefaultTemplatesTest {
 
         val both = t.render(META.copy(flags = setOf(Flag.R18, Flag.AI)), "jpg").joinTo()
         assertEquals("flags do not change the legacy default path", plain, both)
+    }
+
+    @Test fun `backup default template uses ShaftBackups and json filename`() {
+        assertTrue(DefaultTemplates.BACKUP.startsWith("ShaftBackups/Shaft-Backup_"))
+        assertTrue(DefaultTemplates.BACKUP.endsWith(".json"))
     }
 
     @Test fun `illust default appends one based page number only for multi-page`() {

--- a/app/src/test/java/ceui/pixiv/download/DownloadConfigTest.kt
+++ b/app/src/test/java/ceui/pixiv/download/DownloadConfigTest.kt
@@ -120,6 +120,11 @@ class DownloadConfigTest {
         assertEquals(OverwritePolicy.Replace, defaults.overwrite)
     }
 
+    @Test fun `backup bucket without override resolves to its own default template`() {
+        val cfg = DownloadConfig(defaults = defaults)
+        assertEquals(DefaultTemplates.BACKUP, cfg.resolve(Bucket.Backup).template)
+    }
+
     @Test fun `backup bucket always resolves to Rename overwrite policy`() {
         val cfg = DownloadConfig(
             defaults = defaults.copy(overwrite = OverwritePolicy.Replace),

--- a/app/src/test/java/ceui/pixiv/download/DownloadConfigTest.kt
+++ b/app/src/test/java/ceui/pixiv/download/DownloadConfigTest.kt
@@ -8,6 +8,7 @@ import ceui.pixiv.download.config.DownloadConfigJson
 import ceui.pixiv.download.config.OverwritePolicy
 import ceui.pixiv.download.config.StorageChoice
 import ceui.pixiv.download.model.Bucket
+import ceui.pixiv.download.template.DefaultTemplates
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -35,6 +36,32 @@ class DownloadConfigTest {
         assertEquals(setOf(Bucket.Novel), cfg.perBucket.keys)
         // 反序列化出的配置要能安全走完 copy/mapValues 一类的全量遍历。
         cfg.copy(perBucket = cfg.perBucket.mapValues { (_, bc) -> bc })
+    }
+
+    @Test fun `fromJson replaces invalid backup template with json default`() {
+        val json = """
+            {"version":1,
+             "defaults":{"template":"d/{id}.{ext}",
+                         "storage":{"kind":"media_store","collection":"Images"},
+                         "overwrite":"Replace"},
+             "perBucket":{
+                "Backup":{"template":"ShaftBackups/{created:yyyyMMdd_HHmmss}.zip"}}}
+        """.trimIndent()
+        val cfg = DownloadConfigJson.fromJson(json)
+        assertEquals(DefaultTemplates.BACKUP, cfg.resolve(Bucket.Backup).template)
+    }
+
+    @Test fun `fromJson replaces backup template containing ext with json default`() {
+        val json = """
+            {"version":1,
+             "defaults":{"template":"d/{id}.{ext}",
+                         "storage":{"kind":"media_store","collection":"Images"},
+                         "overwrite":"Replace"},
+             "perBucket":{
+                "Backup":{"template":"ShaftBackups/{created:yyyyMMdd_HHmmss}.{ext}"}}}
+        """.trimIndent()
+        val cfg = DownloadConfigJson.fromJson(json)
+        assertEquals(DefaultTemplates.BACKUP, cfg.resolve(Bucket.Backup).template)
     }
 
     @Test fun `resolve falls back to defaults when no override`() {
@@ -91,6 +118,14 @@ class DownloadConfigTest {
 
     @Test fun `default overwrite is Replace`() {
         assertEquals(OverwritePolicy.Replace, defaults.overwrite)
+    }
+
+    @Test fun `backup bucket always resolves to Rename overwrite policy`() {
+        val cfg = DownloadConfig(
+            defaults = defaults.copy(overwrite = OverwritePolicy.Replace),
+            perBucket = mapOf(Bucket.Backup to BucketConfig(overwrite = OverwritePolicy.Skip)),
+        )
+        assertEquals(OverwritePolicy.Rename, cfg.resolve(Bucket.Backup).overwrite)
     }
 
     // ── Global StorageChoice via applyGlobalStorage logic ──

--- a/app/src/test/java/ceui/pixiv/download/NovelSeriesMergeTemplateTest.kt
+++ b/app/src/test/java/ceui/pixiv/download/NovelSeriesMergeTemplateTest.kt
@@ -4,6 +4,7 @@ import ceui.pixiv.download.config.BucketConfig
 import ceui.pixiv.download.config.BucketDefaults
 import ceui.pixiv.download.config.ConfigPresets
 import ceui.pixiv.download.config.DownloadConfig
+import ceui.pixiv.download.config.OverwritePolicy
 import ceui.pixiv.download.config.StorageChoice
 import ceui.pixiv.download.model.Author
 import ceui.pixiv.download.model.Bucket
@@ -121,18 +122,25 @@ class NovelSeriesMergeTemplateTest {
     /**
      * 合集桶的兜底逻辑写在通用的 [DownloadConfig.resolve] 里，必须证明它对其他桶
      * 是零影响：没有 override 的桶照旧全部掉回 defaults，一个字节都不能变。
+     * [Bucket.Backup] 是另一处刻意例外（模板缺省用 [DefaultTemplates.BACKUP]、
+     * 覆盖策略固定 Rename），单独断言。
      */
     @Test fun `other buckets keep the plain defaults fallback`() {
         val images = StorageChoice.MediaStore(StorageChoice.MediaStore.Collection.Images)
         val cfg = DownloadConfig(
             defaults = BucketDefaults(template = "Illust/{id}.{ext}", storage = images),
         )
-        for (bucket in Bucket.entries - Bucket.NovelSeries - Bucket.Caption - Bucket.TempCache) {
+        val exempt = setOf(Bucket.NovelSeries, Bucket.Caption, Bucket.Backup, Bucket.TempCache)
+        for (bucket in Bucket.entries - exempt) {
             val resolved = cfg.resolve(bucket)
             assertEquals("bucket $bucket template", "Illust/{id}.{ext}", resolved.template)
             assertEquals("bucket $bucket storage", images, resolved.storage)
             assertEquals("bucket $bucket overwrite", cfg.defaults.overwrite, resolved.overwrite)
         }
+        val backup = cfg.resolve(Bucket.Backup)
+        assertEquals(DefaultTemplates.BACKUP, backup.template)
+        assertEquals(images, backup.storage)
+        assertEquals(OverwritePolicy.Rename, backup.overwrite)
     }
 
     /** 预设里插画 / 动图 / 小说三条模板不能被这次改动碰到。 */

--- a/app/src/test/java/ceui/pixiv/download/TemplateValidatorTest.kt
+++ b/app/src/test/java/ceui/pixiv/download/TemplateValidatorTest.kt
@@ -47,6 +47,24 @@ class TemplateValidatorTest {
         assertTrue(r.warnings.isEmpty())
     }
 
+    @Test fun `backup bucket accepts json extension`() {
+        val r = TemplateValidator.validate("ShaftBackups/Shaft-Backup_{created:yyyyMMdd_HHmmss}.json", Bucket.Backup)
+        assertTrue(r.ok)
+        assertTrue(r.errors.isEmpty())
+    }
+
+    @Test fun `backup bucket rejects non json extension`() {
+        val r = TemplateValidator.validate("ShaftBackups/Shaft-Backup_{created:yyyyMMdd_HHmmss}.zip", Bucket.Backup)
+        assertFalse(r.ok)
+        assertTrue(r.errors.any { it.message.contains(".json") })
+    }
+
+    @Test fun `backup bucket rejects ext variable`() {
+        val r = TemplateValidator.validate("ShaftBackups/Shaft-Backup_{created:yyyyMMdd_HHmmss}.{ext}", Bucket.Backup)
+        assertFalse(r.ok)
+        assertTrue(r.errors.any { it.message.contains("{ext}") })
+    }
+
     /**
      * 复现 bug 的入口：`[?p<100:…]` 能编译（被当成名为 `p<100` 的 flag），
      * 旧校验只编译不渲染 → 放行保存 → 下载时崩。现在保存校验也渲染样本，


### PR DESCRIPTION
# 备份导出遵循 Backup 桶模板路径/文件名，修正默认 .json 扩展名并强制重命名

> 分支：`patch-8-30`（wangwang-code fork）
> 目标：`classic`
> 最新提交：`78b59400e`

## 背景

备份导出（设置页备份、浏览历史、词典、屏蔽记录等）此前不遵循用户在「下载路径」里为 `Backup` 桶配置的模板：

- 落盘路径硬编码为 `ShaftBackups/<调用方文件名>`；
- 最终文件名固定使用调用方传入的 `Shaft-Backup.json` 等，桶模板里的文件名不生效；
- 默认模板扩展名错误地写成了 `.zip`，实际备份内容是 JSON；
- Backup 桶模板允许保存非 `.json` 扩展名和 `{ext}`；
- 备份写入沿用全局“文件重复时”策略，可能覆盖或跳过旧备份。

## 改动内容

### 1. 备份路径 / 文件名完整遵循 Backup 桶模板

- 新增 `DownloadItems.backupDestination(config)`：
  - 使用 `Bucket.Backup` 模板渲染**完整相对路径**（目录 + 文件名）；
  - 备份文件固定按 `ext = "json"` 渲染；
  - 不再用调用方临时文件名覆盖最终文件名。
- `OutPut.outPutBackupFile()` 改为直接使用 `backupDestination()` 落盘。
- 默认模板调整为：

```text
ShaftBackups/Shaft-Backup_{created:yyyyMMdd_HHmmss}.json
```

### 2. 修正默认扩展名

- `DefaultTemplates.BACKUP`：`.zip` → `.json`
- `TemplateSamples` 中 Backup 桶预览扩展名同步改为 `json`

### 3. 阻止非法 Backup 模板进入配置

- `TemplateValidator` 对 `Bucket.Backup` 强制：
  - 必须以 `.json` 结尾；
  - 不能包含 `{ext}`。
- `DownloadConfigJson.fromJson` 增加反序列化兜底：
  - 旧配置 / 备份导入中若 Backup 模板为 `.zip` 或包含 `{ext}`，自动替换为默认 `.json` 模板；
  - 同时丢弃未知桶 key 与 null 桶配置，避免 Gson 反序列化异常。

### 4. 备份强制“已存在则重命名”

- `DownloadConfig.resolve()` 对 `Bucket.Backup` 固定返回 `OverwritePolicy.Rename`：
  - 不覆盖、不跳过旧备份；
  - SAF 下由系统 Provider `createFile` 自动追加 ` (1)`；
  - MediaStore / 普通目录下由 `Downloads.nextFreePath()` 生成不冲突文件名。
- `DownloadPathSettingsFragment` 中 Backup 桶 UI 固定显示“已存在则重命名”，复用现有 `download_path_policy_rename` 资源。

### 5. 导入选择器初始目录

- 所有备份导入入口的 `EXTRA_INITIAL_URI` 从具体文件名改为 `Download` 根目录，避免因备份文件名已由模板生成而指向不存在的文件。

## 涉及文件

- `app/src/main/java/ceui/lisa/download/IllustDownload.java`
- `app/src/main/java/ceui/lisa/file/OutPut.kt`
- `app/src/main/java/ceui/lisa/fragments/FragmentHistoryTabs.kt`
- `app/src/main/java/ceui/lisa/fragments/FragmentSettingsData.java`
- `app/src/main/java/ceui/lisa/fragments/FragmentViewPager.java`
- `app/src/main/java/ceui/pixiv/download/config/DownloadConfig.kt`
- `app/src/main/java/ceui/pixiv/download/config/DownloadConfigJson.kt`
- `app/src/main/java/ceui/pixiv/download/config/DownloadItems.kt`
- `app/src/main/java/ceui/pixiv/download/template/DefaultTemplates.kt`
- `app/src/main/java/ceui/pixiv/download/template/TemplateSamples.kt`
- `app/src/main/java/ceui/pixiv/download/template/TemplateValidator.kt`
- `app/src/main/java/ceui/pixiv/ui/settings/DownloadPathSettingsFragment.kt`
- `app/src/main/java/ceui/pixiv/ui/synonym/SynonymDictFragment.kt`

## 提交

- `78b59400e` fix(backup): 备份导出遵循 Backup 桶模板路径与文件名并强制重命名

## 测试情况

- `:app:testGithubDebugUnitTest` 相关单测通过：
  - `DownloadConfigTest`
  - `BackupDestinationTest`
  - `TemplateValidatorTest`
  - `DefaultTemplatesTest`
  - `TemplateSamplesTest`
- 编译通过：`:app:compileGithubDebugKotlin`
- 真机实测在SAF与MediaStore模式下均遵循Backup 桶中配置