### PR TITLE
快照管理页批量删除支持自动快照，单卡删除保留滚动位置并修复瀑布流列归属

### DIFF
--- a/app/src/main/java/ceui/pixiv/snapshot/SnapshotListFragment.kt
+++ b/app/src/main/java/ceui/pixiv/snapshot/SnapshotListFragment.kt
@@ -38,7 +38,8 @@ import java.util.Locale
  * filter == null 表示“全部”。
  *
  * 列表由正式快照（SnapshotSummary）和自动快照（AutoSnapshotSummary）合并而成：
- * 自动快照带“自动”标记，长按弹窗可转正/删除，多选模式下不显示勾选框。
+ * 自动快照带“自动”标记，长按弹窗可转正/删除；批量导出多选态不显示自动快照勾选框，
+ * 批量删除多选态允许勾选并批量删除自动快照。
  */
 class SnapshotListFragment : Fragment() {
 
@@ -106,13 +107,16 @@ class SnapshotListFragment : Fragment() {
     }
 
     /**
-     * [resetScroll] 只在导入/删除这类**结构性变更**后传 true。
+     * [resetScroll] 只在导入/批量删除这类**结构性变更**后传 true。
+     * 单卡删除只移除一张卡，保留当前滚动位置即可，与浏览历史页行为一致。
+     * [reflow] 用于单卡删除后让 StaggeredGrid 重新分配 span，避免最后一张停在右列；
+     * 不会清空列表，也不会回顶。
      *
      * 「先清空再提交 + 回顶」是为了让双列瀑布流按新顺序重新布局(否则新卡会被 Diff 塞进
      * 右列/旧列错位)——那是新卡进来时才需要付的代价。onResume 的例行刷新也这么干的话,
      * 每次从详情页返回列表都要整个闪一下并跳回顶部,快照一多就再也找不回刚才看到哪了。
      */
-    fun reload(resetScroll: Boolean = false) {
+    fun reload(resetScroll: Boolean = false, reflow: Boolean = false) {
         val appContext = requireContext().applicationContext
         lifecycleScope.launch {
             val all = try {
@@ -130,16 +134,26 @@ class SnapshotListFragment : Fragment() {
                 return@launch
             }
             if (_binding == null) return@launch
+            val snapshotList = binding.snapshotList
             if (resetScroll) adapter.submitList(null)
-            adapter.submitList(all)
+            if (reflow) {
+                adapter.submitList(all, Runnable {
+                    if (_binding?.snapshotList === snapshotList) {
+                        (snapshotList.layoutManager as? StaggeredGridLayoutManager)
+                            ?.invalidateSpanAssignments()
+                    }
+                })
+            } else {
+                adapter.submitList(all)
+            }
             binding.emptyHint.isVisible = all.isEmpty()
-            if (resetScroll) binding.snapshotList.scrollToPosition(0)
+            if (resetScroll) snapshotList.scrollToPosition(0)
         }
     }
 
-    fun enterSelectionMode() {
-        if (!hasItems()) return
-        adapter.setSelectionMode(true)
+    fun enterSelectionMode(includeAuto: Boolean = false) {
+        if (!hasItems(includeAuto)) return
+        adapter.setSelectionMode(true, includeAuto)
         onSelectionCountChanged?.invoke(0)
     }
 
@@ -148,17 +162,24 @@ class SnapshotListFragment : Fragment() {
         onSelectionCountChanged?.invoke(0)
     }
 
-    /** 批量操作只包含正式快照；自动快照不可多选、不可批量导出/删除。 */
+    /** 批量导出只包含正式快照；自动快照不可导出，只参与批量删除。 */
     fun selectedSnapshots(): List<SnapshotSummary> =
         adapter.currentList
             .filterIsInstance<FormalSnapshotCard>()
             .filter { it.snapshotId in adapter.selectedIds }
             .map { it.summary }
 
+    /** 批量删除可同时包含正式快照与自动快照。 */
+    fun selectedCards(): List<SnapshotCard> =
+        adapter.currentList.filter { it.snapshotId in adapter.selectedIds }
+
     fun selectedCount(): Int = adapter.selectedIds.size
 
-    /** 批量选择只对正式快照有效；自动快照隐匿勾选框，不参与批量操作。 */
-    fun hasItems(): Boolean = adapter.currentList.any { !it.isAuto }
+    /**
+     * 批量导出只对正式快照有效；批量删除允许自动快照，因此 [includeAuto] 时自动快照也算可选项。
+     */
+    fun hasItems(includeAuto: Boolean = false): Boolean =
+        adapter.currentList.any { includeAuto || !it.isAuto }
 
     fun isAllSelected(): Boolean = adapter.isAllSelected()
 
@@ -280,7 +301,7 @@ class SnapshotListFragment : Fragment() {
                         }
                     }
                     if (ok) Common.showToast(getString(R.string.snapshot_delete_success)) else Common.showToast(getString(R.string.snapshot_delete_failed))
-                    reload(resetScroll = true)
+                    reload(reflow = true)
                 }
             }
             .show()
@@ -309,18 +330,22 @@ private class SnapshotAdapter(
     var selectionMode: Boolean = false
         private set
 
+    var selectionIncludesAuto: Boolean = false
+        private set
+
     val selectedIds = linkedSetOf<String>()
     var onSelectionToggle: ((SnapshotCard) -> Unit)? = null
 
-    fun setSelectionMode(enabled: Boolean) {
-        if (selectionMode == enabled) return
+    fun setSelectionMode(enabled: Boolean, includeAuto: Boolean = false) {
+        if (selectionMode == enabled && selectionIncludesAuto == includeAuto) return
         selectionMode = enabled
+        selectionIncludesAuto = if (enabled) includeAuto else false
         if (!enabled) selectedIds.clear()
         notifyDataSetChanged()
     }
 
     fun toggleSelection(card: SnapshotCard) {
-        if (!selectionMode || card.isAuto) return
+        if (!selectionMode || !isSelectable(card)) return
         if (!selectedIds.add(card.snapshotId)) {
             selectedIds.remove(card.snapshotId)
         }
@@ -331,7 +356,7 @@ private class SnapshotAdapter(
     fun selectAll() {
         if (!selectionMode) return
         selectedIds.clear()
-        selectedIds.addAll(currentList.filter { !it.isAuto }.map { it.snapshotId })
+        selectedIds.addAll(currentList.filter(::isSelectable).map { it.snapshotId })
         notifyDataSetChanged()
     }
 
@@ -340,8 +365,11 @@ private class SnapshotAdapter(
         notifyDataSetChanged()
     }
 
+    private fun isSelectable(card: SnapshotCard): Boolean =
+        !card.isAuto || selectionIncludesAuto
+
     fun isAllSelected(): Boolean {
-        val selectable = currentList.count { !it.isAuto }
+        val selectable = currentList.count(::isSelectable)
         return selectable > 0 && selectedIds.size == selectable
     }
 
@@ -359,6 +387,7 @@ private class SnapshotAdapter(
             onDelete = onDelete,
             onLongPress = onLongPress,
             selectionMode = selectionMode,
+            selectable = isSelectable(card),
             selected = card.snapshotId in selectedIds,
             onToggleSelection = { toggleSelection(card) },
         )
@@ -390,6 +419,7 @@ private class SnapshotViewHolder(
         onDelete: (SnapshotCard) -> Unit,
         onLongPress: (SnapshotCard) -> Unit,
         selectionMode: Boolean,
+        selectable: Boolean,
         selected: Boolean,
         onToggleSelection: () -> Unit,
     ) {
@@ -425,11 +455,11 @@ private class SnapshotViewHolder(
         binding.badgeRow.isVisible = !selectionMode
 
         HistorySelectBadge.bindSelection(binding.selectCheck, binding.deleteButton, selectionMode, selected)
-        // 自动快照在多选态隐匿勾选框，且不可被点选进入批量操作。
-        binding.selectCheck.isVisible = selectionMode && !card.isAuto
+        // 自动快照仅在批量导出多选态隐匿勾选框；批量删除多选态可勾选并批量删除。
+        binding.selectCheck.isVisible = selectionMode && selectable
 
         if (selectionMode) {
-            if (card.isAuto) {
+            if (!selectable) {
                 binding.root.setOnClickListener(null)
                 binding.root.setOnLongClickListener(null)
                 binding.deleteButton.setOnClickListener(null)

--- a/app/src/main/java/ceui/pixiv/snapshot/SnapshotManagerFragment.kt
+++ b/app/src/main/java/ceui/pixiv/snapshot/SnapshotManagerFragment.kt
@@ -25,7 +25,7 @@ import timber.log.Timber
 /**
  * 离线快照管理页：仿照 FragmentHistoryTabs，使用 viewpager_with_tablayout。
  * Three tabs: 全部 | 插画 | 漫画，每个 tab 是双列瀑布流卡片。
- * 支持多选批量导出到 SAF 文件夹。
+ * 支持多选批量导出到 SAF 文件夹，也支持多选批量删除（含自动快照）。
  */
 class SnapshotManagerFragment : Fragment() {
 
@@ -164,7 +164,8 @@ class SnapshotManagerFragment : Fragment() {
     private fun enterSelectionMode(purpose: SelectionPurpose) {
         if (inSelectionMode) return
         val tab = currentSnapshotTab() ?: return
-        if (!tab.hasItems()) {
+        val includeAuto = purpose == SelectionPurpose.DELETE
+        if (!tab.hasItems(includeAuto)) {
             Common.showToast(getString(R.string.snapshot_empty))
             return
         }
@@ -172,7 +173,7 @@ class SnapshotManagerFragment : Fragment() {
         selectionPurpose = purpose
         activeSelectionTab = tab
         selectionBackCallback.isEnabled = true
-        tab.enterSelectionMode()
+        tab.enterSelectionMode(includeAuto)
         tab.onSelectionCountChanged = { refreshSelectionToolbar() }
         applySelectionToolbar()
     }
@@ -229,7 +230,7 @@ class SnapshotManagerFragment : Fragment() {
 
     private fun confirmDeleteSelected() {
         val tab = activeSelectionTab ?: return
-        val items = tab.selectedSnapshots()
+        val items = tab.selectedCards()
         if (items.isEmpty()) return
         WitDialog.MessageDialogBuilder(requireContext())
             .setTitle(R.string.snapshot_batch_delete)
@@ -243,7 +244,13 @@ class SnapshotManagerFragment : Fragment() {
                 val appContext = requireContext().applicationContext
                 lifecycleScope.launch {
                     withContext(Dispatchers.IO) {
-                        items.forEach { SnapshotRepository.delete(appContext, it.manifest.snapshotId) }
+                        items.forEach {
+                            if (it.isAuto) {
+                                AutoSnapshotRepository.deleteAuto(appContext, it.snapshotId)
+                            } else {
+                                SnapshotRepository.delete(appContext, it.snapshotId)
+                            }
+                        }
                     }
                     exitSelectionMode()
                     reloadAllTabs(resetScroll = true)


### PR DESCRIPTION
# 快照管理页批量删除支持自动快照，单卡删除保留滚动位置并修复瀑布流列归属

> 分支：`patch-8-31`（wangwang-code fork）
> 目标：`classic`
> 最新提交：`e297880e`

## 背景

快照管理页的多选态此前只有“批量导出”一种语义：自动快照不可导出，因此在多选态中统一隐匿自动快照的勾选框、不允许选中。

但“批量删除”复用了这套导出多选态，导致自动快照也无法参与批量删除——即使自动快照本身支持单张删除，用户也只能一张张删。

另外，单卡删除时页面会 `reload(resetScroll = true)`，每次删除都清空列表并回顶；改成保留滚动位置后，又暴露出 `StaggeredGridLayoutManager` 的 span 缓存问题：逐个删到最后一张时，最后一张可能仍停留在右列，不会自动换到左列。

## 改动内容

### 1. 批量删除多选态允许自动快照

- `SnapshotListFragment` 新增 `includeAuto` 选择态开关：
  - 批量导出：`includeAuto = false`，自动快照仍不显示勾选框、不可选中；
  - 批量删除：`includeAuto = true`，自动快照显示勾选框，可参与批量删除。
- `SnapshotAdapter` 增加 `selectionIncludesAuto`，`toggleSelection` / `selectAll` / `isAllSelected` 统一按“是否可勾选”判断。
- 新增 `selectedCards()` 返回正式 + 自动快照的选中卡片；批量删除改用该方法。
- 批量删除执行时按 `isAuto` 分别走 `AutoSnapshotRepository.deleteAuto` / `SnapshotRepository.delete`。

### 2. 单卡删除不再回顶

- 单卡删除后由 `reload(resetScroll = true)` 改为 `reload(reflow = true)`：
  - 不再先 `submitList(null)` 清空列表，保留当前滚动位置；
  - 行为与浏览历史页“就地摘条、不回顶”的体验对齐。

### 3. 删除后重新分配 StaggeredGrid span

- `reload` 新增 `reflow` 参数。
- `reflow = true` 时使用 `ListAdapter.submitList(list, commitCallback)`，在 diff 真正提交后调用：

```kotlin
(snapshotList.layoutManager as? StaggeredGridLayoutManager)
    ?.invalidateSpanAssignments()
```

- 这样会清空 `StaggeredGridLayoutManager` 的 span 缓存并重新布局，避免最后一张卡停在右列；同时不会清空列表、不会回顶。
- commit 回调中校验 `_binding?.snapshotList === snapshotList`，防止 view 重建后操作旧 RecyclerView。

## 涉及文件

- `app/src/main/java/ceui/pixiv/snapshot/SnapshotListFragment.kt`
- `app/src/main/java/ceui/pixiv/snapshot/SnapshotManagerFragment.kt`

## 提交

- `e297880e` fix(snapshot): 批量删除支持自动快照，单卡删除保留滚动并重排瀑布流列
