### PR TITLE
收藏夹「过滤无效收藏」开关真正控制插画失效作品过滤

### DIFF
--- a/app/src/main/java/ceui/lisa/helper/IllustNovelFilter.java
+++ b/app/src/main/java/ceui/lisa/helper/IllustNovelFilter.java
@@ -57,6 +57,9 @@ public class IllustNovelFilter {
     }
 
     public static boolean judgeUserID(Illust illust) {
+        if (illust.getUser() == null) {
+            return false;
+        }
         MuteEntity temp = AppDatabase.getAppDatabase(Shaft.getContext())
                 .searchDao()
                 .getUserMuteEntityByID(illust.getUser().getId());

--- a/app/src/main/java/ceui/pixiv/ui/collection/LikeIllustFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/collection/LikeIllustFeedFragment.kt
@@ -41,8 +41,9 @@ import kotlinx.coroutines.withContext
  *   宿主 pager 需 BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT），不替用户偷偷请求私密收藏；
  * - 「按标签筛选」页选完标签广播 FILTER_ILLUST 回流，匹配 starType 才认领并刷新；
  *   初始标签可由入参带入（同义词词典管理页跳转，issue #904）；
- * - 「过滤无效收藏」设置：失效作品（!isVisible）由通用过滤链恒过滤（对齐 legacy
- *   legacy Mapper），设置补的是 user 缺失/为 0 的残缺条目；
+ * - 「过滤无效收藏」设置：失效作品（!isVisible）/ user 缺失 / user.id==0 都在设置开启时
+ *   才过滤；关闭时插画收藏也放行 visible=false 的失效条目（对齐小说侧与设置文案，区别于
+ *   其它 feed 的通用过滤链恒过滤 !isVisible）；
  * - 自己的收藏页 + 「收藏页隐藏收藏按钮」设置 → 卡片不显示爱心（对齐 IAdapterWithStar）；
  * - 带 toolbar 形态（TemplateActivity「插画/漫画收藏」）沿用 local_save 菜单，
  *   只响应「收藏到精华」（legacy 的 jump/add 两项在本页本来就是死的）。
@@ -184,14 +185,14 @@ class LikeIllustFeedFragment : IllustFeedFragment() {
 
         /** 页响应 → 条目。跑在 Default 线程、被 VM 长期持有，放伴生对象保证零捕获。 */
         private fun mapLikePage(illusts: List<Illust>): List<FeedItem> {
-            // 失效作品（!isVisible）由 IllustFeedItem 的通用过滤链恒过滤；
-            // 「过滤无效收藏」设置补挡 user 缺失/为 0 的残缺条目（对齐 legacy beforeFirstLoad）
+            // 「过滤无效收藏」设置开启时挡失效作品（!isVisible）+ user 缺失/为 0 的残缺条目；
+            // 关闭时不过滤 visible，让已删除/不可见的插画收藏也能显示（与小说侧一致）。
             val filterInvalid = Shaft.sSettings.isFilterInvalidBookmarks
             return illusts.mapNotNull { illust ->
                 if (filterInvalid && (illust.user == null || illust.user.id == 0L)) {
                     return@mapNotNull null
                 }
-                IllustFeedItem.of(illust)
+                IllustFeedItem.of(illust, skipVisibleFilter = !filterInvalid)
             }
         }
     }

--- a/app/src/main/java/ceui/pixiv/ui/collection/LikeNovelFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/collection/LikeNovelFeedFragment.kt
@@ -38,9 +38,9 @@ import ceui.pixiv.ui.common.setUpToolbar
  *   `repo.setTag(tag)` + `autoRefresh()`，这里是 filterViewModel.tag + forceRefresh()）；
  *   初始标签可由入参带入（同义词词典管理页跳转，issue #904）；
  * - 「过滤无效收藏」设置（isFilterInvalidBookmarks）：对齐 legacy beforeFirstLoad/beforeNextLoad，
- *   失效作品 / user 缺失 / user.id==0 三条都在设置开启时才过滤——注意与插画侧不同，legacy
- *   [ceui.lisa.core.Mapper] 的小说分支**不**恒过滤 !visible（只有 Illust 分支才过滤），
- *   所以这里不能把它提到设置外面，否则设置关着的用户会看不到本来能看到的收藏；
+ *   失效作品 / user 缺失 / user.id==0 三条都在设置开启时才过滤；插画侧已同步为同一语义
+ *   （关闭时不过滤 visible），小说侧的通用过滤链本身不含 visible，所以这里只需在开关开启时
+ *   按 visible==false 补挡；
  * - 无 toolbar 菜单：legacy FragmentLikeNovel 用的是裸 NAdapter（不是插画侧的
  *   IAdapterWithStar），既没有「收藏到精华」菜单，也没有「收藏页隐藏收藏按钮」那套爱心门控。
  */

--- a/app/src/main/java/ceui/pixiv/ui/common/IllustFeedItem.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/IllustFeedItem.kt
@@ -69,9 +69,10 @@ class IllustFeedItem(
             skipR18Filter: Boolean = false,
             skipAiFilter: Boolean = false,
             skipMuteUserFilter: Boolean = false,
+            skipVisibleFilter: Boolean = false,
         ): IllustFeedItem? {
             if (illust == null) return null
-            if (!passesContentFilters(illust, skipR18Filter, skipAiFilter, skipMuteUserFilter)) return null
+            if (!passesContentFilters(illust, skipR18Filter, skipAiFilter, skipMuteUserFilter, skipVisibleFilter)) return null
             return IllustFeedItem(illust)
         }
 
@@ -93,6 +94,8 @@ class IllustFeedItem(
          * [skipAiFilter]：同理，给「AI 专属榜单」用——用户主动点进 AI 榜,全局「屏蔽 AI 作品」
          * 就不该把它清空（那是用户设的「我平时不想看到 AI」，不是「我点开 AI 榜也不想看」）。
          * 只让步 AI 这一条：屏蔽画师/标签、R18 过滤在 AI 榜里照常生效。
+         * [skipVisibleFilter]：收藏夹「过滤无效收藏」关闭时让步——不把 visible != true 的作品
+         * 当失效滤掉；仅收藏页按开关传入，其余列表默认 false 保持恒过滤。
          *
          * ⚠️ 这里面 judgeTag/judgeUserID 各是一次**同步 Room 查询**，调用方必须在后台线程
          * 跑（各 mapper 已由 PixivFeedSource 派到 Dispatchers.Default；详情回传链见
@@ -103,8 +106,9 @@ class IllustFeedItem(
             skipR18Filter: Boolean,
             skipAiFilter: Boolean = false,
             skipMuteUserFilter: Boolean = false,
+            skipVisibleFilter: Boolean = false,
         ): Boolean {
-            if (illust.visible != true) return false
+            if (!skipVisibleFilter && illust.visible != true) return false
             if (IllustNovelFilter.judgeTag(illust)) return false
             // 不挂 judgeID：被「屏蔽此作品」记下的单件作品在 feeds 里是**遮罩**而不是过滤——
             // 卡片留在原位糊掉 + 盖粒子，点一下即取消屏蔽（见 [ceui.pixiv.ui.common.IllustMuteStore]）。


### PR DESCRIPTION
# 收藏夹「过滤无效收藏」开关真正控制插画失效作品过滤

> 分支：`patch-8-31-1`（wangwang-code fork）
> 目标：`classic`
> 最新提交：`cf5c53976`

## 背景

`filterInvalidBookmarks`（收藏夹过滤已失效作品）默认关闭，文案是“开启后将隐藏已删除或不可见的收藏作品”，因此关闭时应能看到失效/不可见条目。

但在插画收藏页，`IllustFeedItem.passesContentFilters()` 里有一行无条件过滤：

```kotlin
if (illust.visible != true) return false
```

导致 `visible != true` 的插画无论开关开/关都被过滤，设置项在插画收藏里实际表现为“始终开启”。小说收藏页则不同：`NovelFeedItem` 通用过滤链不含 `visible`，只有开关开启时才按 `visible == false` 过滤。插画/小说行为不一致，且与设置文案矛盾。

## 改动内容

### 1. `IllustFeedItem` 增加 `skipVisibleFilter`

- `of(...)` / `passesContentFilters(...)` 新增 `skipVisibleFilter: Boolean = false`。
- visible 过滤改为：

```kotlin
if (!skipVisibleFilter && illust.visible != true) return false
```

- 默认 `false`，其它 feed 列表行为不变。

### 2. 插画收藏页按开关传递

- `LikeIllustFeedFragment.mapLikePage()` 改为：

```kotlin
IllustFeedItem.of(illust, skipVisibleFilter = !filterInvalid)
```

- 开关开启：过滤 `visible != true` + user 缺失 / `id == 0`；
- 开关关闭：放行 `visible != true` 的失效/不可见条目，与小说侧及设置文案对齐。

### 3. 补 `IllustNovelFilter.judgeUserID(Illust)` null 保护

- 关闭 visible 过滤后可能出现 `user == null` 的失效条目，`judgeUserID` 原先会直接 `illust.getUser().getId()` 触发 NPE。
- 现在 `user == null` 时返回 `false`。

### 4. 注释收敛

- `LikeIllustFeedFragment` / `LikeNovelFeedFragment` 的 KDoc 同步为“开关关闭时不过滤 visible”的语义。

## 涉及文件

- `app/src/main/java/ceui/pixiv/ui/common/IllustFeedItem.kt`
- `app/src/main/java/ceui/pixiv/ui/collection/LikeIllustFeedFragment.kt`
- `app/src/main/java/ceui/pixiv/ui/collection/LikeNovelFeedFragment.kt`
- `app/src/main/java/ceui/lisa/helper/IllustNovelFilter.java`

## 注意

关闭“过滤无效收藏”后，插画收藏页会显示 `visible != true` 的失效/不可见条目；这类条目可能缺图、作者信息不全或无法打开详情，这是关闭过滤的预期表现。后续如需更友好体验，可另加“已失效”占位卡样式。

## 提交

- `cf5c53976` fix(collection): 收藏夹过滤无效收藏开关真正控制插画 visible 过滤