### PR TITLE
V3 作者资料页性别数字 0/1/2 映射为本地化文本

### DIFF
--- a/app/src/main/java/ceui/lisa/activities/UserV3InfoFragment.kt
+++ b/app/src/main/java/ceui/lisa/activities/UserV3InfoFragment.kt
@@ -263,8 +263,9 @@ class UserV3InfoFragment : Fragment() {
 
         if (!TextUtils.isEmpty(profile.gender)) {
             val genderText = when (profile.gender) {
-                "male" -> "Male"
-                "female" -> "Female"
+                "male", "1" -> getString(R.string.male)
+                "female", "2" -> getString(R.string.female)
+                "0" -> getString(R.string.unknown_gender)
                 else -> profile.gender
             }
             chips.add(Triple("Gender", genderText, false))


### PR DESCRIPTION
# V3 作者资料页性别数字 0/1/2 映射为本地化文本

> 分支：`patch-8-31-2`（wangwang-code fork）
> 目标：`classic`
> 最新提交：`7b12ef2f`

## 背景

issue #1079 点 1：V3 沉浸式作者页的「资料」tab 中，如果作者选择公开性别，目前性别只会显示为 `GENDER + 0/1/2` 的数字。

原因是 `UserV3InfoFragment.setupProfileCard()` 原先只映射了 `"male"` / `"female"` 两种文本值，而部分接口/账号返回的 `profile.gender` 是 `"0" / "1" / "2"` 数字字符串，落入 `else` 分支后原样显示。

## 改动内容

- `app/src/main/java/ceui/lisa/activities/UserV3InfoFragment.kt`
- 性别映射改为同时支持文本与数字：
  - `"male"` / `"1"` → `R.string.male`（男性）
  - `"female"` / `"2"` → `R.string.female`（女性）
  - `"0"` → `R.string.unknown_gender`（未知性別）
  - 其它未知值仍回退显示原始值
- 顺带把硬编码的 `"Male" / "Female"` 换成仓库已有的本地化字符串资源，跟随系统语言。

## 涉及文件

- `app/src/main/java/ceui/lisa/activities/UserV3InfoFragment.kt`

## 提交

- `7b12ef2f` fix(user-v3): 作者资料性别数字 0/1/2 映射为本地化文本 (#1079)