### PR TITLE
V3 作者资料页与工作环境卡片内容过长时自动独占一行

### DIFF
--- a/app/src/main/java/ceui/lisa/activities/UserV3InfoFragment.kt
+++ b/app/src/main/java/ceui/lisa/activities/UserV3InfoFragment.kt
@@ -6,8 +6,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
-import androidx.core.view.doOnLayout
 import androidx.core.view.isVisible
+import androidx.core.view.doOnLayout
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels

--- a/app/src/main/java/ceui/lisa/activities/UserV3InfoFragment.kt
+++ b/app/src/main/java/ceui/lisa/activities/UserV3InfoFragment.kt
@@ -7,7 +7,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
 import androidx.core.view.isVisible
-import androidx.core.view.doOnLayout
+import androidx.core.view.doOnPreDraw
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -311,9 +311,14 @@ class UserV3InfoFragment : Fragment() {
     /**
      * 子卡片先按「半行宽度」量自己的期望宽度，两个都放得下才并列，否则独占一行，而不是强行
      * 并列截断。判断依赖 grid 的真实宽度：首次绑定时父卡片刚从 gone 切 visible，grid 还没量过，
-     * 等这一次 layout 出来再摆（同一帧内完成，不闪）；已布局过（下拉刷新重绑）时 doOnLayout
-     * 同步执行。不能拿屏幕宽度估算——平板双栏 / 分屏下 widthPixels 是整屏宽，估出来比实际
-     * 宽一倍，长文本照样被并列截断，等于没修。
+     * 要等这一次 measure/layout 跑完才有数，所以放到 preDraw 里摆（layout 已完成、还没画）。
+     * 不能拿屏幕宽度估算——平板双栏 / 分屏下 widthPixels 是整屏宽，估出来比实际宽一倍，长文本
+     * 照样被并列截断，等于没修。
+     *
+     * 也不能用 doOnLayout：OnLayoutChangeListener 是在 grid 自己的 layout() 里回调的，回调里
+     * addView 打上的 FORCE_LAYOUT 标记会在 layout() 收尾时被清掉，ViewRootImpl 判定「无需第二趟」，
+     * 首帧 grid 是空的，要等别的东西触发下一次 layout 才出现。preDraw 里 addView 走的是正常的
+     * requestLayout → 下一帧重排，OneShotPreDrawListener 随 view detach 自动摘除。
      */
     private fun renderChipGrid(
         grid: LinearLayout,
@@ -321,7 +326,7 @@ class UserV3InfoFragment : Fragment() {
         createChip: (Int) -> View,
         isFullWidth: (Int) -> Boolean = { false },
     ) {
-        grid.doOnLayout { layoutChipGrid(grid, chipCount, createChip, isFullWidth) }
+        grid.doOnPreDraw { layoutChipGrid(grid, chipCount, createChip, isFullWidth) }
     }
 
     private fun layoutChipGrid(

--- a/app/src/main/java/ceui/lisa/activities/UserV3InfoFragment.kt
+++ b/app/src/main/java/ceui/lisa/activities/UserV3InfoFragment.kt
@@ -6,6 +6,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
+import androidx.core.view.doOnLayout
 import androidx.core.view.isVisible
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
@@ -307,25 +308,35 @@ class UserV3InfoFragment : Fragment() {
         return bd.root
     }
 
+    /**
+     * 子卡片先按「半行宽度」量自己的期望宽度，两个都放得下才并列，否则独占一行，而不是强行
+     * 并列截断。判断依赖 grid 的真实宽度：首次绑定时父卡片刚从 gone 切 visible，grid 还没量过，
+     * 等这一次 layout 出来再摆（同一帧内完成，不闪）；已布局过（下拉刷新重绑）时 doOnLayout
+     * 同步执行。不能拿屏幕宽度估算——平板双栏 / 分屏下 widthPixels 是整屏宽，估出来比实际
+     * 宽一倍，长文本照样被并列截断，等于没修。
+     */
     private fun renderChipGrid(
         grid: LinearLayout,
         chipCount: Int,
         createChip: (Int) -> View,
         isFullWidth: (Int) -> Boolean = { false },
     ) {
+        grid.doOnLayout { layoutChipGrid(grid, chipCount, createChip, isFullWidth) }
+    }
+
+    private fun layoutChipGrid(
+        grid: LinearLayout,
+        chipCount: Int,
+        createChip: (Int) -> View,
+        isFullWidth: (Int) -> Boolean,
+    ) {
         grid.removeAllViews()
         val density = resources.displayMetrics.density
         val rowGap = (10 * density).toInt()
         val chipGap = (5 * density).toInt()
 
-        // 子卡片先按“半行宽度”测自己的期望宽度，容不下就独占一行，而不是强行并列截断。
-        // 首次数据到达时 grid 可能尚未完成布局，退回按屏幕/卡片边距估算。
-        val gridWidth = if (grid.width > 0) grid.width else {
-            resources.displayMetrics.widthPixels -
-                (20 * density).toInt() * 2 -
-                (18 * density).toInt() * 2
-        }
-        val halfSlotWidth = ((gridWidth - chipGap) / 2).coerceAtLeast(0)
+        // 并列时 chip1 有 marginEnd、chip2 有 marginStart，一行让出两份 chipGap。
+        val halfSlotWidth = ((grid.width - chipGap * 2) / 2).coerceAtLeast(0)
 
         fun fitsHalfSlot(chip: View): Boolean {
             val bd = ItemV3ProfileChipBinding.bind(chip)

--- a/app/src/main/java/ceui/lisa/activities/UserV3InfoFragment.kt
+++ b/app/src/main/java/ceui/lisa/activities/UserV3InfoFragment.kt
@@ -281,47 +281,12 @@ class UserV3InfoFragment : Fragment() {
         chips.add(Triple("Premium", if (user.is_premium == true) "★ Premium User" else "Standard", false))
         chips.add(Triple("Pixiv URL", "https://www.pixiv.net/users/${user.id}", true))
 
-        val grid = binding.profileGrid
-        grid.removeAllViews()
-        val density = resources.displayMetrics.density
-        val rowGap = (10 * density).toInt()
-        val chipGap = (5 * density).toInt()
-        var i = 0
-        while (i < chips.size) {
-            val row = LinearLayout(requireContext()).apply {
-                orientation = LinearLayout.HORIZONTAL
-                layoutParams = LinearLayout.LayoutParams(
-                    LinearLayout.LayoutParams.MATCH_PARENT,
-                    LinearLayout.LayoutParams.WRAP_CONTENT
-                ).apply { bottomMargin = rowGap }
-            }
-
-            val chip1 = createProfileChip(chips[i])
-            val isLastSingle = i + 1 >= chips.size
-            val isFullWidth = chips[i].first == "Pixiv URL"
-
-            if (isFullWidth || isLastSingle) {
-                chip1.layoutParams =
-                    LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
-                row.addView(chip1)
-            } else {
-                chip1.layoutParams =
-                    LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f).apply {
-                        marginEnd = chipGap
-                    }
-                row.addView(chip1)
-
-                val chip2 = createProfileChip(chips[i + 1])
-                chip2.layoutParams =
-                    LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f).apply {
-                        marginStart = chipGap
-                    }
-                row.addView(chip2)
-                i++
-            }
-            grid.addView(row)
-            i++
-        }
+        renderChipGrid(
+            binding.profileGrid,
+            chips.size,
+            createChip = { createProfileChip(chips[it]) },
+            isFullWidth = { chips[it].first == "Pixiv URL" }
+        )
     }
 
     private fun createProfileChip(data: Triple<String, String, Boolean>): View {
@@ -340,6 +305,88 @@ class UserV3InfoFragment : Fragment() {
             bd.root.setOnClickListener { openUrl(data.second) }
         }
         return bd.root
+    }
+
+    private fun renderChipGrid(
+        grid: LinearLayout,
+        chipCount: Int,
+        createChip: (Int) -> View,
+        isFullWidth: (Int) -> Boolean = { false },
+    ) {
+        grid.removeAllViews()
+        val density = resources.displayMetrics.density
+        val rowGap = (10 * density).toInt()
+        val chipGap = (5 * density).toInt()
+
+        // 子卡片先按“半行宽度”测自己的期望宽度，容不下就独占一行，而不是强行并列截断。
+        // 首次数据到达时 grid 可能尚未完成布局，退回按屏幕/卡片边距估算。
+        val gridWidth = if (grid.width > 0) grid.width else {
+            resources.displayMetrics.widthPixels -
+                (20 * density).toInt() * 2 -
+                (18 * density).toInt() * 2
+        }
+        val halfSlotWidth = ((gridWidth - chipGap) / 2).coerceAtLeast(0)
+
+        fun fitsHalfSlot(chip: View): Boolean {
+            val bd = ItemV3ProfileChipBinding.bind(chip)
+            val labelWidth = bd.chipLabel.paint.measureText(
+                bd.chipLabel.text.toString().uppercase()
+            )
+            val valueWidth = bd.chipValue.paint.measureText(bd.chipValue.text.toString())
+            val desiredWidth = maxOf(labelWidth, valueWidth).toInt() +
+                bd.root.paddingLeft + bd.root.paddingRight
+            return desiredWidth <= halfSlotWidth
+        }
+
+        var i = 0
+        while (i < chipCount) {
+            val row = LinearLayout(requireContext()).apply {
+                orientation = LinearLayout.HORIZONTAL
+                layoutParams = LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT
+                ).apply { bottomMargin = rowGap }
+            }
+
+            val chip1 = createChip(i)
+            val isLastSingle = i + 1 >= chipCount
+            val fullWidth = isFullWidth(i)
+            val chip1Fits = !fullWidth && !isLastSingle && fitsHalfSlot(chip1)
+            val chip2 = if (chip1Fits) createChip(i + 1) else null
+            val canPair = chip1Fits && chip2 != null && fitsHalfSlot(chip2)
+
+            if (canPair) {
+                chip1.layoutParams =
+                    LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f).apply {
+                        marginEnd = chipGap
+                    }
+                row.addView(chip1)
+
+                val chip2View = checkNotNull(chip2)
+                chip2View.layoutParams =
+                    LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f).apply {
+                        marginStart = chipGap
+                    }
+                row.addView(chip2View)
+                i++
+            } else {
+                // 独占一行时允许文本换行，长文本不再被单行省略
+                makeChipWrappable(chip1)
+                chip1.layoutParams =
+                    LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+                row.addView(chip1)
+            }
+            grid.addView(row)
+            i++
+        }
+    }
+
+    @android.annotation.SuppressLint("InlinedApi")
+    private fun makeChipWrappable(chip: View) {
+        val bd = ItemV3ProfileChipBinding.bind(chip)
+        bd.chipValue.maxLines = Int.MAX_VALUE
+        bd.chipValue.ellipsize = null
+        bd.chipValue.breakStrategy = android.graphics.text.LineBreaker.BREAK_STRATEGY_HIGH_QUALITY
     }
 
     private fun setupWorkspaceCard(workspace: WorkspaceBean?) {
@@ -362,47 +409,11 @@ class UserV3InfoFragment : Fragment() {
         if (items.isEmpty()) return
 
         binding.workspaceCard.visibility = View.VISIBLE
-        val grid = binding.workspaceGrid
-        grid.removeAllViews()
-        val density = resources.displayMetrics.density
-        val rowGap = (10 * density).toInt()
-        val chipGap = (5 * density).toInt()
-
-        var i = 0
-        while (i < items.size) {
-            val row = LinearLayout(requireContext()).apply {
-                orientation = LinearLayout.HORIZONTAL
-                layoutParams = LinearLayout.LayoutParams(
-                    LinearLayout.LayoutParams.MATCH_PARENT,
-                    LinearLayout.LayoutParams.WRAP_CONTENT
-                ).apply { bottomMargin = rowGap }
-            }
-
-            val isLastSingle = i + 1 >= items.size
-            val chip1 = createWorkspaceChip(items[i])
-
-            if (isLastSingle) {
-                chip1.layoutParams =
-                    LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
-                row.addView(chip1)
-            } else {
-                chip1.layoutParams =
-                    LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f).apply {
-                        marginEnd = chipGap
-                    }
-                row.addView(chip1)
-
-                val chip2 = createWorkspaceChip(items[i + 1])
-                chip2.layoutParams =
-                    LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f).apply {
-                        marginStart = chipGap
-                    }
-                row.addView(chip2)
-                i++
-            }
-            grid.addView(row)
-            i++
-        }
+        renderChipGrid(
+            binding.workspaceGrid,
+            items.size,
+            createChip = { createWorkspaceChip(items[it]) }
+        )
 
         binding.workspaceHeaderToggle.setOnClickListener {
             val isVisible = binding.workspaceGrid.visibility == View.VISIBLE


### PR DESCRIPTION
# V3 作者资料页与工作环境卡片内容过长时自动独占一行

> 分支：`patch-8-31-3`（wangwang-code fork）
> 目标：`classic`
> 最新提交：`fa1ec74c9`

## 背景

issue #1079 点 2：V3 沉浸式作者页的「资料」tab 中，Pixiv URL 以及工作环境信息可能显示不全。原因是子卡片固定两两并列、等分宽度，内容较长时会被单行省略截断。

## 改动内容

- 抽出统一方法 `renderChipGrid(...)`，个人资料卡片和工作环境卡片共用同一套布局策略：
  - 按“半行宽度”测量每个子卡片的期望宽度；
  - 两个子卡片都能放下时保持并列；
  - 任一个放不下时，该子卡片独占一行；
  - 独占一行时取消单行省略，允许文本换行（`maxLines` 放开 + `ellipsize` 清除 + 高优先级换行策略）。
- 个人资料卡片：`Pixiv URL` 仍固定独占一行，长 URL 可换行展示。
- 工作环境卡片：同样按内容宽度自动决定并列或独占一行。
- 测量 label 时按大写计算，匹配 `textAllCaps` 的实际展示宽度，避免误判。
- 仅当第一个子卡片能放下时才创建第二个子卡片，减少无效 View 创建。

## 涉及文件

- `app/src/main/java/ceui/lisa/activities/UserV3InfoFragment.kt`

## 提交

- `fa1ec74c9` fix(user-v3): 个人资料与工作环境子卡片按内容宽度自动独占一行 (#1079)