### PR TITLE
V3 作者自我介绍支持翻译与长简介折叠

### DIFF
--- a/app/src/main/java/ceui/lisa/activities/UserV3InfoFragment.kt
+++ b/app/src/main/java/ceui/lisa/activities/UserV3InfoFragment.kt
@@ -6,6 +6,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.LinearLayout
+import androidx.core.view.OneShotPreDrawListener
+import androidx.core.view.doOnPreDraw
 import androidx.core.view.isVisible
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
@@ -19,7 +21,11 @@ import ceui.lisa.utils.PixivOperate
 import ceui.lisa.viewmodel.UserViewModel
 import ceui.loxia.Event
 import ceui.loxia.WebUserDetail
+import ceui.pixiv.ui.comments.translateComment
 import ceui.pixiv.session.SessionManager
+
+/** 作者简介折叠阈值，与 V3 详情页简介一致。 */
+private const val BIO_COLLAPSED_LINES = 5
 
 /**
  * V3 用户主页右侧 Tab —— 资料 / 工作环境 / 社交链接 / 简介 / 屏蔽。
@@ -31,6 +37,10 @@ class UserV3InfoFragment : Fragment() {
     private var _binding: FragmentUserV3InfoBinding? = null
     private val binding get() = _binding!!
     private val userViewModel: UserViewModel by activityViewModels()
+
+    /** 作者简介展开态（对齐 V3 详情页简介折叠）。 */
+    private var bioExpanded = false
+    private var bioFullText: CharSequence? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -73,11 +83,71 @@ class UserV3InfoFragment : Fragment() {
                 binding.muteSwitch.setOnCheckedChangeListener(muteSwitchListener)
             }
         }
+        binding.bioTranslate.setOnClickListener { translateBio() }
+        binding.bioToggle.setOnClickListener {
+            bioExpanded = !bioExpanded
+            applyBioCollapseState()
+        }
     }
 
     override fun onDestroyView() {
+        clearPendingBioPreDraw()
+        bioFullText = null
         super.onDestroyView()
         _binding = null
+    }
+
+    private fun bindBio(full: CharSequence) {
+        bioFullText = full
+        binding.bioSection.isVisible = true
+        binding.bio.text = full
+        binding.bio.movementMethod = android.text.method.LinkMovementMethod.getInstance()
+        applyBioCollapseState()
+    }
+
+    private fun translateBio() {
+        val plain = (bioFullText ?: binding.bio.text).toString().trim()
+        translateComment(plain)
+    }
+
+    /**
+     * 长简介折叠，对齐 V3 详情页简介区：#965/#1005 同款实现口径。
+     * 折叠态在文本层面截到第 [BIO_COLLAPSED_LINES] 行止，避免 textIsSelectable /
+     * LinkMovementMethod 把隐藏行滚出来。
+     */
+    private fun applyBioCollapseState() {
+        val full = bioFullText ?: return
+        binding.bio.maxLines = if (bioExpanded) Int.MAX_VALUE else BIO_COLLAPSED_LINES
+        binding.bio.text = full
+        binding.bio.scrollTo(0, 0)
+        binding.bioToggle.setText(
+            if (bioExpanded) R.string.v3_desc_collapse else R.string.v3_desc_expand
+        )
+        clearPendingBioPreDraw()
+        lateinit var request: OneShotPreDrawListener
+        request = binding.bio.doOnPreDraw {
+            if (binding.bio.getTag(R.id.v3_desc_predraw_listener) === request &&
+                bioFullText === full
+            ) {
+                binding.bio.setTag(R.id.v3_desc_predraw_listener, null)
+                val layout = binding.bio.layout
+                if (layout != null) {
+                    val overflow = layout.lineCount > BIO_COLLAPSED_LINES
+                    binding.bioToggle.isVisible = overflow
+                    if (!bioExpanded && overflow) {
+                        val end = layout.getLineEnd(BIO_COLLAPSED_LINES - 1).coerceIn(0, full.length)
+                        binding.bio.text = full.subSequence(0, end).trimEnd()
+                    }
+                }
+            }
+        }
+        binding.bio.setTag(R.id.v3_desc_predraw_listener, request)
+    }
+
+    private fun clearPendingBioPreDraw() {
+        (binding.bio.getTag(R.id.v3_desc_predraw_listener) as? OneShotPreDrawListener)
+            ?.removeListener()
+        binding.bio.setTag(R.id.v3_desc_predraw_listener, null)
     }
 
     private fun bindUserDetail(data: UserDetailResponse) {
@@ -87,11 +157,11 @@ class UserV3InfoFragment : Fragment() {
 
         // Bio
         if (!TextUtils.isEmpty(user.comment)) {
-            binding.bio.visibility = View.VISIBLE
-            binding.bio.text = androidx.core.text.HtmlCompat.fromHtml(
-                user.comment.orEmpty(), androidx.core.text.HtmlCompat.FROM_HTML_MODE_COMPACT
+            bindBio(
+                androidx.core.text.HtmlCompat.fromHtml(
+                    user.comment.orEmpty(), androidx.core.text.HtmlCompat.FROM_HTML_MODE_COMPACT
+                )
             )
-            binding.bio.movementMethod = android.text.method.LinkMovementMethod.getInstance()
         }
 
         // Social chips from app API (web API may add more later)
@@ -113,11 +183,11 @@ class UserV3InfoFragment : Fragment() {
     private fun bindWebUserDetail(detail: WebUserDetail) {
         // Web 端的 commentHtml 比 app 端的 user.comment 排版更全（有 <a> 等标签）,有就覆盖。
         if (!detail.commentHtml.isNullOrEmpty()) {
-            binding.bio.isVisible = true
-            binding.bio.text = androidx.core.text.HtmlCompat.fromHtml(
-                detail.commentHtml, androidx.core.text.HtmlCompat.FROM_HTML_MODE_COMPACT
+            bindBio(
+                androidx.core.text.HtmlCompat.fromHtml(
+                    detail.commentHtml, androidx.core.text.HtmlCompat.FROM_HTML_MODE_COMPACT
+                )
             )
-            binding.bio.movementMethod = android.text.method.LinkMovementMethod.getInstance()
         }
 
         // Supplement social links from Web API

--- a/app/src/main/res/layout/fragment_user_v3_info.xml
+++ b/app/src/main/res/layout/fragment_user_v3_info.xml
@@ -80,19 +80,71 @@
             </LinearLayout>
 
             <!-- Bio (between profile and workspace) -->
-            <TextView
-                android:id="@+id/bio"
+            <LinearLayout
+                android:id="@+id/bio_section"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
-                android:alpha="0.78"
-                android:autoLink="all"
-                android:lineSpacingMultiplier="1.6"
-                android:textColor="@color/v3_text_1"
-                android:textColorLink="#3D8BFD"
-                android:textIsSelectable="true"
-                android:textSize="14sp"
-                android:visibility="gone" />
+                android:orientation="vertical"
+                android:visibility="gone">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:letterSpacing="0.12"
+                        android:text="@string/label_personal_intro"
+                        android:textAllCaps="true"
+                        android:textColor="@color/v3_text_3"
+                        android:textSize="12sp"
+                        android:textStyle="bold" />
+
+                    <View
+                        android:layout_width="0dp"
+                        android:layout_height="0dp"
+                        android:layout_weight="1" />
+
+                    <ImageView
+                        android:id="@+id/bio_translate"
+                        android:layout_width="48dp"
+                        android:layout_height="48dp"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:padding="12dp"
+                        android:contentDescription="@string/string_translate_caption"
+                        android:src="@drawable/ic_baseline_translate_24"
+                        app:tint="@color/v3_text_3" />
+                </LinearLayout>
+
+                <TextView
+                    android:id="@+id/bio"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:alpha="0.78"
+                    android:autoLink="all"
+                    android:lineSpacingMultiplier="1.6"
+                    android:textColor="@color/v3_text_1"
+                    android:textColorLink="#3D8BFD"
+                    android:textIsSelectable="true"
+                    android:textSize="14sp" />
+
+                <TextView
+                    android:id="@+id/bio_toggle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/selectableItemBackground"
+                    android:gravity="center_vertical"
+                    android:minHeight="48dp"
+                    android:text="@string/v3_desc_expand"
+                    android:textColor="@color/v3_blue"
+                    android:textSize="13sp"
+                    android:textStyle="bold"
+                    android:visibility="gone" />
+            </LinearLayout>
 
             <!-- Workspace Card -->
             <LinearLayout


### PR DESCRIPTION
# V3 作者自我介绍支持翻译与长简介折叠

> 分支：`patch-8-31-4`（wangwang-code fork）
> 目标：`classic`
> 最新提交：`27162c6b2`

## 背景

issue #1079 点 3：V3 沉浸式作者页的「资料」tab 中，作者的自我介绍目前只有纯文本展示，没有翻译入口，也没有针对长简介的折叠/展开。

## 改动内容

- 作者简介区新增「个人介绍」标题头 + 右侧翻译按钮，布局对齐 V3 详情页简介区。
- 翻译按钮复用现有评论翻译链路，将作者简介翻译为 App 当前语言并弹窗展示。
- 长简介支持折叠/展开：
  - 折叠阈值 5 行，与 V3 详情页简介一致；
  - 折叠态在文本层面截断，避免 `textIsSelectable` / 链接拖动把隐藏行滚出来；
  - 展开状态由 Fragment 持有，重绑后不丢失；
  - 视图销毁时清理未执行的预绘制回调与全文引用。
- App API 与 Web API 的简介统一走 `bindBio()` 入口，Web 端更完整的 `commentHtml` 仍可覆盖展示。

## 涉及文件

- `app/src/main/java/ceui/lisa/activities/UserV3InfoFragment.kt`
- `app/src/main/res/layout/fragment_user_v3_info.xml`

## 提交

- `27162c6b2` feat(user-v3): 作者自我介绍支持翻译与长简介折叠 (#1079)
