### PR TITLE
feat(collection): 失效收藏卡片长按复制作品ID/标题 (#1078)

### DIFF
--- a/app/src/main/java/ceui/pixiv/ui/common/IllustCardMenu.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/IllustCardMenu.kt
@@ -39,6 +39,22 @@ internal fun IllustFeedFragment.showCardMenu(
     onToggleSpoiler: (Boolean) -> Unit = { setIllustMuted(item, it) },
 ) {
     val bean = item.illust
+    // 收藏夹关闭「过滤无效收藏」后，已删除/不公开的失效插画仍会显示（灰色封面）。这类作品
+    // 打不开详情，下载/屏蔽/评论等动作也基本无意义，长按只保留「复制作品ID」以及能拿到的
+    // 「复制作品标题」，方便对照本地下载文件确认是哪张作品被删了。
+    if (!Shaft.sSettings.isFilterInvalidBookmarks && bean.visible != true) {
+        showV3Menu("IllustFeedCardMenu") {
+            item(getString(R.string.copy_work_id), R.drawable.baseline_content_copy_24) {
+                Common.copy(requireContext(), bean.id.toString())
+            }
+            if (!bean.title.isNullOrBlank()) {
+                item(getString(R.string.copy_work_title), R.drawable.baseline_content_copy_24) {
+                    Common.copy(requireContext(), bean.title)
+                }
+            }
+        }
+        return
+    }
     val entityWrapper = requireEntityWrapper()
     val inWatchLater = entityWrapper.isInWatchLater(item.illust.id)
     val spoilered = IllustMuteStore.isMuted(item.illust.id)

--- a/app/src/main/java/ceui/pixiv/ui/common/NovelCardMenu.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/NovelCardMenu.kt
@@ -2,13 +2,13 @@ package ceui.pixiv.ui.common
 
 import android.content.Intent
 import ceui.lisa.R
+import ceui.lisa.activities.Shaft
 import ceui.lisa.activities.TemplateActivity
 import ceui.pixiv.ui.muted.MuteTagSheet
 import ceui.lisa.models.TagsBean
 import ceui.lisa.utils.Common
 import ceui.lisa.utils.Params
 import ceui.loxia.Novel
-import ceui.loxia.User
 import ceui.loxia.requireEntityWrapper
 import ceui.pixiv.ui.bulk.BulkSelectHandoff
 import ceui.pixiv.ui.bulk.NovelBulkSelectHandoff
@@ -39,6 +39,21 @@ internal fun NovelFeedFragment.showNovelCardMenu(
     onToggleSpoiler: (Boolean) -> Unit = { setNovelMuted(item.novel, it) },
 ) {
     val novel = item.novel
+    // 收藏夹关闭「过滤无效收藏」后，已删除/不公开的失效小说仍会显示（灰色封面）。长按同样
+    // 只保留复制 ID / 标题，避免对无法打开的作品弹出一堆无效操作。
+    if (!Shaft.sSettings.isFilterInvalidBookmarks && novel.visible == false) {
+        showV3Menu("NovelFeedCardMenu") {
+            item(getString(R.string.copy_work_id), R.drawable.baseline_content_copy_24) {
+                Common.copy(requireContext(), novel.id.toString())
+            }
+            if (!novel.title.isNullOrBlank()) {
+                item(getString(R.string.copy_work_title), R.drawable.baseline_content_copy_24) {
+                    Common.copy(requireContext(), novel.title)
+                }
+            }
+        }
+        return
+    }
     val entityWrapper = requireEntityWrapper()
     val inWatchLater = entityWrapper.isNovelInWatchLater(novel.id)
     val spoilered = NovelMuteStore.isMuted(novel.id)

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1219,6 +1219,8 @@
     <string name="setting_illust_mix_discover">Discovery</string>
     <string name="setting_illust_mix_related">Related</string>
     <string name="action_copy">Copy</string>
+    <string name="copy_work_id">Copy work ID</string>
+    <string name="copy_work_title">Copy work title</string>
     <string name="action_select_all">Select all</string>
     <string name="action_highlight">Highlight</string>
     <string name="action_note">Note</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1219,6 +1219,8 @@
     <string name="setting_illust_mix_discover">ディスカバリー</string>
     <string name="setting_illust_mix_related">関連</string>
     <string name="action_copy">コピー</string>
+    <string name="copy_work_id">作品IDをコピー</string>
+    <string name="copy_work_title">作品タイトルをコピー</string>
     <string name="action_select_all">すべて選択</string>
     <string name="action_highlight">ハイライト</string>
     <string name="action_note">メモ</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1219,6 +1219,8 @@
     <string name="setting_illust_mix_discover">디스커버리</string>
     <string name="setting_illust_mix_related">관련</string>
     <string name="action_copy">복사</string>
+    <string name="copy_work_id">작품 ID 복사</string>
+    <string name="copy_work_title">작품 제목 복사</string>
     <string name="action_select_all">전체 선택</string>
     <string name="action_highlight">하이라이트</string>
     <string name="action_note">메모</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1219,6 +1219,8 @@
     <string name="setting_illust_mix_discover">Обзор</string>
     <string name="setting_illust_mix_related">Похожие</string>
     <string name="action_copy">Копировать</string>
+    <string name="copy_work_id">Копировать ID работы</string>
+    <string name="copy_work_title">Копировать название работы</string>
     <string name="action_select_all">Выделить всё</string>
     <string name="action_highlight">Выделить</string>
     <string name="action_note">Заметка</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1219,6 +1219,8 @@
     <string name="setting_illust_mix_discover">Keşfet</string>
     <string name="setting_illust_mix_related">İlgili</string>
     <string name="action_copy">Kopyala</string>
+    <string name="copy_work_id">Çalışma kimliğini kopyala</string>
+    <string name="copy_work_title">Çalışma başlığını kopyala</string>
     <string name="action_select_all">Tümünü seç</string>
     <string name="action_highlight">Vurgula</string>
     <string name="action_note">Not</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1221,6 +1221,8 @@
     <string name="setting_illust_mix_discover">發現頁</string>
     <string name="setting_illust_mix_related">相關作品</string>
     <string name="action_copy">複製</string>
+    <string name="copy_work_id">複製作品ID</string>
+    <string name="copy_work_title">複製作品標題</string>
     <string name="action_select_all">全選</string>
     <string name="action_highlight">標記</string>
     <string name="action_note">筆記</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1326,6 +1326,8 @@
 
     <!-- Reader actions & menus -->
     <string name="action_copy">复制</string>
+    <string name="copy_work_id">复制作品ID</string>
+    <string name="copy_work_title">复制作品标题</string>
     <string name="action_select_all">全选</string>
     <string name="action_highlight">标记高亮</string>
     <string name="action_note">笔记</string>


### PR DESCRIPTION
# 收藏页失效卡片长按复制作品ID/标题 (#1078)

> 分支：`patch-8-31-5`（wangwang-code fork）
> 目标：`classic`
> 最新提交：`b52b4384f`

## 背景

Issue #1078：收藏页里已删除/不公开的失效作品会显示为灰色封面，无法打开详情。用户希望能通过长按灰色封面复制作品 ID，从而确认是哪个作品被删了。

## 改动内容

- 插画卡长按菜单：当“过滤无效收藏”未开启且该插画 `visible != true` 时，菜单只显示「复制作品ID」；如果标题非空，额外显示「复制作品标题」。
- 小说卡长按菜单：同样对 `visible == false` 的失效小说只保留复制 ID / 标题。
- 新增 `copy_work_id` / `copy_work_title` 文案，并补齐 `en/ja/ko/ru/tr/zh-rTW` 翻译。

## 涉及文件

- `app/src/main/java/ceui/pixiv/ui/common/IllustCardMenu.kt`
- `app/src/main/java/ceui/pixiv/ui/common/NovelCardMenu.kt`
- `app/src/main/res/values/strings.xml`
- `app/src/main/res/values-en/strings.xml`
- `app/src/main/res/values-ja/strings.xml`
- `app/src/main/res/values-ko/strings.xml`
- `app/src/main/res/values-ru/strings.xml`
- `app/src/main/res/values-tr/strings.xml`
- `app/src/main/res/values-zh-rTW/strings.xml`

## 注意

- 本 PR 不包含 `patch-8-31-1` 的“插画收藏 visible 放行”改动；插画失效卡片要等 `patch-8-31-1` 合入后才会显示，届时本长按菜单自然生效。小说收藏侧当前即可显示失效条目，因此小说侧功能不依赖 `patch-8-31-1`。
- 失效作品无法打开详情，因此长按不再显示下载/屏蔽/评论等操作，只保留复制信息。

## 提交

- `b52b4384f` feat(collection): 失效收藏卡片长按仅显示复制作品ID/标题