### PR TITLE
试验性日志文件：Timber 落盘到“日志文件”桶，支持分享与崩溃捕获

### DIFF
--- a/app/src/main/java/ceui/lisa/activities/Shaft.java
+++ b/app/src/main/java/ceui/lisa/activities/Shaft.java
@@ -34,6 +34,7 @@ import ceui.lisa.utils.Settings;
 import ceui.lisa.viewmodel.AppLevelState;
 import ceui.pixiv.services.ServicesProvider;
 import ceui.pixiv.db.EntityWrapper;
+import ceui.pixiv.debug.TimberFileLog;
 import ceui.pixiv.session.SessionManager;
 import ceui.pixiv.utils.NetworkStateManager;
 import ceui.pixiv.progress.ProgressTracker;
@@ -190,6 +191,19 @@ public class Shaft extends Application implements ServicesProvider {
     public void onCreate() {
         super.onCreate();
 
+        // 包一层默认崩溃处理器：把致命崩溃栈同步写入文件日志（若有），再交回系统。
+        final Thread.UncaughtExceptionHandler originalCrashHandler =
+                Thread.getDefaultUncaughtExceptionHandler();
+        Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
+            try {
+                TimberFileLog.INSTANCE.logCrashNow(thread.getName(), throwable);
+            } catch (Throwable ignored) {
+            }
+            if (originalCrashHandler != null) {
+                originalCrashHandler.uncaughtException(thread, throwable);
+            }
+        });
+
         // Keep the main Looper alive across the GMS "Unknown calling package name"
         // SecurityException. GMS delivers it on the main thread's Handler, which
         // otherwise unwinds Looper.loop() and kills the process. Re-entering the
@@ -326,6 +340,10 @@ public class Shaft extends Application implements ServicesProvider {
         initMMKV(this);
         networkStateManager = new NetworkStateManager(this);
         sSettings = Local.getSettings();
+
+        if (sSettings.isLogFileEnabled()) {
+            TimberFileLog.INSTANCE.maybeStart();
+        }
 
         // issue #865: 图片加速代理。在 mOkHttpClient 构建前把持久化的模式/自定义 host
         // 灌进 ImageHostManager —— requiresStandardClient() 靠它决定是否给图片客户端

--- a/app/src/main/java/ceui/lisa/fragments/FragmentSettingsExperimental.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSettingsExperimental.java
@@ -11,6 +11,7 @@ import ceui.lisa.activities.Shaft;
 import ceui.lisa.databinding.FragmentSettingsExperimentalBinding;
 import ceui.lisa.utils.Common;
 import ceui.lisa.utils.Local;
+import ceui.pixiv.debug.TimberFileLog;
 
 /** 设置 · 试验性 */
 public class FragmentSettingsExperimental extends SettingsPageFragment<FragmentSettingsExperimentalBinding> {
@@ -23,6 +24,8 @@ public class FragmentSettingsExperimental extends SettingsPageFragment<FragmentS
     @Override
     protected void initData() {
         bindWitGalleryRows();
+        bindLogFileRow();
+        bindTriggerCrashRow();
 
         // 自动快照是本地离线能力，不涉及站外 UGC，所有渠道都显示。
         baseBind.autoSnapshotOnBookmark.setChecked(Shaft.sSettings.isAutoSnapshotOnBookmark());
@@ -119,6 +122,43 @@ public class FragmentSettingsExperimental extends SettingsPageFragment<FragmentS
         }
         baseBind.witGalleryRela.setOnClickListener(v ->
                 ceui.pixiv.ui.settings.WitDialogGallery.showWit(mContext));
+    }
+
+    private void bindLogFileRow() {
+        baseBind.logFileEnable.setChecked(Shaft.sSettings.isLogFileEnabled());
+        String folder = TimberFileLog.INSTANCE.currentFolderPath();
+        baseBind.logFilePath.setText(getString(
+                R.string.setting_log_file_desc,
+                folder != null ? folder : getString(R.string.setting_log_file_no_file)));
+
+        baseBind.logFileShare.setOnClickListener(v ->
+                TimberFileLog.INSTANCE.shareLogFile(mContext));
+
+        baseBind.logFileEnable.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                Shaft.sSettings.setLogFileEnabled(isChecked);
+                Local.setSettings(Shaft.sSettings);
+                Common.showToast(getString(R.string.please_restart_app), 2);
+            }
+        });
+        baseBind.logFileEnableRela.setOnClickListener(v ->
+                baseBind.logFileEnable.performClick());
+    }
+
+    private void bindTriggerCrashRow() {
+        if (!ceui.lisa.BuildConfig.DEBUG) {
+            baseBind.triggerCrashRela.setVisibility(View.GONE);
+            return;
+        }
+        baseBind.triggerCrashRela.setOnClickListener(v -> crashDeep());
+    }
+
+    /**
+     * 无限递归触发 StackOverflowError：Error 而非 Exception，catch(Exception) 抓不到，且必走未捕获异常处理器。
+     */
+    private void crashDeep() {
+        crashDeep();
     }
 
     private void bindFirebaseRow() {

--- a/app/src/main/java/ceui/lisa/fragments/SettingsCatalog.kt
+++ b/app/src/main/java/ceui/lisa/fragments/SettingsCatalog.kt
@@ -205,6 +205,7 @@ object SettingsCatalog {
             add(Entry(EXPERIMENTAL, "show_plaza_entry_rela", R.string.setting_show_plaza_entry, keywords = "广场 侧边栏 plaza"))
         }
         add(Entry(EXPERIMENTAL, "auto_snapshot_on_bookmark_rela", R.string.setting_auto_snapshot_on_bookmark, R.string.setting_auto_snapshot_on_bookmark_desc, keywords = "自动快照 离线快照 收藏 静默 后台 snapshot bookmark auto"))
+        add(Entry(EXPERIMENTAL, "log_file_enable_rela", R.string.setting_log_file_enable, R.string.setting_log_file_desc, keywords = "日志 文件 调试 落盘 log timber"))
         add(Entry(EXPERIMENTAL, "is_firebase_enable_rela", R.string.string_367, keywords = "统计 分析 隐私 数据收集 遥测 firebase analytics"))
     }
 

--- a/app/src/main/java/ceui/lisa/utils/Settings.java
+++ b/app/src/main/java/ceui/lisa/utils/Settings.java
@@ -145,6 +145,9 @@ public class Settings {
     //是否启用 FIREBASE_ANALYTICS_COLLECTION
     private boolean isFirebaseEnable = true;
 
+    //是否启用 Timber 日志写入「日志文件」桶（试验性，重启生效）
+    private boolean logFileEnabled = false;
+
     private long currentProgress = 0L;
 
     public long getCurrentProgress() {
@@ -554,6 +557,14 @@ public class Settings {
 
     public void setFirebaseEnable(boolean firebaseEnable) {
         isFirebaseEnable = firebaseEnable;
+    }
+
+    public boolean isLogFileEnabled() {
+        return logFileEnabled;
+    }
+
+    public void setLogFileEnabled(boolean logFileEnabled) {
+        this.logFileEnabled = logFileEnabled;
     }
 
     public void setThemeType(AppCompatActivity activity, ThemeHelper.ThemeType themeType) {

--- a/app/src/main/java/ceui/pixiv/debug/TimberFileLog.kt
+++ b/app/src/main/java/ceui/pixiv/debug/TimberFileLog.kt
@@ -1,0 +1,344 @@
+package ceui.pixiv.debug
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import android.util.Log
+import androidx.core.content.FileProvider
+import ceui.lisa.R
+import ceui.lisa.activities.Shaft
+import ceui.pixiv.download.DownloadsRegistry
+import ceui.pixiv.download.backend.StorageBackend
+import ceui.pixiv.download.config.OverwritePolicy
+import ceui.pixiv.download.model.Author
+import ceui.pixiv.download.model.Bucket
+import ceui.pixiv.download.model.ItemMeta
+import ceui.pixiv.download.model.RelativePath
+import ceui.pixiv.download.sanitize.FsSanitizer
+import ceui.pixiv.download.template.SafeTemplateRender
+import ceui.pixiv.witstudio.dialog.WitDialog
+import com.hjq.toast.Toaster
+import timber.log.Timber
+import java.io.File
+import java.io.OutputStreamWriter
+import java.io.PrintWriter
+import java.text.SimpleDateFormat
+import java.time.Instant
+import java.util.Date
+import java.util.Locale
+import java.util.concurrent.Executors
+
+/**
+ * 把 Timber 日志写入「日志文件」桶（[Bucket.Log]）的开关式文件日志。
+ * 所有日志文件操作（打开/写入/关闭/合并）都在单线程 IO executor 上执行，
+ * 避免在主线程做文件 I/O。
+ */
+object TimberFileLog {
+
+    /** 所有日志文件操作的串行执行器（daemon，不阻止进程退出）。 */
+    private val ioExecutor = Executors.newSingleThreadExecutor { r ->
+        Thread(r, "timber-file-log").apply { isDaemon = true }
+    }
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    @Volatile
+    private var tree: TimberFileTree? = null
+
+    /** 本进程周期内创建过的日志文件 Uri（按创建顺序）。SAF 下不扫描目录，靠这份内存记录规避耗时扫描。 */
+    private val lifetimeUris = mutableListOf<Uri>()
+
+    /** 已分享过的文件数量：`lifetimeUris` 前 [lastSharedCount] 个视为已分享。 */
+    @Volatile
+    private var lastSharedCount = 0
+
+    /** 进程启动时调用：异步在 IO 线程打开并 plant 文件 Tree；已开启则忽略。 */
+    fun maybeStart() {
+        ioExecutor.execute { maybeStartOnIoThread() }
+    }
+
+    private fun maybeStartOnIoThread() {
+        if (tree != null) return
+        val treeToPlant = try {
+            TimberFileTree()
+        } catch (ignored: Throwable) {
+            null
+        } ?: return
+        tree = treeToPlant
+        try {
+            Timber.plant(treeToPlant)
+        } catch (plantError: Throwable) {
+            tree = null
+            runCatching { treeToPlant.close() }
+        }
+    }
+
+    /** 记录新打开的日志文件 Uri（由 [TimberFileTree] 打开成功后调用）。 */
+    @Synchronized
+    fun register(uri: Uri) {
+        if (uri !in lifetimeUris) {
+            lifetimeUris += uri
+        }
+    }
+
+    /** 在 IO 线程执行：发布当前日志并重开新日志文件。调用方必须已在 IO executor 上。 */
+    private fun publishOnIoThread() {
+        stopOnIoThread()
+        if (Shaft.sSettings?.isLogFileEnabled == true) {
+            maybeStartOnIoThread()
+        }
+    }
+
+    private fun stopOnIoThread() {
+        val t = tree ?: return
+        tree = null
+        runCatching { Timber.uproot(t) }
+        t.close()
+    }
+
+    /** 当前日志文件所在文件夹，如 `Shaft/Logs`；未启用/打开完成前为 null。 */
+    fun currentFolderPath(): String? = tree?.currentFolderPath
+
+    /** 致命崩溃专用：同步写盘并 flush，不等 IO executor，避免进程被杀前丢失。 */
+    fun logCrashNow(threadName: String, throwable: Throwable) {
+        tree?.writeCrashNow(threadName, throwable)
+    }
+
+    /**
+     * 分享日志文件。
+     * 第一次分享直接分享当前文件；本进程周期内已分享过时，用项目弹窗质询：
+     *  - 分享新生成的日志；
+     *  - 合并历史分享与新生成再分享。
+     * 不扫描 SAF 目录，依赖 [lifetimeUris] 内存记录，避免 SAF 下耗时阻塞。
+     */
+    fun shareLogFile(context: Context) {
+        val all = synchronized(lifetimeUris) { lifetimeUris.toList() }
+        val unshared = all.drop(lastSharedCount)
+        if (unshared.isEmpty()) {
+            toastShareFailed(context)
+            return
+        }
+        if (all.any { it.scheme != "content" }) {
+            toastShareFailed(context)
+            return
+        }
+        val allSizeBefore = synchronized(lifetimeUris) { lifetimeUris.size }
+        if (lastSharedCount > 0) {
+            WitDialog.MenuDialogBuilder(context)
+                .setTitle(context.getString(R.string.setting_log_file_share_history_title))
+                .addItems(
+                    arrayOf(
+                        context.getString(R.string.setting_log_file_share_since_last),
+                        context.getString(R.string.setting_log_file_share_all)
+                    )
+                ) { dialog, which ->
+                    dialog.dismiss()
+                    // 点击弹窗选项后，才在 IO 线程触发 onFinish 发布，并合并/读取文件。
+                    shareFilesOnIo(context, if (which == 0) unshared else all, allSizeBefore)
+                }
+                .show()
+        } else {
+            shareFilesOnIo(context, unshared, allSizeBefore)
+        }
+    }
+
+    private fun shareFilesOnIo(context: Context, uris: List<Uri>, allSizeBefore: Int) {
+        ioExecutor.execute {
+            publishOnIoThread()
+            lastSharedCount = allSizeBefore
+
+            val shareUri = if (uris.size > 1) {
+                mergeToSingleFile(context, uris)
+            } else {
+                uris.singleOrNull()
+            }
+            mainHandler.post {
+                if (shareUri == null || shareUri.scheme != "content") {
+                    toastShareFailed(context)
+                    return@post
+                }
+                val send = Intent(Intent.ACTION_SEND).apply {
+                    type = "text/plain"
+                    putExtra(Intent.EXTRA_STREAM, shareUri)
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                }
+                try {
+                    context.startActivity(
+                        Intent.createChooser(
+                            send,
+                            context.getString(R.string.setting_log_file_share)
+                        )
+                    )
+                } catch (e: Exception) {
+                    toastShareFailed(context)
+                }
+            }
+        }
+    }
+
+    /** 把多个日志文件内容合并成一个临时 txt，返回 FileProvider content:// Uri。 */
+    private fun mergeToSingleFile(context: Context, uris: List<Uri>): Uri? {
+        return try {
+            val base = context.externalCacheDir ?: return null
+            val dir = File(base, "logs").apply { mkdirs() }
+            val stamp = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+            val file = File(dir, "timber_merged_$stamp.txt")
+            file.bufferedWriter(Charsets.UTF_8).use { out ->
+                uris.forEachIndexed { index, uri ->
+                    context.contentResolver.openInputStream(uri)?.use { input ->
+                        if (index > 0) {
+                            out.write("\n\n===== next log =====\n\n")
+                        }
+                        input.bufferedReader(Charsets.UTF_8).use { it.copyTo(out) }
+                    }
+                }
+            }
+            FileProvider.getUriForFile(context, context.packageName + ".provider", file)
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun toastShareFailed(context: Context) {
+        Toaster.show(context.getString(R.string.setting_log_file_share_failed))
+    }
+
+    /** 由 [TimberFileTree.log] 调用：把格式化好的日志行投递到 IO 线程写入。 */
+    fun enqueueLog(tree: TimberFileTree, line: String) {
+        ioExecutor.execute {
+            tree.writeLine(line)
+        }
+    }
+}
+
+/**
+ * 实际的 [Timber.Tree]：打开 `Bucket.Log` 桶的一个新文件并持续写入。
+ * 构造（打开文件）与 [writeLine] / [close] 都运行在 [TimberFileLog] 的 IO executor 上。
+ */
+class TimberFileTree : Timber.Tree() {
+
+    private val writer: PrintWriter?
+    private val handle: StorageBackend.WriteHandle?
+    private val relPath: RelativePath?
+    private val startRealtime = SystemClock.elapsedRealtime()
+
+    /** 当前日志文件所在文件夹（如 `Shaft/Logs`）；打开失败为 null。 */
+    val currentFolderPath: String? get() = relPath?.directory?.joinToString("/")
+
+    init {
+        var h: StorageBackend.WriteHandle? = null
+        var p: RelativePath? = null
+        var w: PrintWriter? = null
+        try {
+            val config = DownloadsRegistry.store.loadOrFallback()
+            val resolved = config.resolve(Bucket.Log)
+            val meta = ItemMeta(
+                id = 0L,
+                title = "log",
+                author = Author(0L, ""),
+                createdAt = Instant.now(),
+            )
+            p = FsSanitizer.clean(
+                SafeTemplateRender.render(
+                    resolved.template,
+                    Bucket.Log,
+                    meta,
+                    "txt",
+                    config.pageNumbering,
+                )
+            )
+            h = DownloadsRegistry.downloads.openRaw(
+                Bucket.Log,
+                p,
+                "text/plain",
+                OverwritePolicy.Replace,
+            ) ?: error("openRaw returned null")
+            w = PrintWriter(OutputStreamWriter(h.stream, Charsets.UTF_8), true)
+        } catch (t: Throwable) {
+            runCatching { h?.onAbort() }
+            h = null
+            p = null
+            w = null
+        }
+        handle = h
+        relPath = p
+        writer = w
+        if (w != null) {
+            TimberFileLog.register(h!!.uri)
+            log(Log.INFO, "TimberFileLog", "log file=${p!!.joinTo()}", null)
+        }
+    }
+
+    override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+        val sb = StringBuilder()
+        val ms = SystemClock.elapsedRealtime() - startRealtime
+        sb.append(
+            String.format(
+                Locale.US,
+                "[%8dms][%s][%c]",
+                ms,
+                Thread.currentThread().name,
+                priorityChar(priority)
+            )
+        )
+        if (!tag.isNullOrEmpty()) {
+            sb.append('[').append(tag).append(']')
+        }
+        // Timber 已在 prepareLog 阶段把 throwable 栈拼进 message，这里不要再重复追加。
+        sb.append(' ').append(message)
+        TimberFileLog.enqueueLog(this, sb.toString())
+    }
+
+    /** 在 IO 线程写入一行。与崩溃同步写共用同一把锁，避免并发交错。 */
+    fun writeLine(line: String) {
+        val w = writer ?: return
+        synchronized(w) {
+            runCatching { w.println(line) }
+        }
+    }
+
+    /** 崩溃专用：在任意线程直接同步写盘并 flush，避免进程被杀前异步任务丢失。 */
+    fun writeCrashNow(threadName: String, throwable: Throwable) {
+        val w = writer ?: return
+        val ms = SystemClock.elapsedRealtime() - startRealtime
+        val sb = StringBuilder()
+        sb.append(
+            String.format(
+                Locale.US,
+                "[%8dms][%s][FATAL] %s",
+                ms,
+                threadName,
+                Log.getStackTraceString(throwable),
+            )
+        )
+        synchronized(w) {
+            runCatching {
+                w.println(sb)
+                w.flush()
+            }
+        }
+    }
+
+    fun close() {
+        val w = writer ?: return
+        runCatching { w.flush() }
+        runCatching { w.close() }
+        val h = handle
+        if (h != null) {
+            runCatching { h.onFinish() }
+        }
+    }
+
+    private fun priorityChar(priority: Int): Char = when (priority) {
+        Log.VERBOSE -> 'V'
+        Log.DEBUG -> 'D'
+        Log.INFO -> 'I'
+        Log.WARN -> 'W'
+        Log.ERROR -> 'E'
+        Log.ASSERT -> 'A'
+        else -> '?'
+    }
+}

--- a/app/src/main/java/ceui/pixiv/download/Downloads.kt
+++ b/app/src/main/java/ceui/pixiv/download/Downloads.kt
@@ -108,12 +108,18 @@ class Downloads(
      * bypass template rendering. New code should prefer [plan] / [open] via a
      * typed [DownloadItem].
      */
-    fun openRaw(bucket: Bucket, rawPath: RelativePath, mime: String): StorageBackend.WriteHandle? {
+    fun openRaw(
+        bucket: Bucket,
+        rawPath: RelativePath,
+        mime: String,
+        overwrite: OverwritePolicy? = null,
+    ): StorageBackend.WriteHandle? {
         require(bucket != Bucket.TempCache) { "openRaw is not intended for TempCache" }
         val resolved = configProvider().resolve(bucket)
         val cleaned = FsSanitizer.clean(rawPath)
         val backend = backendFactory(resolved.storage)
-        val (finalPath, skip) = applyOverwritePolicy(cleaned, backend, resolved.overwrite, mime)
+        val policy = overwrite ?: resolved.overwrite
+        val (finalPath, skip) = applyOverwritePolicy(cleaned, backend, policy, mime)
         if (skip) return null
         return if (resolved.overwrite == OverwritePolicy.Replace) {
             backend.replace(finalPath, mime)

--- a/app/src/main/java/ceui/pixiv/download/template/TemplateSamples.kt
+++ b/app/src/main/java/ceui/pixiv/download/template/TemplateSamples.kt
@@ -70,6 +70,14 @@ object TemplateSamples {
         createdAt = CREATED,
     )
 
+    /** 日志桶：`{title}` 固定为 `log`，文件名主要靠 `{created}` 生成。 */
+    val LOG_SAMPLE = ItemMeta(
+        id = 0L,
+        title = "log",
+        author = Author(0L, ""),
+        createdAt = CREATED,
+    )
+
     private val DEFAULT_EXT: Map<Bucket, String> = mapOf(
         Bucket.Illust      to "jpg",
         Bucket.Ugoira      to "gif",
@@ -86,6 +94,7 @@ object TemplateSamples {
         Bucket.NovelSeries -> NOVEL_SERIES_SAMPLE
         Bucket.Ugoira -> UGOIRA_SAMPLE
         Bucket.Backup -> BACKUP_SAMPLE
+        Bucket.Log -> LOG_SAMPLE
         else -> ILLUST_SAMPLE
     }
 

--- a/app/src/main/java/ceui/pixiv/download/template/TemplateValidator.kt
+++ b/app/src/main/java/ceui/pixiv/download/template/TemplateValidator.kt
@@ -98,7 +98,22 @@ object TemplateValidator {
             }
             return
         }
-        val needsExtension = bucket != Bucket.Novel && bucket != Bucket.Log
+        if (bucket == Bucket.Log) {
+            if (source.contains("{ext}")) {
+                issues += Issue(
+                    Severity.Error,
+                    "Log template must not contain {ext} — log files are always .txt",
+                )
+            }
+            if (!source.endsWith(".txt")) {
+                issues += Issue(
+                    Severity.Error,
+                    "Log template must end with .txt",
+                )
+            }
+            return
+        }
+        val needsExtension = bucket != Bucket.Novel
         if (needsExtension && !source.contains("{ext}") && !source.matches(Regex(".*\\.[A-Za-z0-9]+$"))) {
             issues += Issue(
                 Severity.Warning,

--- a/app/src/main/res/layout/fragment_settings_experimental.xml
+++ b/app/src/main/res/layout/fragment_settings_experimental.xml
@@ -171,7 +171,7 @@
                         android:contentDescription="@string/setting_log_file_share"
                         android:focusable="true"
                         android:src="@drawable/ic_share_black_24dp"
-                        android:tint="@color/v3_text_1" />
+                        app:tint="@color/v3_text_1" />
 
                     <androidx.appcompat.widget.SwitchCompat
                         android:id="@+id/log_file_enable"

--- a/app/src/main/res/layout/fragment_settings_experimental.xml
+++ b/app/src/main/res/layout/fragment_settings_experimental.xml
@@ -141,6 +141,64 @@
                 </RelativeLayout>
 
                 <RelativeLayout
+                    android:id="@+id/log_file_enable_rela"
+                    style="@style/M3SetRow"
+                    android:layout_marginTop="14dp"
+                    android:background="@drawable/wit_row_single">
+
+                    <LinearLayout
+                        style="@style/M3SetTexts"
+                        android:layout_marginEnd="96dp">
+
+                        <TextView
+                            style="@style/M3SetTitle"
+                            android:text="@string/setting_log_file_enable" />
+
+                        <TextView
+                            android:id="@+id/log_file_path"
+                            style="@style/M3SetDesc"
+                            android:text="@string/setting_log_file_no_file" />
+                    </LinearLayout>
+
+                    <ImageView
+                        android:id="@+id/log_file_share"
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:layout_centerVertical="true"
+                        android:layout_marginEnd="12dp"
+                        android:layout_toStartOf="@id/log_file_enable"
+                        android:clickable="true"
+                        android:contentDescription="@string/setting_log_file_share"
+                        android:focusable="true"
+                        android:src="@drawable/ic_share_black_24dp"
+                        android:tint="@color/v3_text_1" />
+
+                    <androidx.appcompat.widget.SwitchCompat
+                        android:id="@+id/log_file_enable"
+                        style="@style/M3SetSwitch" />
+
+                </RelativeLayout>
+
+                <RelativeLayout
+                    android:id="@+id/trigger_crash_rela"
+                    style="@style/M3SetRow"
+                    android:layout_marginTop="14dp"
+                    android:background="@drawable/wit_row_single">
+
+                    <LinearLayout style="@style/M3SetTexts">
+
+                        <TextView
+                            style="@style/M3SetTitle"
+                            android:text="@string/setting_trigger_crash" />
+
+                        <TextView
+                            style="@style/M3SetDesc"
+                            android:text="@string/setting_trigger_crash_desc" />
+                    </LinearLayout>
+
+                </RelativeLayout>
+
+                <RelativeLayout
                     android:id="@+id/is_firebase_enable_rela"
                     style="@style/M3SetRow"
                     android:layout_marginTop="14dp"

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -2869,6 +2869,18 @@
     <!-- Auto snapshot (experimental) -->
     <string name="setting_auto_snapshot_on_bookmark">Create offline snapshot on bookmark</string>
     <string name="setting_auto_snapshot_on_bookmark_desc">Quietly create a lightweight offline snapshot after you bookmark a work (experimental)</string>
+
+    <!-- Log file (experimental) -->
+    <string name="setting_log_file_enable">Enable log file</string>
+    <string name="setting_log_file_desc">May affect performance\nLog file at %1$s</string>
+    <string name="setting_log_file_no_file">Not generated yet</string>
+    <string name="setting_log_file_share">Share log file</string>
+    <string name="setting_log_file_share_history_title">There are previously shared log files</string>
+    <string name="setting_log_file_share_since_last">Share newly generated logs</string>
+    <string name="setting_log_file_share_all">Merge previously shared and newly generated logs</string>
+    <string name="setting_trigger_crash">Trigger a fatal error</string>
+    <string name="setting_trigger_crash_desc">Crashes immediately to verify crash log capture</string>
+    <string name="setting_log_file_share_failed">Failed to share log file</string>
     <string name="snapshot_auto_badge">Auto</string>
     <string name="snapshot_promote">Convert to regular snapshot</string>
     <string name="snapshot_promote_title">Convert to Regular Snapshot</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -2852,6 +2852,18 @@
     <!-- 自動スナップショット（試験的） -->
     <string name="setting_auto_snapshot_on_bookmark">ブックマーク時にオフラインスナップショットを作成</string>
     <string name="setting_auto_snapshot_on_bookmark_desc">作品をブックマークした後、バックグラウンドで軽量なオフラインスナップショットを静かに作成します（試験的）</string>
+
+    <!-- ログファイル（試験的） -->
+    <string name="setting_log_file_enable">ログファイルを有効にする</string>
+    <string name="setting_log_file_desc">パフォーマンスに影響する可能性があります\nログファイル: %1$s</string>
+    <string name="setting_log_file_no_file">未生成</string>
+    <string name="setting_log_file_share">ログファイルを共有</string>
+    <string name="setting_log_file_share_history_title">過去に共有したログファイルがあります</string>
+    <string name="setting_log_file_share_since_last">新しく生成されたログを共有</string>
+    <string name="setting_log_file_share_all">過去に共有したログと新しく生成されたログをまとめて共有</string>
+    <string name="setting_log_file_share_failed">ログファイルの共有に失敗しました</string>
+    <string name="setting_trigger_crash">致命的なエラーを発生させる</string>
+    <string name="setting_trigger_crash_desc">クリックすると即座にクラッシュします（クラッシュログの記録を確認するため）</string>
     <string name="snapshot_auto_badge">自動</string>
     <string name="snapshot_promote">正式スナップショットに変換</string>
     <string name="snapshot_promote_title">正式スナップショットに変換</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -2852,6 +2852,18 @@
     <!-- 자동 스냅샷 (실험 기능) -->
     <string name="setting_auto_snapshot_on_bookmark">북마크 시 오프라인 스냅샷 생성</string>
     <string name="setting_auto_snapshot_on_bookmark_desc">작품을 북마크한 후 백그라운드에서 가벼운 오프라인 스냅샷을 자동 생성합니다 (실험 기능)</string>
+
+    <!-- 로그 파일 (실험) -->
+    <string name="setting_log_file_enable">로그 파일 사용</string>
+    <string name="setting_log_file_desc">성능에 영향을 줄 수 있음\n로그 파일 위치: %1$s</string>
+    <string name="setting_log_file_no_file">아직 생성되지 않음</string>
+    <string name="setting_log_file_share">로그 파일 공유</string>
+    <string name="setting_log_file_share_history_title">이전에 공유한 로그 파일이 있습니다</string>
+    <string name="setting_log_file_share_since_last">새로 생성된 로그 공유</string>
+    <string name="setting_log_file_share_all">이전에 공유한 로그와 새로 생성된 로그를 합쳐서 공유</string>
+    <string name="setting_log_file_share_failed">로그 파일 공유 실패</string>
+    <string name="setting_trigger_crash">치명적인 오류 발생시키기</string>
+    <string name="setting_trigger_crash_desc">클릭하면 즉시 크래시됩니다(크래시 로그 기록 확인용)</string>
     <string name="snapshot_auto_badge">자동</string>
     <string name="snapshot_promote">일반 스냅샷으로 전환</string>
     <string name="snapshot_promote_title">일반 스냅샷으로 전환</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -2852,6 +2852,18 @@
     <!-- Автоматический снимок (экспериментально) -->
     <string name="setting_auto_snapshot_on_bookmark">Создавать офлайн-снимок при добавлении в закладки</string>
     <string name="setting_auto_snapshot_on_bookmark_desc">Тихо создавать лёгкий офлайн-снимок после добавления работы в закладки (экспериментально)</string>
+
+    <!-- Файл журнала (экспериментально) -->
+    <string name="setting_log_file_enable">Включить файл журнала</string>
+    <string name="setting_log_file_desc">Может повлиять на производительность\nФайл журнала: %1$s</string>
+    <string name="setting_log_file_no_file">Ещё не создан</string>
+    <string name="setting_log_file_share">Поделиться файлом журнала</string>
+    <string name="setting_log_file_share_history_title">Есть ранее опубликованные файлы журнала</string>
+    <string name="setting_log_file_share_since_last">Поделиться новыми журналами</string>
+    <string name="setting_log_file_share_all">Объединить ранее опубликованные и новые журналы</string>
+    <string name="setting_log_file_share_failed">Не удалось поделиться файлом журнала</string>
+    <string name="setting_trigger_crash">Вызвать фатальную ошибку</string>
+    <string name="setting_trigger_crash_desc">Немедленно вызывает сбой (для проверки записи журнала сбоев)</string>
     <string name="snapshot_auto_badge">Авто</string>
     <string name="snapshot_promote">Преобразовать в обычный снимок</string>
     <string name="snapshot_promote_title">Преобразовать в обычный снимок</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -2852,6 +2852,18 @@
     <!-- Otomatik anlık görüntü (deneysel) -->
     <string name="setting_auto_snapshot_on_bookmark">Yer imine eklendiğinde çevrimdışı anlık görüntü oluştur</string>
     <string name="setting_auto_snapshot_on_bookmark_desc">Bir eseri yer imine ekledikten sonra arka planda sessizce hafif bir çevrimdışı anlık görüntü oluşturur (deneysel)</string>
+
+    <!-- Günlük dosyası (deneysel) -->
+    <string name="setting_log_file_enable">Günlük dosyasını etkinleştir</string>
+    <string name="setting_log_file_desc">Performansı etkileyebilir\nGünlük dosyası: %1$s</string>
+    <string name="setting_log_file_no_file">Henüz oluşturulmadı</string>
+    <string name="setting_log_file_share">Günlük dosyasını paylaş</string>
+    <string name="setting_log_file_share_history_title">Daha önce paylaşılmış günlük dosyaları var</string>
+    <string name="setting_log_file_share_since_last">Yeni oluşturulan günlükleri paylaş</string>
+    <string name="setting_log_file_share_all">Daha önce paylaşılan ve yeni oluşturulan günlükleri birleştir</string>
+    <string name="setting_log_file_share_failed">Günlük dosyası paylaşılamadı</string>
+    <string name="setting_trigger_crash">Ölümcül bir hata tetikle</string>
+    <string name="setting_trigger_crash_desc">Tıklanınca hemen çöker (çökme günlüğü kaydını doğrulamak için)</string>
     <string name="snapshot_auto_badge">Otomatik</string>
     <string name="snapshot_promote">Normal anlık görüntüye dönüştür</string>
     <string name="snapshot_promote_title">Normal Anlık Görüntüye Dönüştür</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -2868,6 +2868,18 @@
     <!-- 自動快照（實驗性） -->
     <string name="setting_auto_snapshot_on_bookmark">收藏時產生離線快照</string>
     <string name="setting_auto_snapshot_on_bookmark_desc">收藏作品後在背景靜默產生一份輕量離線快照（實驗性）</string>
+
+    <!-- 日誌檔案（實驗性） -->
+    <string name="setting_log_file_enable">啟用日誌檔案</string>
+    <string name="setting_log_file_desc">可能影響效能\n日誌檔案在%1$s</string>
+    <string name="setting_log_file_no_file">尚未產生</string>
+    <string name="setting_log_file_share">分享日誌檔案</string>
+    <string name="setting_log_file_share_history_title">有歷史分享過的日誌檔案</string>
+    <string name="setting_log_file_share_since_last">分享新產生的日誌</string>
+    <string name="setting_log_file_share_all">合併歷史分享與新產生再分享</string>
+    <string name="setting_trigger_crash">觸發一次致命錯誤</string>
+    <string name="setting_trigger_crash_desc">點擊後立即崩潰，用於驗證崩潰日誌落盤</string>
+    <string name="setting_log_file_share_failed">分享日誌檔案失敗</string>
     <string name="snapshot_auto_badge">自動</string>
     <string name="snapshot_promote">轉為正式快照</string>
     <string name="snapshot_promote_title">轉為正式快照</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3126,6 +3126,18 @@
     <!-- 自动快照（试验性） -->
     <string name="setting_auto_snapshot_on_bookmark">收藏时生成离线快照</string>
     <string name="setting_auto_snapshot_on_bookmark_desc">收藏作品后在后台静默生成一份轻量离线快照（试验性）</string>
+
+    <!-- 日志文件（试验性） -->
+    <string name="setting_log_file_enable">启用日志文件</string>
+    <string name="setting_log_file_desc">可能影响性能\n日志文件在%1$s</string>
+    <string name="setting_log_file_no_file">尚未生成</string>
+    <string name="setting_log_file_share">分享日志文件</string>
+    <string name="setting_log_file_share_history_title">有历史分享过的日志文件</string>
+    <string name="setting_log_file_share_since_last">分享新生成的日志</string>
+    <string name="setting_log_file_share_all">合并历史分享与新生成再分享</string>
+    <string name="setting_trigger_crash">引发一次致命错误</string>
+    <string name="setting_trigger_crash_desc">点击后立即崩溃，用于验证崩溃日志落盘</string>
+    <string name="setting_log_file_share_failed">分享日志文件失败</string>
     <string name="snapshot_auto_badge">自动</string>
     <string name="snapshot_promote">转为正式快照</string>
     <string name="snapshot_promote_title">转为正式快照</string>

--- a/app/src/test/java/ceui/pixiv/download/TemplateValidatorTest.kt
+++ b/app/src/test/java/ceui/pixiv/download/TemplateValidatorTest.kt
@@ -65,6 +65,24 @@ class TemplateValidatorTest {
         assertTrue(r.errors.any { it.message.contains("{ext}") })
     }
 
+    @Test fun `log bucket accepts txt extension`() {
+        val r = TemplateValidator.validate("Shaft/Logs/{created:yyyyMMdd_HHmmss}.txt", Bucket.Log)
+        assertTrue(r.ok)
+        assertTrue(r.errors.isEmpty())
+    }
+
+    @Test fun `log bucket rejects non txt extension`() {
+        val r = TemplateValidator.validate("Shaft/Logs/{created:yyyyMMdd_HHmmss}.log", Bucket.Log)
+        assertFalse(r.ok)
+        assertTrue(r.errors.any { it.message.contains(".txt") })
+    }
+
+    @Test fun `log bucket rejects ext variable`() {
+        val r = TemplateValidator.validate("Shaft/Logs/{created:yyyyMMdd_HHmmss}.{ext}", Bucket.Log)
+        assertFalse(r.ok)
+        assertTrue(r.errors.any { it.message.contains("{ext}") })
+    }
+
     /**
      * 复现 bug 的入口：`[?p<100:…]` 能编译（被当成名为 `p<100` 的 flag），
      * 旧校验只编译不渲染 → 放行保存 → 下载时崩。现在保存校验也渲染样本，


### PR DESCRIPTION
# 试验性日志文件：Timber 落盘到“日志文件”桶，支持分享与崩溃捕获

> 分支：`patch-9-5`（wangwang-code fork）
> 目标：`classic`
> 最新提交：`d252d080f`

## 背景

项目“下载路径”里很早就有「日志文件」桶，但一直没有真正的日志写入。本次把它变真：新增一个试验性开关，让 Timber 日志按日志桶配置的模板落盘，并提供分享、崩溃栈捕获能力。

## 改动内容

### 1. Timber 文件日志（新增 `TimberFileLog.kt`）
- `TimberFileTree`：一个 `Timber.Tree`，把 `Timber.*` 日志写入 `Bucket.Log` 桶；
- 文件名遵循日志桶模板（默认 `Shaft/Logs/{created:yyyyMMdd_HHmmss}.txt`），冲突时强制覆盖，不跟随全局覆盖策略；
- 所有日志文件操作（打开/写入/关闭/合并）都在单线程 IO executor 上执行，避免主线程卡顿；
- 崩溃专用同步 `logCrashNow`：不经过异步队列，直接写盘并 flush，确保崩溃栈能落盘。

### 2. 试验性设置
- 新增「启用日志文件」开关：
  - 小字展示日志文件所在文件夹；
  - 开关左侧分享图标：直接分享日志文件；
  - 多文件分享时先合并成一个临时 `.txt` 再分享（部分应用不接受多文件）；
  - 同一进程内多次分享会弹窗选择「分享新生成的日志」或「合并历史分享与新生成再分享」；
  - 切换开关 toast 复用 `please_restart_app`，重启生效。
- 新增 debug-only「引发一次致命错误」：无限递归触发 `StackOverflowError`，用于验证崩溃日志落盘。

### 3. 崩溃捕获
- `Shaft.onCreate` 最前面包一层 `Thread.UncaughtExceptionHandler`：
  - 先同步把致命崩溃栈写入日志文件；
  - 再交回系统默认 handler 照常崩溃。

### 4. 模板/配置
- `Downloads.openRaw` 新增可选 `overwrite` 参数，支持调用方强制覆盖；
- `TemplateValidator` 新增日志桶校验：不允许 `{ext}`、必须以 `.txt` 结尾；
- `TemplateSamples` 新增 `LOG_SAMPLE`，设置页预览/校验按日志语义渲染；
- `TemplateValidatorTest` 新增日志桶校验用例。

### 5. 多语言
- 新增字符串补齐 `values` / `values-en` / `values-zh-rTW` / `values-ja` / `values-ko` / `values-ru` / `values-tr` 共 7 份。

## 涉及文件

- `app/src/main/java/ceui/lisa/activities/Shaft.java`
- `app/src/main/java/ceui/lisa/fragments/FragmentSettingsExperimental.java`
- `app/src/main/java/ceui/lisa/fragments/SettingsCatalog.kt`
- `app/src/main/java/ceui/lisa/utils/Settings.java`
- `app/src/main/java/ceui/pixiv/debug/TimberFileLog.kt`（新增）
- `app/src/main/java/ceui/pixiv/download/Downloads.kt`
- `app/src/main/java/ceui/pixiv/download/template/TemplateSamples.kt`
- `app/src/main/java/ceui/pixiv/download/template/TemplateValidator.kt`
- `app/src/main/res/layout/fragment_settings_experimental.xml`
- `app/src/main/res/values*/strings.xml`
- `app/src/test/java/ceui/pixiv/download/TemplateValidatorTest.kt`

## 注意 / 限制

### TimberFileLog 不能记录的内容
- 系统/框架直接写入 logcat 的日志，例如：
  - GC（ART/dalvikvm）
  - HWUI / OpenGLRenderer 过载
  - Choreographer「Skipped N frames」
- native 崩溃（SIGSEGV / SIGABRT 等信号），不会走 Java `Thread.UncaughtExceptionHandler`
- 系统默认 `FATAL EXCEPTION` 崩溃栈（只有应用代码显式 `Timber.e(t)` 才会被记录）
- 文件日志 Tree 尚未启动完成（启动极早期）之前的 Timber 日志

- 试验性功能，默认关闭；开关切换需重启生效。
- 日志桶存储为 MediaStore 时，进程异常被杀且未触发 onFinish 的日志文件可能停留在 pending 状态；正常分享时会发布。
- 崩溃包装只捕获 Java 未捕获异常（含 `Error`），不捕获 native 信号类崩溃。
- 「引发一次致命错误」仅 debug 包可见，避免 release 误触。

## 提交

- `d252d080f` feat(debug): 日志文件桶落盘 Timber 日志（试验性开关/分享/崩溃捕获）
