### PR TITLE
修复导航栏「上次关闭位置」冷启动不生效：切 tab 即时持久化到 MMKV（#1092）

### DIFF
--- a/app/src/main/java/ceui/lisa/activities/MainActivity.java
+++ b/app/src/main/java/ceui/lisa/activities/MainActivity.java
@@ -416,8 +416,11 @@ public class MainActivity extends BaseActivity<ActivityCoverBinding> implements 
         });
         baseBind.viewPager.setOffscreenPageLimit(baseFragments.length - 1);
         final int navigationInitPosition = getNavigationInitPosition();
-        // 启动恢复即视为“已持久化”，避免 setCurrentItem 触发 onPageSelected 后重复写同一值。
-        lastPersistedNavigationPosition = navigationInitPosition;
+        // 去重水位必须来自真实落盘值，不能直接假定本次启动页已经保存。否则用户从固定
+        // 启动页切到「上次位置」且期间没再换 TAB 时，MMKV 仍会保留更早的旧位置。
+        lastPersistedNavigationPosition = Shaft.getMMKV().getInt(
+                Params.MAIN_ACTIVITY_NAVIGATION_POSITION, -1);
+        persistNavigationPosition(navigationInitPosition);
         baseBind.viewPager.setCurrentItem(navigationInitPosition);
         Manager.get().restore();
 
@@ -920,7 +923,11 @@ public class MainActivity extends BaseActivity<ActivityCoverBinding> implements 
     protected void onStop() {
         super.onStop();
         // 退后台/划掉任务时兜底落盘；onPageSelected 已处理过的大部分场景这里会被去重跳过。
-        persistNavigationPosition(baseBind.viewPager.getCurrentItem());
+        // 未登录跳登录页、或旧系统还在申请存储权限时 adapter 尚未初始化，不能用默认的 0
+        // 覆盖上一次真实位置。
+        if (baseBind.viewPager.getAdapter() != null) {
+            persistNavigationPosition(baseBind.viewPager.getCurrentItem());
+        }
     }
 
     @Override

--- a/app/src/main/java/ceui/lisa/activities/MainActivity.java
+++ b/app/src/main/java/ceui/lisa/activities/MainActivity.java
@@ -89,6 +89,8 @@ public class MainActivity extends BaseActivity<ActivityCoverBinding> implements 
     // 与 baseFragments 一一对应的底部菜单 item id;TAB 顺序可配置后,
     // id 和位置的关系不再固定,所有 id<->position 换算都查这张表
     private int[] tabMenuIds = null;
+    /** 最近一次已持久化的底部导航位置；用于去重，避免同一位置反复写 MMKV。 */
+    private int lastPersistedNavigationPosition = -1;
 
     /**
      * 开屏动画安全兜底超时：万一首页推荐插画 tab 没能按预期跑到（异常 / 未来改了默认
@@ -255,6 +257,8 @@ public class MainActivity extends BaseActivity<ActivityCoverBinding> implements 
                 }
                 // 换 tab 必须把底栏放回来:收起状态下滑到别的 tab,否则没底栏可点。
                 bottomBarAutoHide.reveal();
+                // 即时持久化当前 tab：进程在任意时刻被杀，下次冷启动都能恢复。
+                persistNavigationPosition(position);
             }
 
             @Override
@@ -411,7 +415,10 @@ public class MainActivity extends BaseActivity<ActivityCoverBinding> implements 
             }
         });
         baseBind.viewPager.setOffscreenPageLimit(baseFragments.length - 1);
-        baseBind.viewPager.setCurrentItem(getNavigationInitPosition());
+        final int navigationInitPosition = getNavigationInitPosition();
+        // 启动恢复即视为“已持久化”，避免 setCurrentItem 触发 onPageSelected 后重复写同一值。
+        lastPersistedNavigationPosition = navigationInitPosition;
+        baseBind.viewPager.setCurrentItem(navigationInitPosition);
         Manager.get().restore();
 
         // Show rate dialog after a short delay to avoid disrupting app startup.
@@ -910,6 +917,13 @@ public class MainActivity extends BaseActivity<ActivityCoverBinding> implements 
     }
 
     @Override
+    protected void onStop() {
+        super.onStop();
+        // 退后台/划掉任务时兜底落盘；onPageSelected 已处理过的大部分场景这里会被去重跳过。
+        persistNavigationPosition(baseBind.viewPager.getCurrentItem());
+    }
+
+    @Override
     protected void onDestroy() {
         super.onDestroy();
         LocalBroadcastManager.getInstance(this).unregisterReceiver(profileReadyReceiver);
@@ -917,9 +931,16 @@ public class MainActivity extends BaseActivity<ActivityCoverBinding> implements 
 
     @Override
     public void finish() {
-        int currentPosition = baseBind.viewPager.getCurrentItem();
-        Shaft.getMMKV().putInt(Params.MAIN_ACTIVITY_NAVIGATION_POSITION, currentPosition);
+        persistNavigationPosition(baseBind.viewPager.getCurrentItem());
         super.finish();
+    }
+
+    private void persistNavigationPosition(int position) {
+        if (position == lastPersistedNavigationPosition) {
+            return;
+        }
+        Shaft.getMMKV().putInt(Params.MAIN_ACTIVITY_NAVIGATION_POSITION, position);
+        lastPersistedNavigationPosition = position;
     }
 
     private int getNavigationInitPosition() {


### PR DESCRIPTION
# 修复导航栏「上次关闭位置」冷启动不生效：切 tab 即时持久化到 MMKV（#1092）

> 分支：`patch-9-5-1`（wangwang-code fork；本地 remote 名为 `my`）
> 目标：`classic`
> 提交：`59f3b5fe` fix(navigation): 上次关闭位置冷启动恢复按切 tab 即时持久化 (#1092)

## 背景

issue #1092：设置「导航栏初始化位置 = 上次关闭位置」后，冷启动 / 重新打开 App 仍会落在「推荐」页，表现为“重新打开只会是推荐”。

## 根因

- 启动时 `MainActivity.getNavigationInitPosition()` 只有在设置值为 `LATEST` 时，才从 MMKV 读取 `MAIN_ACTIVITY_NAVIGATION_POSITION`；
- 但这个 key 原先**只在 `MainActivity.finish()` 里写入**；
- 冷启动通常来自最近任务划掉、进程被系统回收、或退后台后被杀，这些路径**不会调用 `finish()`**；
- 因此 MMKV 里一直保留默认值 `0`，冷启动自然回到「推荐」。

## 改动内容

只修改 `MainActivity.java`，按“即时但不狂写”的最优解落地：

### 1. 切 tab 即时写入

- 在 `ViewPager.onPageSelected` 中调用 `persistNavigationPosition(position)`；
- 只有用户真正切换到底部 tab 时才写 MMKV，不监听 `onPageScrolled` / `onPageScrollStateChanged`，避免拖动、惯性滑动导致狂写。

### 2. 退后台兜底写入

- 新增 `onStop()`，离开前台 / 划掉任务 / 退后台时再落盘一次；
- 由于 `onPageSelected` 通常已经写过，这里会被去重逻辑跳过，不会产生额外写入。

### 3. 去重，避免同值重复写

- 新增 `lastPersistedNavigationPosition` 字段；
- `persistNavigationPosition()` 只在位置与上次已持久化位置不同时写 MMKV；
- `finish()` 也统一走该方法，保留显式退出保存行为。

### 4. 启动时初始化去重水位

- `setCurrentItem()` 前先把 `lastPersistedNavigationPosition` 设为本次恢复位置；
- 避免冷启动恢复非 0 tab 时，`setCurrentItem` 触发的 `onPageSelected` 再次写同一个值。

## 效果

- 用户切到任意 tab 后，进程无论何时被杀，下次冷启动都能恢复到“上次所在位置”；
- 写入频率 = 每次真正切 tab + 每次退后台有变化时兜底，同值自动跳过；
- 仍使用原 MMKV key，兼容旧数据与旧逻辑。

## 涉及文件

- `app/src/main/java/ceui/lisa/activities/MainActivity.java`

## 可增强（本次不做）

当前持久化的仍是裸 ViewPager 下标（`getCurrentItem()`）。虽然对本次 issue 已足够，但底部栏顺序可配置（`bottom_bar_order_rela`），R18 / “我” tab 也可动态显隐，冷启动恢复时同一个下标可能映射到不同的逻辑 tab。

后续可改为存储**稳定 tab 标识**而不是裸 index，例如：

- 保存 `tabMenuIds[position]`（`R.id.action_1` / `action_2` / ...）；
- 冷启动时再映射回当前 `baseFragments` 的下标。

这样即使底部栏顺序 / tab 显隐变化，也能恢复到同一个逻辑页。本次不扩大改动面，留作后续增强。
