### PR TITLE
默认小说下载格式“每次询问”全流程生效，统一 ExportSheet 质询

### DIFF
--- a/app/src/main/java/ceui/pixiv/ui/bulk/NovelBulkSelectV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/bulk/NovelBulkSelectV3Fragment.kt
@@ -13,6 +13,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -21,8 +22,13 @@ import ceui.lisa.utils.GlideUtil
 import ceui.lisa.utils.Params
 import ceui.loxia.Novel
 import ceui.pixiv.actions.PixivActions
+import ceui.pixiv.chat.base.viewModels
 import ceui.pixiv.ui.common.tintMenuIconsWhite
 import ceui.pixiv.ui.detail.showV3Menu
+import ceui.pixiv.ui.novel.reader.export.ExportFormat
+import ceui.pixiv.ui.novel.reader.export.NovelExportManager
+import ceui.pixiv.ui.novel.reader.ui.ExportFormatCallback
+import ceui.pixiv.ui.novel.reader.ui.ExportSheet
 import ceui.pixiv.ui.task.BatchDownloadNovelsTask
 import ceui.pixiv.ui.task.FailedNovel
 import ceui.pixiv.witstudio.dialog.WitDialog
@@ -36,6 +42,11 @@ import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+
+/** 小说批量下载的待确认选中列表，跨旋转保留在 Fragment ViewModel 中。 */
+class NovelBulkDownloadRequestViewModel : ViewModel() {
+    var pendingNovels: List<Novel>? = null
+}
 
 /**
  * V3 风格小说批量操作 · 多选页（issue #974）。
@@ -61,7 +72,7 @@ import kotlinx.coroutines.withContext
  *  - 首段（filled）= 下载选中小说。**不 finish 本页**，见 [startDownload]
  *  - 尾段（tonal）= 批量收藏 / 批量取消收藏，走 [PixivActions] 门面 → `:actionqueue` 队列
  */
-class NovelBulkSelectV3Fragment : Fragment() {
+class NovelBulkSelectV3Fragment : Fragment(), ExportFormatCallback {
 
     companion object {
         /** [handoffKey] 是入口 put 进 [NovelBulkSelectHandoff] 时拿到的 key；null / 过期时本页显示「没有可选项」。 */
@@ -75,6 +86,8 @@ class NovelBulkSelectV3Fragment : Fragment() {
     private var source: List<Novel> = emptyList()
 
     private val items = mutableListOf<SelectableNovel>()
+
+    private val novelDownloadRequest by viewModels { NovelBulkDownloadRequestViewModel() }
 
     /**
      * 封面的 Glide 请求管理器，建一次复用。**别在 bind 里 `Glide.with(view)`** ——
@@ -230,11 +243,29 @@ class NovelBulkSelectV3Fragment : Fragment() {
         if (downloadRunning) return
         val picked = selectedNovels()
         if (picked.isEmpty()) return
+        val format = NovelExportManager.resolveConfiguredFormat()
+        if (format != null) {
+            startDownload(picked, format)
+        } else {
+            novelDownloadRequest.pendingNovels = picked
+            ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        }
+    }
+
+    override fun onExportFormatChosen(format: ExportFormat) {
+        val picked = novelDownloadRequest.pendingNovels ?: return
+        novelDownloadRequest.pendingNovels = null
+        startDownload(picked, format)
+    }
+
+    private fun startDownload(picked: List<Novel>, format: ExportFormat) {
+        if (downloadRunning) return
         downloadRunning = true
         btnConfirm.isEnabled = false
         BatchDownloadNovelsTask(
             activity = requireActivity(),
             novels = picked,
+            format = format,
             onFinished = { failures -> onDownloadFinished(failures) },
         )
     }

--- a/app/src/main/java/ceui/pixiv/ui/common/NovelCardMenu.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/NovelCardMenu.kt
@@ -13,7 +13,6 @@ import ceui.pixiv.services.requireEntityWrapper
 import ceui.pixiv.ui.bulk.BulkSelectHandoff
 import ceui.pixiv.ui.bulk.NovelBulkSelectHandoff
 import ceui.pixiv.ui.detail.showV3Menu
-import ceui.pixiv.ui.task.BatchDownloadNovelsTask
 import ceui.pixiv.ui.navigation.TemplateRoute
 
 /**
@@ -109,21 +108,7 @@ internal fun NovelFeedFragment.showNovelCardMenu(
         // 下载这一篇：复用批量/系列下载同一条落盘链路（BatchDownloadNovelsTask），
         // 不灌 download_queue——小说下载本来就不走那张表。
         item(getString(R.string.string_339), R.drawable.ic_file_download_black_24dp) {
-            BatchDownloadNovelsTask(
-                activity = requireActivity(),
-                novels = listOf(novel),
-                onFinished = { failures ->
-                    if (isAdded) {
-                        Common.showToast(
-                            if (failures.isEmpty()) {
-                                getString(R.string.batch_download_all_ok)
-                            } else {
-                                getString(R.string.batch_download_some_failed, failures.size)
-                            }
-                        )
-                    }
-                },
-            )
+            startNovelDownload(novel)
         }
         val watchLaterLabel = getString(
             if (inWatchLater) R.string.watch_later_remove else R.string.watch_later_add

--- a/app/src/main/java/ceui/pixiv/ui/common/NovelFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/NovelFeedFragment.kt
@@ -10,6 +10,7 @@ import android.widget.ImageView
 import androidx.annotation.LayoutRes
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
+import androidx.lifecycle.ViewModel
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewbinding.ViewBinding
 import ceui.lisa.R
@@ -25,6 +26,7 @@ import ceui.pixiv.witstudio.theme.V3Palette
 import ceui.pixiv.api.Client
 import ceui.loxia.Novel
 import ceui.pixiv.actions.PixivActions
+import ceui.pixiv.chat.base.viewModels
 import ceui.pixiv.feeds.FeedCell
 import ceui.pixiv.feeds.FeedFragment
 import ceui.pixiv.feeds.FeedItem
@@ -34,7 +36,12 @@ import ceui.pixiv.feeds.FeedSkeletonView
 import ceui.pixiv.feeds.FeedViewModel
 import ceui.pixiv.feeds.feedRenderer
 import ceui.pixiv.ui.novel.NovelSeriesFragment
+import ceui.pixiv.ui.novel.reader.export.ExportFormat
+import ceui.pixiv.ui.novel.reader.export.NovelExportManager
+import ceui.pixiv.ui.novel.reader.ui.ExportFormatCallback
+import ceui.pixiv.ui.novel.reader.ui.ExportSheet
 import ceui.pixiv.ui.recommend.bindTrendingScore
+import ceui.pixiv.ui.task.BatchDownloadNovelsTask
 import ceui.pixiv.utils.playLikePressHaptic
 import ceui.pixiv.utils.pinHostGlide
 import ceui.pixiv.utils.ppppx
@@ -64,6 +71,11 @@ private data class NovelImageRequestKey(
 private const val NOVEL_SPOILER_BLUR_RADIUS = 25
 private const val NOVEL_SPOILER_BLUR_SAMPLING = 3
 
+/** 小说列表页“下载这一篇”的待确认请求，跨旋转保留在 Fragment ViewModel 中。 */
+class NovelDownloadRequestViewModel : ViewModel() {
+    var pendingNovel: Novel? = null
+}
+
 /**
  * 小说列表页的共享基类（对齐插画侧 [IllustFeedFragment]）。子类只声明数据源
  *（feedViewModels + mapper 产出 [NovelFeedItem]）；本类统一提供主力小说卡（recy_novel）：
@@ -84,9 +96,50 @@ private const val NOVEL_SPOILER_BLUR_SAMPLING = 3
  */
 abstract class NovelFeedFragment(
     @LayoutRes contentLayoutId: Int = ceui.pixiv.feeds.R.layout.fragment_feed,
-) : FeedFragment(contentLayoutId) {
+) : FeedFragment(contentLayoutId), ExportFormatCallback {
 
     abstract override val feedViewModel: FeedViewModel<String>
+
+    private val novelDownloadRequest by viewModels { NovelDownloadRequestViewModel() }
+
+    /**
+     * 小说卡“下载这一篇”：有默认格式直接下，设置为“每次询问”时弹 [ExportSheet]。
+     * 请求放在 Fragment ViewModel 中，旋转后由新实例的 [onExportFormatChosen] 继续执行。
+     */
+    fun startNovelDownload(novel: Novel) {
+        val format = NovelExportManager.resolveConfiguredFormat()
+        if (format != null) {
+            startNovelDownload(novel, format)
+        } else {
+            novelDownloadRequest.pendingNovel = novel
+            ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        }
+    }
+
+    override fun onExportFormatChosen(format: ExportFormat) {
+        val novel = novelDownloadRequest.pendingNovel ?: return
+        novelDownloadRequest.pendingNovel = null
+        startNovelDownload(novel, format)
+    }
+
+    private fun startNovelDownload(novel: Novel, format: ExportFormat) {
+        BatchDownloadNovelsTask(
+            activity = requireActivity(),
+            novels = listOf(novel),
+            format = format,
+            onFinished = { failures ->
+                if (isAdded) {
+                    Common.showToast(
+                        if (failures.isEmpty()) {
+                            getString(R.string.batch_download_all_ok)
+                        } else {
+                            getString(R.string.batch_download_some_failed, failures.size)
+                        }
+                    )
+                }
+            },
+        )
+    }
 
     /**
      * 封面 / 头像的 Glide 请求管理器，建一次复用（对齐插画侧 [IllustFeedFragment.illustGlide]）。

--- a/app/src/main/java/ceui/pixiv/ui/common/NovelFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/NovelFeedFragment.kt
@@ -70,6 +70,7 @@ private data class NovelImageRequestKey(
 
 private const val NOVEL_SPOILER_BLUR_RADIUS = 25
 private const val NOVEL_SPOILER_BLUR_SAMPLING = 3
+private const val NOVEL_CARD_EXPORT_TAG = "NovelCardExportSheet"
 
 /** 小说列表页“下载这一篇”的待确认请求，跨旋转保留在 Fragment ViewModel 中。 */
 class NovelDownloadRequestViewModel : ViewModel() {
@@ -112,11 +113,24 @@ abstract class NovelFeedFragment(
             startNovelDownload(novel, format)
         } else {
             novelDownloadRequest.pendingNovel = novel
-            ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+            ExportSheet().show(childFragmentManager, NOVEL_CARD_EXPORT_TAG)
         }
     }
 
     override fun onExportFormatChosen(format: ExportFormat) {
+        finishNovelCardDownload(format)
+    }
+
+    final override fun onExportFormatChosen(format: ExportFormat, sourceTag: String?) {
+        if (sourceTag == NOVEL_CARD_EXPORT_TAG) {
+            // NovelTextFragment 同时展示相关推荐卡；不能让它的详情导出回调吞掉卡片请求。
+            finishNovelCardDownload(format)
+        } else {
+            onExportFormatChosen(format)
+        }
+    }
+
+    private fun finishNovelCardDownload(format: ExportFormat) {
         val novel = novelDownloadRequest.pendingNovel ?: return
         novelDownloadRequest.pendingNovel = null
         startNovelDownload(novel, format)

--- a/app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFragment.kt
@@ -16,6 +16,7 @@ import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.RecyclerView
@@ -24,6 +25,7 @@ import ceui.lisa.R
 import ceui.lisa.databinding.ItemBigReadButtonBinding
 import ceui.pixiv.witstudio.theme.V3Palette
 import ceui.pixiv.api.Client
+import ceui.pixiv.chat.base.viewModels as directViewModel
 import ceui.loxia.Novel
 import ceui.pixiv.api.model.NovelSeriesResp
 import ceui.pixiv.widgets.ProgressIndicator
@@ -42,6 +44,7 @@ import ceui.pixiv.ui.detail.seriesAuthorRenderer
 import ceui.pixiv.ui.detail.seriesCaptionRenderer
 import ceui.pixiv.ui.detail.seriesSectionLabelRenderer
 import ceui.pixiv.ui.novel.reader.export.ExportFormat
+import ceui.pixiv.ui.novel.reader.export.NovelExportManager
 import ceui.pixiv.ui.novel.reader.ui.ExportFormatCallback
 import ceui.pixiv.ui.novel.reader.ui.ExportSheet
 import ceui.pixiv.ui.task.BatchDownloadNovelsTask
@@ -58,6 +61,17 @@ import ceui.pixiv.witstudio.dialog.WitDialog
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicBoolean
+
+/** 系列下载的待确认动作，跨旋转保留在 Fragment ViewModel 中。 */
+class NovelSeriesDownloadRequestViewModel : ViewModel() {
+    var pendingAction: PendingAction? = null
+
+    enum class PendingAction {
+        MERGE,
+        BATCH_SELECTED,
+        DOWNLOAD_ALL,
+    }
+}
 
 /**
  * 小说系列 V3 详情页（feeds 框架版）。hero + 作者 + 档案 + 简介 + 「作品列表」标题 + 章节卡。
@@ -81,6 +95,8 @@ class NovelSeriesFragment :
     }
 
     private val selectionModel by viewModels<NovelSeriesSelectionViewModel>()
+
+    private val novelDownloadRequest by directViewModel { NovelSeriesDownloadRequestViewModel() }
 
     private var singleDownloadBtn: View? = null
     private var multiSelectBar: View? = null
@@ -242,23 +258,42 @@ class NovelSeriesFragment :
     private fun heroDetail() = feedViewModel.uiState.value.items
         .filterIsInstance<NovelSeriesHeroFeedItem>().firstOrNull()?.series
 
-    /**
-     * 合并下载：只负责弹格式选择，真正的动作在 [onExportFormatChosen] 里按当时的 VM 状态重建。
-     *
-     * 刻意**不**把动作攒成一个 `pendingMergeAction` 闭包挂在 Fragment 字段上：[ExportSheet] 是
-     * DialogFragment，旋转 / 切深色会重建宿主 Fragment，而对话框由 FragmentManager 自动恢复并
-     * 回调到**新**实例上——旧实例的字段连同闭包一起没了，用户选完格式点确定会静默无反应。
-     * 合并要用的数据（系列详情、已加载章节）全都住在比 view 长命的 VM 里，现取即可。
-     */
     private fun launchMergeDownload() {
         if (heroDetail() == null) {
             Toaster.show(getString(R.string.merge_download_failed_empty))
             return
         }
-        ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        val format = NovelExportManager.resolveConfiguredFormat()
+        if (format != null) {
+            startMergeDownload(format)
+        } else {
+            novelDownloadRequest.pendingAction = NovelSeriesDownloadRequestViewModel.PendingAction.MERGE
+            ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        }
     }
 
     override fun onExportFormatChosen(format: ExportFormat) {
+        val action = novelDownloadRequest.pendingAction
+        novelDownloadRequest.pendingAction = null
+        when (action) {
+            NovelSeriesDownloadRequestViewModel.PendingAction.BATCH_SELECTED -> {
+                val novels = selectedNovels()
+                val ordered = loadedNovels().distinctBy { it.id }
+                if (novels.isNotEmpty()) {
+                    startBatchDownloadSelected(novels, ordered, format)
+                }
+            }
+            NovelSeriesDownloadRequestViewModel.PendingAction.DOWNLOAD_ALL -> {
+                launchDownloadAll(format)
+            }
+            NovelSeriesDownloadRequestViewModel.PendingAction.MERGE -> {
+                startMergeDownload(format)
+            }
+            null -> Unit
+        }
+    }
+
+    private fun startMergeDownload(format: ExportFormat) {
         val detail = heroDetail()
         if (detail == null) {
             Toaster.show(getString(R.string.merge_download_failed_empty))
@@ -306,9 +341,20 @@ class NovelSeriesFragment :
         // 系列位置按已加载的完整章节序列算，不能按选中子集的下标算——
         // 勾选第 3、5、9 章时，文件名 / 信息头里要的是 3、5、9 而不是 1、2、3。
         val ordered = loadedNovels().distinctBy { it.id }
+        val format = NovelExportManager.resolveConfiguredFormat()
+        if (format != null) {
+            startBatchDownloadSelected(novels, ordered, format)
+        } else {
+            novelDownloadRequest.pendingAction = NovelSeriesDownloadRequestViewModel.PendingAction.BATCH_SELECTED
+            ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        }
+    }
+
+    private fun startBatchDownloadSelected(novels: List<Novel>, ordered: List<Novel>, format: ExportFormat) {
         BatchDownloadNovelsTask(
             activity = requireActivity(),
             novels = novels,
+            format = format,
             onFinished = { failures -> onBatchDownloadFinished(failures) },
             seriesPositions = seriesPositionsOf(ordered),
             seriesTotal = seriesTotalCount(loadedCount = ordered.size),
@@ -350,6 +396,16 @@ class NovelSeriesFragment :
     }
 
     private fun launchDownloadAll() {
+        val format = NovelExportManager.resolveConfiguredFormat()
+        if (format != null) {
+            launchDownloadAll(format)
+        } else {
+            novelDownloadRequest.pendingAction = NovelSeriesDownloadRequestViewModel.PendingAction.DOWNLOAD_ALL
+            ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        }
+    }
+
+    private fun launchDownloadAll(format: ExportFormat) {
         object : FetchAllTask<Novel, NovelSeriesResp>(
             requireActivity(),
             taskFullName = "下载系列小说全部作品-${seriesId}",
@@ -367,6 +423,7 @@ class NovelSeriesFragment :
                 BatchDownloadNovelsTask(
                     activity = requireActivity(),
                     novels = results,
+                    format = format,
                     onFinished = { failures -> onBatchDownloadFinished(failures) },
                     seriesPositions = seriesPositionsOf(ordered),
                     seriesTotal = ordered.size,

--- a/app/src/main/java/ceui/pixiv/ui/novel/NovelTextFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/NovelTextFragment.kt
@@ -251,8 +251,7 @@ class NovelTextFragment :
     }
 
     override fun onClickDownloadNovel(sender: View, novelId: Long) {
-        val defaultFormat = Shaft.sSettings.defaultNovelExportFormat
-        val format = ExportFormat.entries.firstOrNull { it.name == defaultFormat }
+        val format = NovelExportManager.resolveConfiguredFormat()
         if (format != null) executeExport(format) else showExportSheet()
     }
 

--- a/app/src/main/java/ceui/pixiv/ui/novel/reader/NovelReaderV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/reader/NovelReaderV3Fragment.kt
@@ -41,6 +41,7 @@ import ceui.pixiv.ui.detail.showV3Menu
 import ceui.pixiv.ui.novel.reader.model.PageGeometry
 import ceui.pixiv.ui.novel.reader.export.ExportFormat
 import ceui.pixiv.ui.novel.reader.export.ExportResult
+import ceui.pixiv.ui.novel.reader.export.NovelExportManager
 import ceui.pixiv.ui.novel.reader.model.HighlightColor
 import ceui.pixiv.ui.novel.reader.model.HighlightSpan
 import ceui.pixiv.ui.novel.reader.model.SearchHit
@@ -799,8 +800,7 @@ class NovelReaderV3Fragment : Fragment(R.layout.fragment_novel_reader_v3),
                     Toaster.showShort(getString(R.string.msg_novel_not_ready))
                     return@item
                 }
-                val defaultFormat = Shaft.sSettings.defaultNovelExportFormat
-                val format = ExportFormat.entries.firstOrNull { it.name == defaultFormat }
+                val format = NovelExportManager.resolveConfiguredFormat()
                 if (format != null) {
                     executeExport(format)
                 } else {

--- a/app/src/main/java/ceui/pixiv/ui/novel/reader/export/NovelExportManager.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/reader/export/NovelExportManager.kt
@@ -33,12 +33,24 @@ object NovelExportManager {
         ExportFormat.Pdf to PdfExporter(),
     )
 
+    /**
+     * 解析「默认小说下载格式」设置。
+     *
+     * @return 非空 = 直接使用该格式；null = 设置为「每次询问」，调用方应弹格式选择。
+     */
+    fun resolveConfiguredFormat(): ExportFormat? {
+        val name = Shaft.sSettings.defaultNovelExportFormat
+        return if (name.isNullOrBlank()) null else ExportFormat.entries.firstOrNull { it.name == name }
+    }
+
     suspend fun export(
         context: Context,
         format: ExportFormat,
         novel: Novel?,
         webNovel: WebNovel,
         tokens: List<ContentToken>,
+        seriesOrder: Int? = null,
+        seriesTotal: Int? = null,
     ): ExportResult = withContext(Dispatchers.IO) {
         val destination: RelativePath = if (novel != null) {
             DownloadItems.novelDestinationFromLoxia(
@@ -46,7 +58,9 @@ object NovelExportManager {
                 extOverride = format.extension,
                 // 序号取「系列可见列表位置」（SeriesCache，reader 场景通常已缓存），
                 // 让单篇下载 / 导出和系列批量下载渲染出同一个文件名（issue #964）。
-                seriesOrder = seriesOrderOf(novel),
+                // 批量/系列下载调用方可直接传 seriesOrder/seriesTotal 覆盖缓存查询。
+                seriesOrder = seriesOrder ?: seriesOrderOf(novel),
+                seriesTotal = seriesTotal,
             )
         } else {
             // No Novel — only the web payload. Best-effort meta;

--- a/app/src/main/java/ceui/pixiv/ui/novel/reader/ui/ExportSheet.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/reader/ui/ExportSheet.kt
@@ -14,6 +14,11 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 interface ExportFormatCallback {
     fun onExportFormatChosen(format: ExportFormat)
+
+    /** FragmentManager 会恢复 tag，宿主可据此区分详情导出和列表卡片下载。 */
+    fun onExportFormatChosen(format: ExportFormat, sourceTag: String?) {
+        onExportFormatChosen(format)
+    }
 }
 
 class ExportSheet : BottomSheetDialogFragment() {
@@ -37,7 +42,7 @@ class ExportSheet : BottomSheetDialogFragment() {
         )
         binding.list.layoutManager = LinearLayoutManager(requireContext())
         binding.list.adapter = Adapter(rows) { format ->
-            (parentFragment as? ExportFormatCallback)?.onExportFormatChosen(format)
+            (parentFragment as? ExportFormatCallback)?.onExportFormatChosen(format, tag)
             dismissAllowingStateLoss()
         }
         return binding.root

--- a/app/src/main/java/ceui/pixiv/ui/task/BatchDownloadNovelsTask.kt
+++ b/app/src/main/java/ceui/pixiv/ui/task/BatchDownloadNovelsTask.kt
@@ -13,6 +13,10 @@ import ceui.pixiv.ui.common.getTxtFileIdInDownloads
 import ceui.pixiv.ui.common.saveToDownloadsScopedStorage
 import ceui.pixiv.download.config.DownloadItems
 import ceui.pixiv.download.model.RelativePath
+import ceui.pixiv.ui.novel.reader.export.ExportFormat
+import ceui.pixiv.ui.novel.reader.export.ExportResult
+import ceui.pixiv.ui.novel.reader.export.NovelExportManager
+import ceui.pixiv.ui.novel.reader.paginate.ContentParser
 import com.hjq.toast.Toaster
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -43,6 +47,7 @@ data class FailedNovel(
 class BatchDownloadNovelsTask(
     private val activity: FragmentActivity,
     private val novels: List<Novel>,
+    private val format: ExportFormat,
     private val onProgress: (done: Int, total: Int) -> Unit = { _, _ -> },
     private val onFinished: (failures: List<FailedNovel>) -> Unit,
     /**
@@ -109,6 +114,7 @@ class BatchDownloadNovelsTask(
         val total = seriesTotal.takeIf { seriesIndex != null }
         val destination: RelativePath = DownloadItems.novelDestinationFromLoxia(
             novel,
+            extOverride = format.extension,
             seriesOrder = seriesIndex,
             seriesTotal = total,
         )
@@ -116,7 +122,7 @@ class BatchDownloadNovelsTask(
 
         // Skip already-downloaded files. DownloadNovelTask uses the same
         // pre-check before it hits the network.
-        if (getTxtFileIdInDownloads(ctx, fileName) != null) {
+        if (format == ExportFormat.Txt && getTxtFileIdInDownloads(ctx, fileName) != null) {
             Timber.d("$fileName already exists, skipping")
             return
         }
@@ -124,6 +130,24 @@ class BatchDownloadNovelsTask(
         val html = Client.appApi.getNovelText(novel.id).string()
         val wNovel = WebNovelParser.parsePixivObject(html)?.novel
             ?: throw RuntimeException("invalid web novel")
+
+        // 非 TXT 格式直接复用阅读器导出链路，避免在批量下载里再维护一套 MD/EPUB/PDF 实现。
+        if (format != ExportFormat.Txt) {
+            val tokens = ContentParser.tokenize(wNovel)
+            when (val result = NovelExportManager.export(
+                context = ctx,
+                format = format,
+                novel = novel,
+                webNovel = wNovel,
+                tokens = tokens,
+                seriesOrder = seriesIndex,
+                seriesTotal = total,
+            )) {
+                is ExportResult.Success -> Unit
+                is ExportResult.Failure -> throw RuntimeException(result.message)
+            }
+            return
+        }
 
         val buffer = StringBuffer().apply {
             append("\n\n")

--- a/app/src/main/java/ceui/pixiv/ui/task/NovelAutoDownload.kt
+++ b/app/src/main/java/ceui/pixiv/ui/task/NovelAutoDownload.kt
@@ -114,9 +114,12 @@ object NovelAutoDownload {
                 NovelTextCache.put(novel.id, it)
             }
         }
+        // 自动下载是收藏的副作用，没有交互入口可「每次询问」：
+        // 显式配置了默认格式就用它，否则回退 TXT，避免静默跳过自动下载。
+        val format = NovelExportManager.resolveConfiguredFormat() ?: ExportFormat.Txt
         when (val result = NovelExportManager.export(
             context = context,
-            format = ExportFormat.Txt,
+            format = format,
             novel = novel,
             webNovel = entry.webNovel,
             tokens = entry.tokens,

--- a/app/src/main/java/ceui/pixiv/ui/user/UserNovelSeriesFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/user/UserNovelSeriesFeedFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.ViewModel
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewbinding.ViewBinding
 import ceui.lisa.R
@@ -13,6 +14,7 @@ import ceui.lisa.activities.TemplateActivity
 import ceui.lisa.databinding.FragmentToolbarFeedBinding
 import ceui.lisa.databinding.RecyNovelSeriesOfUserBinding
 import ceui.pixiv.api.Client
+import ceui.pixiv.chat.base.viewModels
 import ceui.lisa.model.ListNovelSeries
 import ceui.lisa.models.NovelSeriesItem
 import ceui.lisa.utils.Common
@@ -31,6 +33,7 @@ import ceui.pixiv.ui.common.viewBinding
 import ceui.pixiv.ui.novel.CrossSeriesDownloadOptionsSheet
 import ceui.pixiv.ui.novel.NovelSeriesFragment
 import ceui.pixiv.ui.novel.reader.export.ExportFormat
+import ceui.pixiv.ui.novel.reader.export.NovelExportManager
 import ceui.pixiv.ui.novel.reader.ui.ExportFormatCallback
 import ceui.pixiv.ui.novel.reader.ui.ExportSheet
 import ceui.pixiv.ui.task.CrossSeriesDownloadTask
@@ -40,6 +43,12 @@ import ceui.pixiv.witstudio.dialog.WitDialog
 import ceui.pixiv.witstudio.dialog.WitDialogAction
 import kotlin.math.floor
 import ceui.pixiv.ui.navigation.TemplateRoute
+
+/** 跨系列下载的待确认请求，跨旋转保留在 Fragment ViewModel 中。 */
+class CrossSeriesDownloadRequestViewModel : ViewModel() {
+    var pendingSeriesList: List<NovelSeriesItem>? = null
+    var mergeAll: Boolean = false
+}
 
 /**
  * 某作者「小说系列」总览页（feeds 框架版，替代 legacy [ceui.lisa.fragments.FragmentNovelSeries] +
@@ -55,12 +64,15 @@ import ceui.pixiv.ui.navigation.TemplateRoute
  *   - 选择下载：多选系列，每个系列各自合并为独立文件；
  *   - 全部下载：全部系列，每个各自合并为独立文件；
  *   - 合并下载：全部系列合并为唯一一个文件。
- * 选完模式再弹 [ExportSheet] 选输出格式（TXT/MD/PDF/EPUB），回调走 [CrossSeriesDownloadTask]。
+ * 选完模式后按「默认小说下载格式」直接执行或弹格式选择（TXT/MD/PDF/EPUB），
+ * 回调走 [CrossSeriesDownloadTask]。
  * 该流程只依赖 [allItems]（当前列表快照）/ activity / childFragmentManager / isAdded，与 legacy 等价。
  */
 class UserNovelSeriesFeedFragment : FeedFragment(), ExportFormatCallback {
 
     private val binding by viewBinding(FragmentToolbarFeedBinding::bind)
+
+    private val novelDownloadRequest by viewModels { CrossSeriesDownloadRequestViewModel() }
 
     /**
      * 两种形态,对齐 [UserNovelFeedFragment]:
@@ -217,16 +229,16 @@ class UserNovelSeriesFeedFragment : FeedFragment(), ExportFormatCallback {
         builder.create().show()
     }
 
-    /**
-     * 用户在 [CrossSeriesDownloadOptionsSheet] 选完模式后，再弹 [ExportSheet] 选输出格式。
-     * 把"要做什么"暂存到 [pendingMergeAction]，等 sheet 回调 [onExportFormatChosen] 拿到 format 再真正启动 task。
-     */
-    private var pendingMergeAction: ((ExportFormat) -> Unit)? = null
-
     private fun runPerSeries(seriesList: List<NovelSeriesItem>) {
         if (!isAdded) return
-        pendingMergeAction = { format -> startPerSeries(seriesList, format) }
-        ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        val format = NovelExportManager.resolveConfiguredFormat()
+        if (format != null) {
+            startPerSeries(seriesList, format)
+        } else {
+            novelDownloadRequest.pendingSeriesList = seriesList
+            novelDownloadRequest.mergeAll = false
+            ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        }
     }
 
     private fun runMergeAll() {
@@ -236,13 +248,26 @@ class UserNovelSeriesFeedFragment : FeedFragment(), ExportFormatCallback {
             return
         }
         if (!isAdded) return
-        pendingMergeAction = { format -> startMergeAll(list, format) }
-        ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        val format = NovelExportManager.resolveConfiguredFormat()
+        if (format != null) {
+            startMergeAll(list, format)
+        } else {
+            novelDownloadRequest.pendingSeriesList = list
+            novelDownloadRequest.mergeAll = true
+            ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        }
     }
 
     override fun onExportFormatChosen(format: ExportFormat) {
-        pendingMergeAction?.invoke(format)
-        pendingMergeAction = null
+        val seriesList = novelDownloadRequest.pendingSeriesList
+        val mergeAll = novelDownloadRequest.mergeAll
+        novelDownloadRequest.pendingSeriesList = null
+        novelDownloadRequest.mergeAll = false
+        if (mergeAll) {
+            startMergeAll(seriesList ?: allItems(), format)
+        } else if (seriesList != null) {
+            startPerSeries(seriesList, format)
+        }
     }
 
     private fun startPerSeries(seriesList: List<NovelSeriesItem>, format: ExportFormat) {

--- a/app/src/test/java/ceui/pixiv/ui/common/NovelExportRoutingTest.kt
+++ b/app/src/test/java/ceui/pixiv/ui/common/NovelExportRoutingTest.kt
@@ -1,0 +1,52 @@
+package ceui.pixiv.ui.common
+
+import android.app.Application
+import androidx.fragment.app.FragmentActivity
+import ceui.pixiv.feeds.FeedViewModel
+import ceui.pixiv.ui.novel.reader.export.ExportFormat
+import ceui.pixiv.ui.novel.reader.ui.ExportFormatCallback
+import ceui.pixiv.ui.novel.reader.ui.ExportSheet
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35], manifest = Config.NONE, application = Application::class)
+class NovelExportRoutingTest {
+    // Same inheritance as NovelTextFragment: a detail export overrides the list callback.
+    class DetailHost : NovelFeedFragment() {
+        override val feedViewModel: FeedViewModel<String> get() = error("No feed needed")
+        val detailExports = mutableListOf<ExportFormat>()
+        override fun onExportFormatChosen(format: ExportFormat) {
+            detailExports += format
+        }
+    }
+
+    @Test fun `card response must not fall through to the detail novel`() {
+        val controller = Robolectric.buildActivity(FragmentActivity::class.java).create()
+        val host = DetailHost()
+        controller.get().supportFragmentManager.beginTransaction().add(host, "detail").commitNow()
+        // A restored sheet without a pending request must be ignored, never export the detail.
+        (host as ExportFormatCallback).onExportFormatChosen(ExportFormat.Epub, "NovelCardExportSheet")
+        assertEquals(emptyList<ExportFormat>(), host.detailExports)
+        controller.destroy()
+    }
+
+    @Test fun `detail sheet still reaches the overridden detail export`() {
+        val host = DetailHost()
+        (host as ExportFormatCallback).onExportFormatChosen(ExportFormat.Txt, ExportSheet.TAG)
+        assertEquals(listOf(ExportFormat.Txt), host.detailExports)
+    }
+
+    @Test fun `existing sheet hosts retain their original callback`() {
+        val received = mutableListOf<ExportFormat>()
+        val host = object : ExportFormatCallback {
+            override fun onExportFormatChosen(format: ExportFormat) { received += format }
+        }
+        host.onExportFormatChosen(ExportFormat.Pdf, ExportSheet.TAG)
+        assertEquals(listOf(ExportFormat.Pdf), received)
+    }
+}


### PR DESCRIPTION
# 默认小说下载格式“每次询问”全流程生效，统一 ExportSheet 质询

> 分支：`patch-9-6`（wangwang-code fork）
> 目标：`classic`
> 最新提交：`28db26cde`

## 背景

“默认小说下载格式”设置为「每次询问」时，部分下载入口不会弹格式选择，而是直接以 TXT 保存。

## 根因

- 小说卡单篇下载、系列下载全部/勾选下载、小说多选批量下载走 `BatchDownloadNovelsTask`，该任务只写 TXT，且调用方没有读取默认格式设置；
- `NovelAutoDownload` 直接硬编码 `ExportFormat.Txt`；
- 因此「每次询问」在这些场景下被绕过，静默保存 TXT。

## 改动内容

### 1. 统一默认格式解析

- `NovelExportManager` 新增 `resolveConfiguredFormat()`：
  - 有默认格式 → 直接使用；
  - 空字符串（=每次询问）→ 返回 `null`，由调用方弹格式选择。
- 小说详情页 / 阅读器也改为复用该方法，删除重复的 `ExportFormat.entries.firstOrNull` 手写逻辑。

### 2. 批量/系列下载支持非 TXT

- `BatchDownloadNovelsTask` 增加 `format: ExportFormat` 参数，且设为必填，避免未来再次静默 TXT；
- 非 TXT 格式直接复用阅读器导出链路 `NovelExportManager.export`，支持 TXT / Markdown / EPUB / PDF；
- `NovelExportManager.export` 增加可选 `seriesOrder` / `seriesTotal`，保留系列批量下载的文件名/序号语义。

### 3. 全流程统一“每次询问”交互

以下入口在“每次询问”时统一弹出小说详情页同款 `ExportSheet` 底部弹层：

- 小说卡长按 → 下载这一篇
- 小说系列 → 下载全部（分开保存）
- 小说系列 → 勾选章节下载
- 小说系列 → 合并下载
- 跨系列 → 每系列合并 / 全部合并
- 小说多选页 → 下载选中

### 4. 旋转安全

- `ExportSheet` 保持原有 `parentFragment as? ExportFormatCallback` 回调，不跨旋转保存捕获 Fragment 的 lambda；
- 各宿主 Fragment 使用 Fragment ViewModel 保存待确认请求，旋转后由新 Fragment 实例继续执行下载；
- ViewModel 通过项目已有直接工厂 `viewModels { ... }` 创建，不依赖反射，R8 安全。

### 5. 自动下载

- `NovelAutoDownload` 有显式默认格式时使用默认格式；
- 设置为「每次询问」时回退 TXT（后台副作用无交互面，不静默中断自动下载）。

## 涉及文件

- `app/src/main/java/ceui/pixiv/ui/novel/reader/export/NovelExportManager.kt`
- `app/src/main/java/ceui/pixiv/ui/task/BatchDownloadNovelsTask.kt`
- `app/src/main/java/ceui/pixiv/ui/task/NovelAutoDownload.kt`
- `app/src/main/java/ceui/pixiv/ui/common/NovelFeedFragment.kt`
- `app/src/main/java/ceui/pixiv/ui/common/NovelCardMenu.kt`
- `app/src/main/java/ceui/pixiv/ui/bulk/NovelBulkSelectV3Fragment.kt`
- `app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFragment.kt`
- `app/src/main/java/ceui/pixiv/ui/user/UserNovelSeriesFeedFragment.kt`
- `app/src/main/java/ceui/pixiv/ui/novel/NovelTextFragment.kt`
- `app/src/main/java/ceui/pixiv/ui/novel/reader/NovelReaderV3Fragment.kt`

## 注意

- 自动下载是收藏的副作用，没有交互面可“每次询问”，因此空默认格式时回退 TXT；
- 若希望“每次询问”时自动下载也不落盘，需要另行决策，本次不扩大改动面。

## 提交

- `28db26cde` fix(novel): 默认小说下载格式全流程遵循“每次询问”
