### PR TITLE
修复批量操作页旋转后列表空态

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -219,6 +219,9 @@ android {
         viewBinding = true
         buildConfig = true // 启用 BuildConfig
     }
+    testOptions {
+        unitTests.includeAndroidResources = true
+    }
     packagingOptions {
         jniLibs {
             useLegacyPackaging = true

--- a/app/src/main/java/ceui/pixiv/ui/bulk/BulkSelectV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/bulk/BulkSelectV3Fragment.kt
@@ -13,6 +13,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -23,6 +24,7 @@ import ceui.lisa.utils.GlideUtil
 import ceui.lisa.utils.Params
 import ceui.pixiv.api.model.Illust
 import ceui.pixiv.actions.PixivActions
+import ceui.pixiv.chat.base.viewModels
 import ceui.pixiv.ui.common.tintMenuIconsWhite
 import ceui.pixiv.ui.detail.showV3Menu
 import ceui.pixiv.ui.download.DownloadExportLinks
@@ -36,6 +38,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import ceui.pixiv.ui.navigation.TemplateRoute
+
+/** 批量选择页的交接数据缓存，跨旋转保留，避免重复 take 导致列表空态。 */
+private class BulkSelectRequestViewModel : ViewModel() {
+    var source: List<Illust>? = null
+    var items: List<SelectableItem>? = null
+}
 
 /**
  * V3 风格批量操作 · 多选页。
@@ -64,6 +72,8 @@ class BulkSelectV3Fragment : Fragment() {
         }
     }
 
+    private val bulkViewModel by viewModels { BulkSelectRequestViewModel() }
+
     private val items = mutableListOf<SelectableItem>()
     private val adapter: BulkSelectAdapter by lazy {
         BulkSelectAdapter(items) { pos -> toggleAt(pos) }
@@ -81,6 +91,15 @@ class BulkSelectV3Fragment : Fragment() {
     private lateinit var hint: TextView
     private lateinit var btnConfirm: Button
     private lateinit var btnBookmarkActions: View
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (bulkViewModel.source == null) {
+            bulkViewModel.source = IllustBulkSelectHandoff.take(
+                arguments?.getString(BulkSelectHandoff.ARG_HANDOFF_KEY)
+            )
+        }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -127,7 +146,8 @@ class BulkSelectV3Fragment : Fragment() {
         grid.adapter = adapter
 
         // 取列表 —— 大列表（10000+）SelectableItem 构造也搬 IO 避免主线程长时间循环。
-        val raw = IllustBulkSelectHandoff.take(arguments?.getString(BulkSelectHandoff.ARG_HANDOFF_KEY))
+        // 只允许首次创建时 take；旋转重建从 ViewModel 恢复，避免重复 take 变成空态。
+        val raw = bulkViewModel.source
         if (raw.isNullOrEmpty()) {
             hint.text = getString(R.string.bulk_select_no_items)
             btnConfirm.isEnabled = false
@@ -141,18 +161,29 @@ class BulkSelectV3Fragment : Fragment() {
         hint.text = getString(R.string.bulk_select_loading)
         btnConfirm.isEnabled = false
         setBookmarkActionsEnabled(false)
-        viewLifecycleOwner.lifecycleScope.launch {
-            val prepared = withContext(Dispatchers.IO) {
-                raw.map { illust ->
-                    // ugoira 现在也走批量队列（独立 consumer 管线），不再 disable。
-                    // 默认不选（issue #922），用户点选要的，或 toolbar 一键全选。
-                    SelectableItem(illust, selected = false, selectable = true)
-                }
-            }
+
+        val restored = bulkViewModel.items
+        if (restored != null) {
             items.clear()
-            items.addAll(prepared)
+            items.addAll(restored)
+            bulkViewModel.items = items
             adapter.notifyDataSetChanged()
             refreshHeaderAndCta()
+        } else {
+            viewLifecycleOwner.lifecycleScope.launch {
+                val prepared = withContext(Dispatchers.IO) {
+                    raw.map { illust ->
+                        // ugoira 现在也走批量队列（独立 consumer 管线），不再 disable。
+                        // 默认不选（issue #922），用户点选要的，或 toolbar 一键全选。
+                        SelectableItem(illust, selected = false, selectable = true)
+                    }
+                }
+                items.clear()
+                items.addAll(prepared)
+                bulkViewModel.items = items
+                adapter.notifyDataSetChanged()
+                refreshHeaderAndCta()
+            }
         }
 
         btnConfirm.setOnClickListener {

--- a/app/src/main/java/ceui/pixiv/ui/bulk/NovelBulkSelectV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/bulk/NovelBulkSelectV3Fragment.kt
@@ -13,6 +13,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -21,6 +22,7 @@ import ceui.lisa.utils.GlideUtil
 import ceui.lisa.utils.Params
 import ceui.loxia.Novel
 import ceui.pixiv.actions.PixivActions
+import ceui.pixiv.chat.base.viewModels
 import ceui.pixiv.ui.common.tintMenuIconsWhite
 import ceui.pixiv.ui.detail.showV3Menu
 import ceui.pixiv.ui.task.BatchDownloadNovelsTask
@@ -36,6 +38,12 @@ import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+
+/** 小说批量选择页的交接数据缓存，跨旋转保留，避免重复 take 导致列表空态。 */
+private class NovelBulkSelectRequestViewModel : ViewModel() {
+    var source: List<Novel>? = null
+    var items: List<SelectableNovel>? = null
+}
 
 /**
  * V3 风格小说批量操作 · 多选页（issue #974）。
@@ -71,6 +79,8 @@ class NovelBulkSelectV3Fragment : Fragment() {
         }
     }
 
+    private val bulkViewModel by viewModels { NovelBulkSelectRequestViewModel() }
+
     /** 源列表。勾选结果靠下标换回这里的 [Novel]。 */
     private var source: List<Novel> = emptyList()
 
@@ -95,6 +105,15 @@ class NovelBulkSelectV3Fragment : Fragment() {
     private lateinit var hint: TextView
     private lateinit var btnConfirm: Button
     private lateinit var btnBookmarkActions: View
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (bulkViewModel.source == null) {
+            bulkViewModel.source = NovelBulkSelectHandoff.take(
+                arguments?.getString(BulkSelectHandoff.ARG_HANDOFF_KEY)
+            )
+        }
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -135,7 +154,8 @@ class NovelBulkSelectV3Fragment : Fragment() {
         list.layoutManager = LinearLayoutManager(requireContext())
         list.adapter = adapter
 
-        val raw = NovelBulkSelectHandoff.take(arguments?.getString(BulkSelectHandoff.ARG_HANDOFF_KEY))
+        // 只允许首次创建时 take；旋转重建从 ViewModel 恢复，避免重复 take 变成空态。
+        val raw = bulkViewModel.source
         if (raw.isNullOrEmpty()) {
             hint.text = getString(R.string.bulk_select_no_items)
             btnConfirm.isEnabled = false
@@ -149,46 +169,56 @@ class NovelBulkSelectV3Fragment : Fragment() {
         btnConfirm.isEnabled = false
         setBookmarkActionsEnabled(false)
 
-        // 大列表（上限 20000）的展示数据构造搬 IO，避免主线程长时间循环。
-        viewLifecycleOwner.lifecycleScope.launch {
-            // 必须用 Activity context 取字符串，**不能图省事换成 applicationContext**：
-            // 本 app 有应用内语言设置，Activity 的 Configuration 由
-            // BaseActivity.attachBaseContext 保证包成用户选的语言，而 Application 那份在
-            // 「切了语言、还没冷启」的窗口里会停留在系统 locale（见 AppLocales
-            // .applyConfigurationInPlace 的注释，那个方法存在就是为了补这个洞）。
-            // 协程挂在 viewLifecycleOwner 上，view 一销毁就取消，攥不住这个引用。
-            val ctx = requireContext()
-            // 数字分组也跟着同一份 Configuration 走，别用 Locale.getDefault() ——
-            // 那是 JVM 全局值，跟上面读字符串用的 locale 不保证是同一个。
-            val locale = ConfigurationCompat.getLocales(ctx.resources.configuration)[0]
-                ?: Locale.getDefault()
-            val prepared = withContext(Dispatchers.IO) {
-                val numbers = NumberFormat.getIntegerInstance(locale)
-                raw.mapIndexed { index, novel ->
-                    val words = ctx.getString(
-                        R.string.v3_novel_word_count, numbers.format(novel.text_length ?: 0)
-                    )
-                    SelectableNovel(
-                        index = index,
-                        coverUrl = novel.image_urls?.medium,
-                        title = novel.title.orEmpty(),
-                        author = novel.user?.name.orEmpty(),
-                        // 收藏态直接写在行里：批量收藏 / 取消收藏时，用户得先看得出
-                        // 哪些本来就已经收藏了，否则「实际入队 3 条」会显得莫名其妙。
-                        meta = if (novel.is_bookmarked == true) {
-                            ctx.getString(R.string.bulk_select_novel_meta_bookmarked, words)
-                        } else {
-                            words
-                        },
-                        // 默认全不选（同插画页，issue #922）：想要全部的走 toolbar 一键全选。
-                        selected = false,
-                    )
-                }
-            }
+        val restored = bulkViewModel.items
+        if (restored != null) {
             items.clear()
-            items.addAll(prepared)
+            items.addAll(restored)
+            bulkViewModel.items = items
             adapter.notifyDataSetChanged()
             refreshHeaderAndCta()
+        } else {
+            // 大列表（上限 20000）的展示数据构造搬 IO，避免主线程长时间循环。
+            viewLifecycleOwner.lifecycleScope.launch {
+                // 必须用 Activity context 取字符串，**不能图省事换成 applicationContext**：
+                // 本 app 有应用内语言设置，Activity 的 Configuration 由
+                // BaseActivity.attachBaseContext 保证包成用户选的语言，而 Application 那份在
+                // 「切了语言、还没冷启」的窗口里会停留在系统 locale（见 AppLocales
+                // .applyConfigurationInPlace 的注释，那个方法存在就是为了补这个洞）。
+                // 协程挂在 viewLifecycleOwner 上，view 一销毁就取消，攥不住这个引用。
+                val ctx = requireContext()
+                // 数字分组也跟着同一份 Configuration 走，别用 Locale.getDefault() ——
+                // 那是 JVM 全局值，跟上面读字符串用的 locale 不保证是同一个。
+                val locale = ConfigurationCompat.getLocales(ctx.resources.configuration)[0]
+                    ?: Locale.getDefault()
+                val prepared = withContext(Dispatchers.IO) {
+                    val numbers = NumberFormat.getIntegerInstance(locale)
+                    raw.mapIndexed { index, novel ->
+                        val words = ctx.getString(
+                            R.string.v3_novel_word_count, numbers.format(novel.text_length ?: 0)
+                        )
+                        SelectableNovel(
+                            index = index,
+                            coverUrl = novel.image_urls?.medium,
+                            title = novel.title.orEmpty(),
+                            author = novel.user?.name.orEmpty(),
+                            // 收藏态直接写在行里：批量收藏 / 取消收藏时，用户得先看得出
+                            // 哪些本来就已经收藏了，否则「实际入队 3 条」会显得莫名其妙。
+                            meta = if (novel.is_bookmarked == true) {
+                                ctx.getString(R.string.bulk_select_novel_meta_bookmarked, words)
+                            } else {
+                                words
+                            },
+                            // 默认全不选（同插画页，issue #922）：想要全部的走 toolbar 一键全选。
+                            selected = false,
+                        )
+                    }
+                }
+                items.clear()
+                items.addAll(prepared)
+                bulkViewModel.items = items
+                adapter.notifyDataSetChanged()
+                refreshHeaderAndCta()
+            }
         }
     }
 

--- a/app/src/main/java/ceui/pixiv/ui/bulk/NovelBulkSelectV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/bulk/NovelBulkSelectV3Fragment.kt
@@ -43,6 +43,7 @@ import kotlinx.coroutines.withContext
 private class NovelBulkSelectRequestViewModel : ViewModel() {
     var source: List<Novel>? = null
     var items: List<SelectableNovel>? = null
+    var itemLocaleTags: String? = null
 }
 
 /**
@@ -169,8 +170,11 @@ class NovelBulkSelectV3Fragment : Fragment() {
         btnConfirm.isEnabled = false
         setBookmarkActionsEnabled(false)
 
+        // 缓存里的 meta 已本地化；语言变更需要重建文案，但勾选状态仍从旧列表恢复。
+        val locales = ConfigurationCompat.getLocales(resources.configuration)
+        val localeTags = locales.toLanguageTags()
         val restored = bulkViewModel.items
-        if (restored != null) {
+        if (restored != null && bulkViewModel.itemLocaleTags == localeTags) {
             items.clear()
             items.addAll(restored)
             bulkViewModel.items = items
@@ -188,8 +192,7 @@ class NovelBulkSelectV3Fragment : Fragment() {
                 val ctx = requireContext()
                 // 数字分组也跟着同一份 Configuration 走，别用 Locale.getDefault() ——
                 // 那是 JVM 全局值，跟上面读字符串用的 locale 不保证是同一个。
-                val locale = ConfigurationCompat.getLocales(ctx.resources.configuration)[0]
-                    ?: Locale.getDefault()
+                val locale = locales[0] ?: Locale.getDefault()
                 val prepared = withContext(Dispatchers.IO) {
                     val numbers = NumberFormat.getIntegerInstance(locale)
                     raw.mapIndexed { index, novel ->
@@ -209,13 +212,14 @@ class NovelBulkSelectV3Fragment : Fragment() {
                                 words
                             },
                             // 默认全不选（同插画页，issue #922）：想要全部的走 toolbar 一键全选。
-                            selected = false,
+                            selected = restored?.getOrNull(index)?.selected ?: false,
                         )
                     }
                 }
                 items.clear()
                 items.addAll(prepared)
                 bulkViewModel.items = items
+                bulkViewModel.itemLocaleTags = localeTags
                 adapter.notifyDataSetChanged()
                 refreshHeaderAndCta()
             }

--- a/app/src/test/java/ceui/pixiv/ui/bulk/BulkSelectRecreationTest.kt
+++ b/app/src/test/java/ceui/pixiv/ui/bulk/BulkSelectRecreationTest.kt
@@ -1,0 +1,162 @@
+package ceui.pixiv.ui.bulk
+
+import android.app.Application
+import android.content.Context
+import android.content.res.Configuration
+import android.os.Bundle
+import android.os.Looper
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.recyclerview.widget.RecyclerView
+import ceui.lisa.R
+import ceui.lisa.core.GlideConfiguration
+import ceui.loxia.Novel
+import ceui.pixiv.api.model.Illust
+import com.blankj.utilcode.util.Utils
+import com.bumptech.glide.Glide
+import com.bumptech.glide.Registry
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.android.controller.ActivityController
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.Implementation
+import org.robolectric.annotation.Implements
+import java.text.NumberFormat
+import java.util.Locale
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35], application = Application::class, qualifiers = "en",
+    shadows = [BulkSelectRecreationTest.NoNetworkGlideModule::class])
+class BulkSelectRecreationTest {
+    private lateinit var controller: ActivityController<HostActivity>
+
+    @Before
+    fun setUp() {
+        Utils.init(RuntimeEnvironment.getApplication())
+        controller = Robolectric.buildActivity(HostActivity::class.java).setup()
+    }
+
+    @After
+    fun tearDown() {
+        controller.pause().stop().destroy()
+        Glide.tearDown()
+    }
+
+    @Test
+    fun `illustration selection survives repeated activity recreation`() {
+        val key = IllustBulkSelectHandoff.put(listOf(Illust(id = 1L), Illust(id = 2L)))
+        show(BulkSelectV3Fragment.newInstance(key))
+        row(0).itemView.performClick()
+
+        repeat(2) {
+            controller.recreate()
+            awaitItems()
+            assertEquals(2, list().adapter!!.itemCount)
+            assertEquals(View.VISIBLE, row(0).itemView.findViewById<View>(R.id.checkBadge).visibility)
+            assertEquals(View.GONE, row(1).itemView.findViewById<View>(R.id.checkBadge).visibility)
+        }
+    }
+
+    @Test
+    fun `novel selection survives repeated activity recreation`() {
+        val key = NovelBulkSelectHandoff.put(listOf(Novel(id = 1L), Novel(id = 2L)))
+        show(NovelBulkSelectV3Fragment.newInstance(key))
+        row(0).itemView.performClick()
+
+        repeat(2) {
+            controller.recreate()
+            awaitItems()
+            assertEquals(2, list().adapter!!.itemCount)
+            assertTrue(row(0).itemView.isSelected)
+            assertFalse(row(1).itemView.isSelected)
+        }
+    }
+
+    @Test
+    fun `novel locale change rebuilds metadata and preserves selection`() {
+        val key = NovelBulkSelectHandoff.put(listOf(
+            Novel(id = 1L, text_length = 12345, is_bookmarked = true),
+            Novel(id = 2L, text_length = 6789),
+        ))
+        show(NovelBulkSelectV3Fragment.newInstance(key))
+        row(0).itemView.performClick()
+        val oldMeta = row(0).itemView.findViewById<TextView>(R.id.meta).text.toString()
+
+        val configuration = Configuration(controller.get().resources.configuration).apply {
+            setLocale(Locale.JAPANESE)
+        }
+        controller.configurationChange(configuration)
+        awaitItems()
+
+        val activity = controller.get()
+        val words = activity.getString(
+            R.string.v3_novel_word_count, NumberFormat.getIntegerInstance(Locale.JAPANESE).format(12345),
+        )
+        val expected = activity.getString(R.string.bulk_select_novel_meta_bookmarked, words)
+        val restored = row(0).itemView
+        assertTrue("The locale change must use different resources", expected != oldMeta)
+        assertEquals(expected, restored.findViewById<TextView>(R.id.meta).text.toString())
+        assertTrue(restored.isSelected)
+        assertFalse(row(1).itemView.isSelected)
+        assertEquals(2, list().adapter!!.itemCount)
+    }
+
+    private fun show(fragment: Fragment) {
+        controller.get().supportFragmentManager.beginTransaction()
+            .add(android.R.id.content, fragment, "bulk").commitNow()
+        awaitItems()
+    }
+
+    private fun list(): RecyclerView {
+        val view = controller.get().supportFragmentManager.findFragmentByTag("bulk")!!.requireView()
+        return view.findViewById<RecyclerView>(R.id.list) ?: view.findViewById(R.id.grid)
+    }
+
+    private fun awaitItems() {
+        val deadline = System.nanoTime() + 10_000_000_000L
+        while (list().adapter!!.itemCount == 0 && System.nanoTime() < deadline) {
+            shadowOf(Looper.getMainLooper()).idle()
+            Thread.yield()
+        }
+        shadowOf(Looper.getMainLooper()).idle()
+        assertTrue("Bulk preparation did not complete", list().adapter!!.itemCount > 0)
+    }
+
+    private fun row(position: Int): RecyclerView.ViewHolder {
+        val list = list()
+        list.measure(
+            View.MeasureSpec.makeMeasureSpec(1080, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(1920, View.MeasureSpec.EXACTLY),
+        )
+        list.layout(0, 0, 1080, 1920)
+        shadowOf(Looper.getMainLooper()).idle()
+        return requireNotNull(list.findViewHolderForAdapterPosition(position))
+    }
+
+    class HostActivity : FragmentActivity() {
+        override fun onCreate(savedInstanceState: Bundle?) {
+            setTheme(R.style.AppTheme)
+            super.onCreate(savedInstanceState)
+            setContentView(FrameLayout(this))
+        }
+    }
+
+    // Exercise real row binding without initializing Shaft's application-wide network client.
+    @Implements(GlideConfiguration::class, isInAndroidSdk = false)
+    class NoNetworkGlideModule {
+        @Implementation
+        fun registerComponents(context: Context, glide: Glide, registry: Registry) = Unit
+    }
+}

--- a/app/src/test/resources/robolectric.properties
+++ b/app/src/test/resources/robolectric.properties
@@ -1,0 +1,2 @@
+# Resource-enabled JVM tests do not run Shaft's native application initialization.
+application=android.app.Application


### PR DESCRIPTION
# 修复批量操作页旋转后列表空态

> 分支：`patch-9-6-1`（wangwang-code fork）
> 目标：`classic`
> 最新提交：`ccef7a032`

## 背景

批量操作页（插画批量选择 / 小说批量选择）在旋转屏幕后，列表变成空态，显示「没有可选项」，无法继续操作。

## 根因

两个批量选择页都在 `onViewCreated` 里调用 handoff 的 `take()`：

- `BulkSelectV3Fragment`：`IllustBulkSelectHandoff.take(...)`
- `NovelBulkSelectV3Fragment`：`NovelBulkSelectHandoff.take(...)`

`BulkSelectHandoff.take()` 是**一次即删**的：

```kotlin
fun take(key: String?): List<T>? = key?.let { pending.remove(it) }
```

首次进入页面时 `take()` 已把列表从进程内信箱移除；旋转后 Fragment 重建，`onViewCreated` 再次用同一个 key `take()` 只能拿到 `null`，于是页面进入空态。

## 改动内容

- 把 handoff 的消费从 `onViewCreated` 移到 `onCreate`，只允许首次创建时 `take()`；
- 将 `source` 与已构建好的 `items` 放入 Fragment ViewModel，跨旋转保留；
- 旋转后 `onViewCreated` 直接读取 ViewModel：
  - 已有 `items` → 直接恢复列表；
  - 没有 `items` → 才执行首次 IO 构建并缓存；
- 同时保留用户已勾选状态，旋转后不会重置为全不选；
- ViewModel 使用项目已有直接工厂 `viewModels { ... }` 创建，不依赖反射。

## 涉及文件

- `app/src/main/java/ceui/pixiv/ui/bulk/BulkSelectV3Fragment.kt`
- `app/src/main/java/ceui/pixiv/ui/bulk/NovelBulkSelectV3Fragment.kt`

## 提交

- `ccef7a032` fix(bulk): 批量操作页旋转后从 ViewModel 恢复列表，避免空态
