### PR TITLE
修复小说系列多选「全选」按钮透底导致文字难辨认

### DIFF
--- a/app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFragment.kt
@@ -189,7 +189,9 @@ class NovelSeriesFragment :
             textSize = 15f
             gravity = Gravity.CENTER
             setTypeface(typeface, Typeface.BOLD)
-            background = palette.pillSecondary(28 * density, (1 * density).toInt())
+            // 用不透明 cardFill 代替半透明 pillSecondary：多选条悬浮在列表上，
+            // 半透明底会透出下方章节封面，textAccent 文字难以辨认。
+            background = palette.settingsCardBg(28 * density, (1 * density).toInt())
             layoutParams = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.MATCH_PARENT, 1f)
                 .apply { marginEnd = (10 * density).toInt() }
             setOnClick { onClickSelectAllToggle() }


### PR DESCRIPTION
# 修复小说系列多选「全选」按钮透底导致文字难辨认

> 分支：`patch-9-6-2`（wangwang-code fork）
> 目标：`classic`
> 最新提交：`1b5b9410e`

## 背景

小说系列详情页通过「下载选项 → 选择下载」进入多选模式后，底部操作条里的「全选」按钮会透出下方章节封面/内容，导致按钮文字难以辨认。

## 根因

多选操作条悬浮在章节列表上方，没有不透明底板；「全选」按钮使用了 `pillSecondary` 作为背景：

```kotlin
background = palette.pillSecondary(28 * density, (1 * density).toInt())
```

`pillSecondary` 的填充色是 20% 透明主题色：

```kotlin
setColor(alpha20)
```

半透明底透出下方内容后，`textAccent` 文字对比度不足，难以阅读。

## 改动内容

将「全选」按钮背景改为不透明方案：

```kotlin
background = palette.settingsCardBg(28 * density, (1 * density).toInt())
```

`settingsCardBg` 使用不透明 `cardFill` 底色 + `cardHairline` 描边，而 `textAccent` 本身按 `cardFill` 做过对比度校正，因此文字可读性有保证，同时保留圆角胶囊外观。

## 涉及文件

- `app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFragment.kt`

## 提交

- `1b5b9410e` fix(novel): 系列多选全选按钮改用不透明底色，避免透底文字难辨认
