### PR TITLE
修复小说系列多选勾选引发封面与作者头像重载闪烁

### DIFF
--- a/app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFeed.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFeed.kt
@@ -112,7 +112,10 @@ data class NovelSeriesCardFeedItem(
 }
 
 /** 多选态变化（进入/退出多选、勾选/取消勾选）的增量刷新 payload，避免重绑图片。 */
-private object NovelSeriesSelectionPayload
+internal object NovelSeriesSelectionPayload {
+    fun canBindSelectionOnly(payloads: List<Any>): Boolean =
+        payloads.isNotEmpty() && payloads.all { it === this }
+}
 
 // ── FeedSource：首页 = 头部条目 + 章节卡；后续页 = 仅章节卡（游标 = next_url）──
 
@@ -257,7 +260,8 @@ fun novelSeriesCardRenderer(): FeedRenderer<NovelSeriesCardFeedItem, CellNovelV3
             if (oldItem.novel == newItem.novel) NovelSeriesSelectionPayload else null
         },
         bindPayloads = { cell, payloads ->
-            if (payloads.any { it === NovelSeriesSelectionPayload }) {
+            // RecyclerView 会合并多次更新；混入全量刷新标记时必须回退，不能漏绑小说内容。
+            if (NovelSeriesSelectionPayload.canBindSelectionOnly(payloads)) {
                 bindNovelSeriesCardSelection(cell.binding, cell.item)
                 true
             } else {

--- a/app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFeed.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFeed.kt
@@ -111,6 +111,9 @@ data class NovelSeriesCardFeedItem(
     override val feedKey: Any get() = novel.id
 }
 
+/** 多选态变化（进入/退出多选、勾选/取消勾选）的增量刷新 payload，避免重绑图片。 */
+private object NovelSeriesSelectionPayload
+
 // ── FeedSource：首页 = 头部条目 + 章节卡；后续页 = 仅章节卡（游标 = next_url）──
 
 class NovelSeriesFeedSource(private val seriesId: Long) : FeedSource<String> {
@@ -250,6 +253,17 @@ fun novelSeriesCardRenderer(): FeedRenderer<NovelSeriesCardFeedItem, CellNovelV3
             cell.binding.novelCover.clearGlideOnRecycle()
             cell.binding.authorAvatar.clearGlideOnRecycle()
         },
+        changePayload = { oldItem, newItem ->
+            if (oldItem.novel == newItem.novel) NovelSeriesSelectionPayload else null
+        },
+        bindPayloads = { cell, payloads ->
+            if (payloads.any { it === NovelSeriesSelectionPayload }) {
+                bindNovelSeriesCardSelection(cell.binding, cell.item)
+                true
+            } else {
+                false
+            }
+        },
     ) { cell ->
         val b = cell.binding
         val novel = cell.item.novel
@@ -308,16 +322,7 @@ fun novelSeriesCardRenderer(): FeedRenderer<NovelSeriesCardFeedItem, CellNovelV3
         }
 
         // multi-select indicator
-        b.selectIndicator.isVisible = cell.item.isMultiSelectMode
-        if (cell.item.isMultiSelectMode) {
-            if (cell.item.isSelected) {
-                b.selectIndicator.setImageResource(R.drawable.ic_check_circle_black_24dp)
-                b.selectIndicator.clearColorFilter()
-            } else {
-                b.selectIndicator.setImageResource(R.drawable.ic_checkbox_off)
-                b.selectIndicator.setColorFilter(ctx.getColor(R.color.v3_text_3))
-            }
-        }
+        bindNovelSeriesCardSelection(b, cell.item)
 
         b.root.setOnClick { sender ->
             if (cell.item.isMultiSelectMode) {
@@ -329,6 +334,19 @@ fun novelSeriesCardRenderer(): FeedRenderer<NovelSeriesCardFeedItem, CellNovelV3
         }
         applyCardTouchScale(b.root, 0.98f)
     }
+
+private fun bindNovelSeriesCardSelection(b: CellNovelV3Binding, item: NovelSeriesCardFeedItem) {
+    b.selectIndicator.isVisible = item.isMultiSelectMode
+    if (item.isMultiSelectMode) {
+        if (item.isSelected) {
+            b.selectIndicator.setImageResource(R.drawable.ic_check_circle_black_24dp)
+            b.selectIndicator.clearColorFilter()
+        } else {
+            b.selectIndicator.setImageResource(R.drawable.ic_checkbox_off)
+            b.selectIndicator.setColorFilter(b.root.context.getColor(R.color.v3_text_3))
+        }
+    }
+}
 
 private fun bindNovelCardBookmark(
     b: CellNovelV3Binding,

--- a/app/src/test/java/ceui/pixiv/ui/novel/NovelSeriesSelectionPayloadTest.kt
+++ b/app/src/test/java/ceui/pixiv/ui/novel/NovelSeriesSelectionPayloadTest.kt
@@ -1,0 +1,60 @@
+package ceui.pixiv.ui.novel
+
+import ceui.loxia.Novel
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NovelSeriesSelectionPayloadTest {
+    private val renderer = novelSeriesCardRenderer()
+    private val initial = NovelSeriesCardFeedItem(Novel(id = 42L, title = "Old title"), false, false)
+
+    @Test
+    fun `enter select deselect and exit can merge into one selection bind`() {
+        val states = listOf(
+            initial,
+            initial.copy(isMultiSelectMode = true),
+            initial.copy(isMultiSelectMode = true, isSelected = true),
+            initial.copy(isMultiSelectMode = true),
+            initial,
+        )
+        val payloads = states.zipWithNext { old, new ->
+            requireNotNull(renderer.changePayload(old, new))
+        }
+
+        payloads.forEach { assertSame(NovelSeriesSelectionPayload, it) }
+        assertTrue(NovelSeriesSelectionPayload.canBindSelectionOnly(payloads))
+    }
+
+    @Test
+    fun `content refresh merged with selection still requires full binding in either order`() {
+        val refreshed = initial.copy(novel = initial.novel.copy(title = "New title"))
+        assertNull(renderer.changePayload(initial, refreshed))
+        // FeedDiff replaces null with its non-null FULL_REBIND sentinel before dispatching.
+        val fullRebind = Any()
+        val selection = requireNotNull(
+            renderer.changePayload(refreshed, refreshed.copy(isMultiSelectMode = true)),
+        )
+
+        assertFalse(NovelSeriesSelectionPayload.canBindSelectionOnly(listOf(fullRebind, selection)))
+        assertFalse(NovelSeriesSelectionPayload.canBindSelectionOnly(listOf(selection, fullRebind)))
+    }
+
+    @Test
+    fun `content and selection changed together require full binding`() {
+        val changed = initial.copy(
+            novel = initial.novel.copy(title = "New title"),
+            isMultiSelectMode = true,
+            isSelected = true,
+        )
+        assertNull(renderer.changePayload(initial, changed))
+    }
+
+    @Test
+    fun `missing or unknown payload requires full binding`() {
+        assertFalse(NovelSeriesSelectionPayload.canBindSelectionOnly(emptyList()))
+        assertFalse(NovelSeriesSelectionPayload.canBindSelectionOnly(listOf(Any())))
+    }
+}


### PR DESCRIPTION
# 修复小说系列多选勾选引发封面与作者头像重载闪烁

> 分支：`patch-9-6-3`（wangwang-code fork）
> 目标：`classic`
> 最新提交：`0174ffcda`

## 背景

小说系列详情页「下载选项 → 选择下载」进入多选后，单个勾选 / 全选 / 取消全选会引发章节卡的作品封面与作者头像重新加载，造成明显闪烁。

## 根因

`syncCards()` 每次都会通过 `updateItems<NovelSeriesCardFeedItem>` 生成新的条目：

```kotlin
it.copy(isMultiSelectMode = mode, isSelected = it.novel.id in selected)
```

`FeedAdapter` 的 DiffUtil 发现内容变化后，`novelSeriesCardRenderer` 没有实现 `changePayload` / `bindPayloads`，于是走全量重绑。全量重绑会重新执行：

```kotlin
Glide.with(ctx).load(...).into(b.novelCover)
Glide.with(ctx).load(...).into(b.authorAvatar)
```

虽然 ViewHolder 被复用，但重新 `Glide.load(...).into(...)` 会取消旧请求并重新加载，封面与作者头像因此闪烁。

## 改动内容

给 `novelSeriesCardRenderer` 增加增量刷新：

- `changePayload`：当 `novel` 没变、只有 `isMultiSelectMode` / `isSelected` 变化时，返回 `NovelSeriesSelectionPayload`；
- `bindPayloads`：收到该 payload 时只更新选中指示器，不再重绑封面 / 头像 / 标题 / 标签等；
- 把选中态 UI 抽成 `bindNovelSeriesCardSelection()`，全量绑定和增量绑定共用同一份逻辑。

这样单个勾选 / 全选 / 取消全选只改动右上角勾选图标，不会触发图片重新加载。

## 涉及文件

- `app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFeed.kt`

## 提交

- `0174ffcda` fix(novel): 系列多选勾选仅增量刷新选中指示器，避免封面头像重载闪烁
