### PR TITLE
小说有插图时切换为按 EPUB 导出 (#1088)

### DIFF
--- a/app/src/main/java/ceui/lisa/fragments/FragmentSettingsDownload.java
+++ b/app/src/main/java/ceui/lisa/fragments/FragmentSettingsDownload.java
@@ -104,6 +104,12 @@ public class FragmentSettingsDownload extends SettingsPageFragment<FragmentSetti
             }
             baseBind.defaultNovelFormat.setText(NOVEL_FORMAT_NAMES[idx]);
         }
+        baseBind.novelEpubOnImages.setChecked(Shaft.sSettings.isDefaultNovelExportEpubOnImages());
+        baseBind.novelEpubOnImages.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            Shaft.sSettings.setDefaultNovelExportEpubOnImages(isChecked);
+            Local.setSettings(Shaft.sSettings);
+        });
+        refreshNovelEpubOnImagesRow();
         baseBind.defaultNovelFormatRela.setOnClickListener(v -> {
             int checkedIdx = 0;
             String cur = Shaft.sSettings.getDefaultNovelExportFormat();
@@ -118,6 +124,7 @@ public class FragmentSettingsDownload extends SettingsPageFragment<FragmentSetti
                             Shaft.sSettings.setDefaultNovelExportFormat(NOVEL_FORMAT_VALUES[which]);
                             baseBind.defaultNovelFormat.setText(NOVEL_FORMAT_NAMES[which]);
                             Local.setSettings(Shaft.sSettings);
+                            refreshNovelEpubOnImagesRow();
                             dialog.dismiss();
                         }
                     })
@@ -462,6 +469,12 @@ public class FragmentSettingsDownload extends SettingsPageFragment<FragmentSetti
             return 1;
         }
         return 0;
+    }
+
+    private void refreshNovelEpubOnImagesRow() {
+        if (baseBind == null) return;
+        boolean visible = "Txt".equals(Shaft.sSettings.getDefaultNovelExportFormat());
+        baseBind.novelEpubOnImagesRela.setVisibility(visible ? View.VISIBLE : View.GONE);
     }
 
     private void refreshStorageLabel() {

--- a/app/src/main/java/ceui/lisa/fragments/SettingsCatalog.kt
+++ b/app/src/main/java/ceui/lisa/fragments/SettingsCatalog.kt
@@ -169,6 +169,7 @@ object SettingsCatalog {
         add(Entry(DOWNLOAD, "default_image_resolution_rela", R.string.setting_default_image_resolution, keywords = "清晰度 分辨率 画质 原图 保存 resolution"))
         add(Entry(DOWNLOAD, "write_exif_tags_rela", R.string.setting_write_exif_tags_title, R.string.setting_write_exif_tags_desc, keywords = "标签 关键词 exif xmp 元数据 相册 keywords metadata tags dc:subject"))
         add(Entry(DOWNLOAD, "default_novel_format_rela", R.string.setting_default_novel_format, keywords = "小说 格式 txt epub pdf markdown 导出 export"))
+        add(Entry(DOWNLOAD, "novel_epub_on_images_rela", R.string.setting_novel_epub_on_images, R.string.setting_novel_epub_on_images_desc, keywords = "小说 插图 图片 epub txt 自动 格式 illustration image"))
         add(Entry(DOWNLOAD, "novel_header_rela", R.string.novel_header_settings_title, R.string.novel_header_settings_entry_desc, keywords = "信息头 元信息 头部 字段 作者信息 txt"))
         add(Entry(DOWNLOAD, "download_limit_type_rela", R.string.string_452, keywords = "限制 wifi 流量 蜂窝 移动网络 limit"))
         add(Entry(DOWNLOAD, "max_concurrent_downloads_rela", R.string.setting_max_concurrent_downloads, keywords = "并发 同时 多任务 线程 速度 concurrent"))

--- a/app/src/main/java/ceui/lisa/utils/Settings.java
+++ b/app/src/main/java/ceui/lisa/utils/Settings.java
@@ -1524,6 +1524,17 @@ public class Settings {
         this.defaultNovelExportFormat = defaultNovelExportFormat;
     }
 
+    // 默认导出格式为 Txt 时，正文含插图自动改用 Epub（默认关闭）
+    private boolean defaultNovelExportEpubOnImages = false;
+
+    public boolean isDefaultNovelExportEpubOnImages() {
+        return defaultNovelExportEpubOnImages;
+    }
+
+    public void setDefaultNovelExportEpubOnImages(boolean defaultNovelExportEpubOnImages) {
+        this.defaultNovelExportEpubOnImages = defaultNovelExportEpubOnImages;
+    }
+
     // "" = 原图（当前默认行为），否则存 Params.IMAGE_RESOLUTION_* 值
     private String defaultImageResolution = "";
 

--- a/app/src/main/java/ceui/pixiv/ui/bulk/NovelBulkSelectV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/bulk/NovelBulkSelectV3Fragment.kt
@@ -13,6 +13,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -21,8 +22,13 @@ import ceui.lisa.utils.GlideUtil
 import ceui.lisa.utils.Params
 import ceui.loxia.Novel
 import ceui.pixiv.actions.PixivActions
+import ceui.pixiv.chat.base.viewModels
 import ceui.pixiv.ui.common.tintMenuIconsWhite
 import ceui.pixiv.ui.detail.showV3Menu
+import ceui.pixiv.ui.novel.reader.export.ExportFormat
+import ceui.pixiv.ui.novel.reader.export.NovelExportManager
+import ceui.pixiv.ui.novel.reader.ui.ExportFormatCallback
+import ceui.pixiv.ui.novel.reader.ui.ExportSheet
 import ceui.pixiv.ui.task.BatchDownloadNovelsTask
 import ceui.pixiv.ui.task.FailedNovel
 import ceui.pixiv.witstudio.dialog.WitDialog
@@ -36,6 +42,11 @@ import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+
+/** 小说批量下载的待确认选中列表，跨旋转保留在 Fragment ViewModel 中。 */
+class NovelBulkDownloadRequestViewModel : ViewModel() {
+    var pendingNovels: List<Novel>? = null
+}
 
 /**
  * V3 风格小说批量操作 · 多选页（issue #974）。
@@ -61,7 +72,7 @@ import kotlinx.coroutines.withContext
  *  - 首段（filled）= 下载选中小说。**不 finish 本页**，见 [startDownload]
  *  - 尾段（tonal）= 批量收藏 / 批量取消收藏，走 [PixivActions] 门面 → `:actionqueue` 队列
  */
-class NovelBulkSelectV3Fragment : Fragment() {
+class NovelBulkSelectV3Fragment : Fragment(), ExportFormatCallback {
 
     companion object {
         /** [handoffKey] 是入口 put 进 [NovelBulkSelectHandoff] 时拿到的 key；null / 过期时本页显示「没有可选项」。 */
@@ -75,6 +86,8 @@ class NovelBulkSelectV3Fragment : Fragment() {
     private var source: List<Novel> = emptyList()
 
     private val items = mutableListOf<SelectableNovel>()
+
+    private val novelDownloadRequest by viewModels { NovelBulkDownloadRequestViewModel() }
 
     /**
      * 封面的 Glide 请求管理器，建一次复用。**别在 bind 里 `Glide.with(view)`** ——
@@ -230,11 +243,29 @@ class NovelBulkSelectV3Fragment : Fragment() {
         if (downloadRunning) return
         val picked = selectedNovels()
         if (picked.isEmpty()) return
+        val format = NovelExportManager.resolveConfiguredFormat()
+        if (format != null) {
+            startDownload(picked, format)
+        } else {
+            novelDownloadRequest.pendingNovels = picked
+            ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        }
+    }
+
+    override fun onExportFormatChosen(format: ExportFormat) {
+        val picked = novelDownloadRequest.pendingNovels ?: return
+        novelDownloadRequest.pendingNovels = null
+        startDownload(picked, format)
+    }
+
+    private fun startDownload(picked: List<Novel>, format: ExportFormat) {
+        if (downloadRunning) return
         downloadRunning = true
         btnConfirm.isEnabled = false
         BatchDownloadNovelsTask(
             activity = requireActivity(),
             novels = picked,
+            format = format,
             onFinished = { failures -> onDownloadFinished(failures) },
         )
     }

--- a/app/src/main/java/ceui/pixiv/ui/common/NovelCardMenu.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/NovelCardMenu.kt
@@ -13,7 +13,6 @@ import ceui.pixiv.services.requireEntityWrapper
 import ceui.pixiv.ui.bulk.BulkSelectHandoff
 import ceui.pixiv.ui.bulk.NovelBulkSelectHandoff
 import ceui.pixiv.ui.detail.showV3Menu
-import ceui.pixiv.ui.task.BatchDownloadNovelsTask
 import ceui.pixiv.ui.navigation.TemplateRoute
 
 /**
@@ -109,21 +108,7 @@ internal fun NovelFeedFragment.showNovelCardMenu(
         // 下载这一篇：复用批量/系列下载同一条落盘链路（BatchDownloadNovelsTask），
         // 不灌 download_queue——小说下载本来就不走那张表。
         item(getString(R.string.string_339), R.drawable.ic_file_download_black_24dp) {
-            BatchDownloadNovelsTask(
-                activity = requireActivity(),
-                novels = listOf(novel),
-                onFinished = { failures ->
-                    if (isAdded) {
-                        Common.showToast(
-                            if (failures.isEmpty()) {
-                                getString(R.string.batch_download_all_ok)
-                            } else {
-                                getString(R.string.batch_download_some_failed, failures.size)
-                            }
-                        )
-                    }
-                },
-            )
+            startNovelDownload(novel)
         }
         val watchLaterLabel = getString(
             if (inWatchLater) R.string.watch_later_remove else R.string.watch_later_add

--- a/app/src/main/java/ceui/pixiv/ui/common/NovelFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/NovelFeedFragment.kt
@@ -10,6 +10,7 @@ import android.widget.ImageView
 import androidx.annotation.LayoutRes
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
+import androidx.lifecycle.ViewModel
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewbinding.ViewBinding
 import ceui.lisa.R
@@ -25,6 +26,7 @@ import ceui.pixiv.witstudio.theme.V3Palette
 import ceui.pixiv.api.Client
 import ceui.loxia.Novel
 import ceui.pixiv.actions.PixivActions
+import ceui.pixiv.chat.base.viewModels
 import ceui.pixiv.feeds.FeedCell
 import ceui.pixiv.feeds.FeedFragment
 import ceui.pixiv.feeds.FeedItem
@@ -34,7 +36,12 @@ import ceui.pixiv.feeds.FeedSkeletonView
 import ceui.pixiv.feeds.FeedViewModel
 import ceui.pixiv.feeds.feedRenderer
 import ceui.pixiv.ui.novel.NovelSeriesFragment
+import ceui.pixiv.ui.novel.reader.export.ExportFormat
+import ceui.pixiv.ui.novel.reader.export.NovelExportManager
+import ceui.pixiv.ui.novel.reader.ui.ExportFormatCallback
+import ceui.pixiv.ui.novel.reader.ui.ExportSheet
 import ceui.pixiv.ui.recommend.bindTrendingScore
+import ceui.pixiv.ui.task.BatchDownloadNovelsTask
 import ceui.pixiv.utils.playLikePressHaptic
 import ceui.pixiv.utils.pinHostGlide
 import ceui.pixiv.utils.ppppx
@@ -64,6 +71,11 @@ private data class NovelImageRequestKey(
 private const val NOVEL_SPOILER_BLUR_RADIUS = 25
 private const val NOVEL_SPOILER_BLUR_SAMPLING = 3
 
+/** 小说列表页“下载这一篇”的待确认请求，跨旋转保留在 Fragment ViewModel 中。 */
+class NovelDownloadRequestViewModel : ViewModel() {
+    var pendingNovel: Novel? = null
+}
+
 /**
  * 小说列表页的共享基类（对齐插画侧 [IllustFeedFragment]）。子类只声明数据源
  *（feedViewModels + mapper 产出 [NovelFeedItem]）；本类统一提供主力小说卡（recy_novel）：
@@ -84,9 +96,50 @@ private const val NOVEL_SPOILER_BLUR_SAMPLING = 3
  */
 abstract class NovelFeedFragment(
     @LayoutRes contentLayoutId: Int = ceui.pixiv.feeds.R.layout.fragment_feed,
-) : FeedFragment(contentLayoutId) {
+) : FeedFragment(contentLayoutId), ExportFormatCallback {
 
     abstract override val feedViewModel: FeedViewModel<String>
+
+    private val novelDownloadRequest by viewModels { NovelDownloadRequestViewModel() }
+
+    /**
+     * 小说卡“下载这一篇”：有默认格式直接下，设置为“每次询问”时弹 [ExportSheet]。
+     * 请求放在 Fragment ViewModel 中，旋转后由新实例的 [onExportFormatChosen] 继续执行。
+     */
+    fun startNovelDownload(novel: Novel) {
+        val format = NovelExportManager.resolveConfiguredFormat()
+        if (format != null) {
+            startNovelDownload(novel, format)
+        } else {
+            novelDownloadRequest.pendingNovel = novel
+            ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        }
+    }
+
+    override fun onExportFormatChosen(format: ExportFormat) {
+        val novel = novelDownloadRequest.pendingNovel ?: return
+        novelDownloadRequest.pendingNovel = null
+        startNovelDownload(novel, format)
+    }
+
+    private fun startNovelDownload(novel: Novel, format: ExportFormat) {
+        BatchDownloadNovelsTask(
+            activity = requireActivity(),
+            novels = listOf(novel),
+            format = format,
+            onFinished = { failures ->
+                if (isAdded) {
+                    Common.showToast(
+                        if (failures.isEmpty()) {
+                            getString(R.string.batch_download_all_ok)
+                        } else {
+                            getString(R.string.batch_download_some_failed, failures.size)
+                        }
+                    )
+                }
+            },
+        )
+    }
 
     /**
      * 封面 / 头像的 Glide 请求管理器，建一次复用（对齐插画侧 [IllustFeedFragment.illustGlide]）。

--- a/app/src/main/java/ceui/pixiv/ui/common/NovelFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/common/NovelFeedFragment.kt
@@ -70,6 +70,7 @@ private data class NovelImageRequestKey(
 
 private const val NOVEL_SPOILER_BLUR_RADIUS = 25
 private const val NOVEL_SPOILER_BLUR_SAMPLING = 3
+private const val NOVEL_CARD_EXPORT_TAG = "NovelCardExportSheet"
 
 /** 小说列表页“下载这一篇”的待确认请求，跨旋转保留在 Fragment ViewModel 中。 */
 class NovelDownloadRequestViewModel : ViewModel() {
@@ -112,11 +113,24 @@ abstract class NovelFeedFragment(
             startNovelDownload(novel, format)
         } else {
             novelDownloadRequest.pendingNovel = novel
-            ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+            ExportSheet().show(childFragmentManager, NOVEL_CARD_EXPORT_TAG)
         }
     }
 
     override fun onExportFormatChosen(format: ExportFormat) {
+        finishNovelCardDownload(format)
+    }
+
+    final override fun onExportFormatChosen(format: ExportFormat, sourceTag: String?) {
+        if (sourceTag == NOVEL_CARD_EXPORT_TAG) {
+            // NovelTextFragment 同时展示相关推荐卡；不能让它的详情导出回调吞掉卡片请求。
+            finishNovelCardDownload(format)
+        } else {
+            onExportFormatChosen(format)
+        }
+    }
+
+    private fun finishNovelCardDownload(format: ExportFormat) {
         val novel = novelDownloadRequest.pendingNovel ?: return
         novelDownloadRequest.pendingNovel = null
         startNovelDownload(novel, format)

--- a/app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFragment.kt
@@ -310,30 +310,37 @@ class NovelSeriesFragment :
     }
 
     private suspend fun askMergeTxtOrEpub(): ExportFormat? = withContext(Dispatchers.Main) {
-        suspendCancellableCoroutine { cont ->
-            if (!isAdded) {
-                cont.resume(null)
-                return@suspendCancellableCoroutine
-            }
-            val dialog = WitDialog.MenuDialogBuilder(requireContext())
-                .setTitle(getString(R.string.setting_novel_epub_on_images))
-                .addItems(
-                    arrayOf(getString(R.string.format_txt), getString(R.string.format_epub)),
-                ) { d, which ->
-                    if (cont.isActive) {
-                        cont.resume(if (which == 0) ExportFormat.Txt else ExportFormat.Epub)
+        var dialog: WitDialog? = null
+        try {
+            suspendCancellableCoroutine { cont ->
+                if (!isAdded) {
+                    cont.resume(null)
+                    return@suspendCancellableCoroutine
+                }
+                val created = WitDialog.MenuDialogBuilder(requireContext())
+                    .setTitle(getString(R.string.setting_novel_epub_on_images))
+                    .addItems(
+                        arrayOf(getString(R.string.format_txt), getString(R.string.format_epub)),
+                    ) { d, which ->
+                        if (cont.isActive) {
+                            cont.resume(if (which == 0) ExportFormat.Txt else ExportFormat.Epub)
+                        }
+                        d.dismiss()
                     }
-                    d.dismiss()
-                }
-                .addAction(getString(R.string.action_cancel)) { d, _ ->
+                    .addAction(getString(R.string.action_cancel)) { d, _ ->
+                        if (cont.isActive) cont.resume(null)
+                        d.dismiss()
+                    }
+                    .create()
+                dialog = created
+                created.setOnDismissListener {
                     if (cont.isActive) cont.resume(null)
-                    d.dismiss()
                 }
-                .create()
-            dialog.setOnDismissListener {
-                if (cont.isActive) cont.resume(null)
+                created.show()
             }
-            dialog.show()
+        } finally {
+            // Activity 销毁会取消抓取协程；同步关闭依附旧 Activity 的窗口。
+            dialog?.dismiss()
         }
     }
 

--- a/app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFragment.kt
@@ -16,6 +16,7 @@ import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ViewModel
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.RecyclerView
@@ -24,6 +25,7 @@ import ceui.lisa.R
 import ceui.lisa.databinding.ItemBigReadButtonBinding
 import ceui.pixiv.witstudio.theme.V3Palette
 import ceui.pixiv.api.Client
+import ceui.pixiv.chat.base.viewModels as directViewModel
 import ceui.loxia.Novel
 import ceui.pixiv.api.model.NovelSeriesResp
 import ceui.pixiv.widgets.ProgressIndicator
@@ -42,6 +44,7 @@ import ceui.pixiv.ui.detail.seriesAuthorRenderer
 import ceui.pixiv.ui.detail.seriesCaptionRenderer
 import ceui.pixiv.ui.detail.seriesSectionLabelRenderer
 import ceui.pixiv.ui.novel.reader.export.ExportFormat
+import ceui.pixiv.ui.novel.reader.export.NovelExportManager
 import ceui.pixiv.ui.novel.reader.ui.ExportFormatCallback
 import ceui.pixiv.ui.novel.reader.ui.ExportSheet
 import ceui.pixiv.ui.task.BatchDownloadNovelsTask
@@ -58,6 +61,17 @@ import ceui.pixiv.witstudio.dialog.WitDialog
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicBoolean
+
+/** 系列下载的待确认动作，跨旋转保留在 Fragment ViewModel 中。 */
+class NovelSeriesDownloadRequestViewModel : ViewModel() {
+    var pendingAction: PendingAction? = null
+
+    enum class PendingAction {
+        MERGE,
+        BATCH_SELECTED,
+        DOWNLOAD_ALL,
+    }
+}
 
 /**
  * 小说系列 V3 详情页（feeds 框架版）。hero + 作者 + 档案 + 简介 + 「作品列表」标题 + 章节卡。
@@ -81,6 +95,8 @@ class NovelSeriesFragment :
     }
 
     private val selectionModel by viewModels<NovelSeriesSelectionViewModel>()
+
+    private val novelDownloadRequest by directViewModel { NovelSeriesDownloadRequestViewModel() }
 
     private var singleDownloadBtn: View? = null
     private var multiSelectBar: View? = null
@@ -242,23 +258,42 @@ class NovelSeriesFragment :
     private fun heroDetail() = feedViewModel.uiState.value.items
         .filterIsInstance<NovelSeriesHeroFeedItem>().firstOrNull()?.series
 
-    /**
-     * 合并下载：只负责弹格式选择，真正的动作在 [onExportFormatChosen] 里按当时的 VM 状态重建。
-     *
-     * 刻意**不**把动作攒成一个 `pendingMergeAction` 闭包挂在 Fragment 字段上：[ExportSheet] 是
-     * DialogFragment，旋转 / 切深色会重建宿主 Fragment，而对话框由 FragmentManager 自动恢复并
-     * 回调到**新**实例上——旧实例的字段连同闭包一起没了，用户选完格式点确定会静默无反应。
-     * 合并要用的数据（系列详情、已加载章节）全都住在比 view 长命的 VM 里，现取即可。
-     */
     private fun launchMergeDownload() {
         if (heroDetail() == null) {
             Toaster.show(getString(R.string.merge_download_failed_empty))
             return
         }
-        ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        val format = NovelExportManager.resolveConfiguredFormat()
+        if (format != null) {
+            startMergeDownload(format)
+        } else {
+            novelDownloadRequest.pendingAction = NovelSeriesDownloadRequestViewModel.PendingAction.MERGE
+            ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        }
     }
 
     override fun onExportFormatChosen(format: ExportFormat) {
+        val action = novelDownloadRequest.pendingAction
+        novelDownloadRequest.pendingAction = null
+        when (action) {
+            NovelSeriesDownloadRequestViewModel.PendingAction.BATCH_SELECTED -> {
+                val novels = selectedNovels()
+                val ordered = loadedNovels().distinctBy { it.id }
+                if (novels.isNotEmpty()) {
+                    startBatchDownloadSelected(novels, ordered, format)
+                }
+            }
+            NovelSeriesDownloadRequestViewModel.PendingAction.DOWNLOAD_ALL -> {
+                launchDownloadAll(format)
+            }
+            NovelSeriesDownloadRequestViewModel.PendingAction.MERGE -> {
+                startMergeDownload(format)
+            }
+            null -> Unit
+        }
+    }
+
+    private fun startMergeDownload(format: ExportFormat) {
         val detail = heroDetail()
         if (detail == null) {
             Toaster.show(getString(R.string.merge_download_failed_empty))
@@ -306,9 +341,20 @@ class NovelSeriesFragment :
         // 系列位置按已加载的完整章节序列算，不能按选中子集的下标算——
         // 勾选第 3、5、9 章时，文件名 / 信息头里要的是 3、5、9 而不是 1、2、3。
         val ordered = loadedNovels().distinctBy { it.id }
+        val format = NovelExportManager.resolveConfiguredFormat()
+        if (format != null) {
+            startBatchDownloadSelected(novels, ordered, format)
+        } else {
+            novelDownloadRequest.pendingAction = NovelSeriesDownloadRequestViewModel.PendingAction.BATCH_SELECTED
+            ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        }
+    }
+
+    private fun startBatchDownloadSelected(novels: List<Novel>, ordered: List<Novel>, format: ExportFormat) {
         BatchDownloadNovelsTask(
             activity = requireActivity(),
             novels = novels,
+            format = format,
             onFinished = { failures -> onBatchDownloadFinished(failures) },
             seriesPositions = seriesPositionsOf(ordered),
             seriesTotal = seriesTotalCount(loadedCount = ordered.size),
@@ -350,6 +396,16 @@ class NovelSeriesFragment :
     }
 
     private fun launchDownloadAll() {
+        val format = NovelExportManager.resolveConfiguredFormat()
+        if (format != null) {
+            launchDownloadAll(format)
+        } else {
+            novelDownloadRequest.pendingAction = NovelSeriesDownloadRequestViewModel.PendingAction.DOWNLOAD_ALL
+            ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        }
+    }
+
+    private fun launchDownloadAll(format: ExportFormat) {
         object : FetchAllTask<Novel, NovelSeriesResp>(
             requireActivity(),
             taskFullName = "下载系列小说全部作品-${seriesId}",
@@ -367,6 +423,7 @@ class NovelSeriesFragment :
                 BatchDownloadNovelsTask(
                     activity = requireActivity(),
                     novels = results,
+                    format = format,
                     onFinished = { failures -> onBatchDownloadFinished(failures) },
                     seriesPositions = seriesPositionsOf(ordered),
                     seriesTotal = ordered.size,

--- a/app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFragment.kt
@@ -42,6 +42,7 @@ import ceui.pixiv.ui.detail.seriesAuthorRenderer
 import ceui.pixiv.ui.detail.seriesCaptionRenderer
 import ceui.pixiv.ui.detail.seriesSectionLabelRenderer
 import ceui.pixiv.ui.novel.reader.export.ExportFormat
+import ceui.pixiv.ui.novel.reader.export.NovelExportManager
 import ceui.pixiv.ui.novel.reader.ui.ExportFormatCallback
 import ceui.pixiv.ui.novel.reader.ui.ExportSheet
 import ceui.pixiv.ui.task.BatchDownloadNovelsTask
@@ -55,8 +56,12 @@ import ceui.pixiv.utils.ppppx
 import ceui.pixiv.utils.setOnClick
 import com.hjq.toast.Toaster
 import ceui.pixiv.witstudio.dialog.WitDialog
+import kotlin.coroutines.resume
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -243,22 +248,27 @@ class NovelSeriesFragment :
         .filterIsInstance<NovelSeriesHeroFeedItem>().firstOrNull()?.series
 
     /**
-     * 合并下载：只负责弹格式选择，真正的动作在 [onExportFormatChosen] 里按当时的 VM 状态重建。
-     *
-     * 刻意**不**把动作攒成一个 `pendingMergeAction` 闭包挂在 Fragment 字段上：[ExportSheet] 是
-     * DialogFragment，旋转 / 切深色会重建宿主 Fragment，而对话框由 FragmentManager 自动恢复并
-     * 回调到**新**实例上——旧实例的字段连同闭包一起没了，用户选完格式点确定会静默无反应。
-     * 合并要用的数据（系列详情、已加载章节）全都住在比 view 长命的 VM 里，现取即可。
+     * 合并下载：有默认格式直接走快路径；默认“每次询问”时弹 [ExportSheet]。
+     * 默认 TXT 且开启「有插图时存 EPUB」时，抓完章节后由 [startMergeDownload] 弹 TXT/EPUB 质询。
      */
     private fun launchMergeDownload() {
         if (heroDetail() == null) {
             Toaster.show(getString(R.string.merge_download_failed_empty))
             return
         }
-        ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        val format = NovelExportManager.resolveConfiguredFormat()
+        if (format != null) {
+            startMergeDownload(format, allowAutoEpub = true)
+        } else {
+            ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        }
     }
 
     override fun onExportFormatChosen(format: ExportFormat) {
+        startMergeDownload(format)
+    }
+
+    private fun startMergeDownload(format: ExportFormat, allowAutoEpub: Boolean = false) {
         val detail = heroDetail()
         if (detail == null) {
             Toaster.show(getString(R.string.merge_download_failed_empty))
@@ -271,6 +281,8 @@ class NovelSeriesFragment :
             knownNovels = dedup,
             format = format,
             stopSignal = stopSignal,
+            allowAutoEpub = allowAutoEpub,
+            confirmFormat = if (allowAutoEpub) { _ -> askMergeTxtOrEpub() } else null,
         )
         val config = FetchProgressDialog.Config(
             title = "merge-novel-series",
@@ -295,6 +307,34 @@ class NovelSeriesFragment :
             onCancelRequested = { stopSignal.set(true) },
         )
         FetchProgressDialog.show(requireActivity().supportFragmentManager, flow, config)
+    }
+
+    private suspend fun askMergeTxtOrEpub(): ExportFormat? = withContext(Dispatchers.Main) {
+        suspendCancellableCoroutine { cont ->
+            if (!isAdded) {
+                cont.resume(null)
+                return@suspendCancellableCoroutine
+            }
+            val dialog = WitDialog.MenuDialogBuilder(requireContext())
+                .setTitle(getString(R.string.setting_novel_epub_on_images))
+                .addItems(
+                    arrayOf(getString(R.string.format_txt), getString(R.string.format_epub)),
+                ) { d, which ->
+                    if (cont.isActive) {
+                        cont.resume(if (which == 0) ExportFormat.Txt else ExportFormat.Epub)
+                    }
+                    d.dismiss()
+                }
+                .addAction(getString(R.string.action_cancel)) { d, _ ->
+                    if (cont.isActive) cont.resume(null)
+                    d.dismiss()
+                }
+                .create()
+            dialog.setOnDismissListener {
+                if (cont.isActive) cont.resume(null)
+            }
+            dialog.show()
+        }
     }
 
     private fun launchBatchDownloadSelected() {

--- a/app/src/main/java/ceui/pixiv/ui/novel/NovelTextFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/NovelTextFragment.kt
@@ -251,9 +251,8 @@ class NovelTextFragment :
     }
 
     override fun onClickDownloadNovel(sender: View, novelId: Long) {
-        val defaultFormat = Shaft.sSettings.defaultNovelExportFormat
-        val format = ExportFormat.entries.firstOrNull { it.name == defaultFormat }
-        if (format != null) executeExport(format) else showExportSheet()
+        val format = NovelExportManager.resolveConfiguredFormat()
+        if (format != null) executeExport(format, allowAutoEpub = true) else showExportSheet()
     }
 
     override fun onLongClickDownloadNovel(sender: View, novelId: Long) {
@@ -268,9 +267,8 @@ class NovelTextFragment :
         executeExport(format)
     }
 
-    private fun executeExport(format: ExportFormat) {
+    private fun executeExport(format: ExportFormat, allowAutoEpub: Boolean = false) {
         val appContext = requireContext().applicationContext
-        Toaster.show(getString(R.string.msg_export_start, getString(format.displayNameResId)))
         viewLifecycleOwner.lifecycleScope.launch {
             val result = runCatching {
                 val novel = ObjectPool.get<Novel>(novelId).value
@@ -286,9 +284,16 @@ class NovelTextFragment :
                 if (cached == null) {
                     NovelTextCache.put(novelId, NovelTextCache.Entry(web, tokens))
                 }
+                // 仅默认 TXT 快路径允许静默切 EPUB；手动在“每次询问”里选 TXT 不切。
+                val actualFormat = if (allowAutoEpub && NovelExportManager.shouldAutoEpubForDefaultTxt(format, tokens)) {
+                    ExportFormat.Epub
+                } else {
+                    format
+                }
+                Toaster.show(getString(R.string.msg_export_start, getString(actualFormat.displayNameResId)))
                 NovelExportManager.export(
                     context = appContext,
-                    format = format,
+                    format = actualFormat,
                     novel = novel,
                     webNovel = web,
                     tokens = tokens,

--- a/app/src/main/java/ceui/pixiv/ui/novel/NovelTextFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/NovelTextFragment.kt
@@ -251,8 +251,7 @@ class NovelTextFragment :
     }
 
     override fun onClickDownloadNovel(sender: View, novelId: Long) {
-        val defaultFormat = Shaft.sSettings.defaultNovelExportFormat
-        val format = ExportFormat.entries.firstOrNull { it.name == defaultFormat }
+        val format = NovelExportManager.resolveConfiguredFormat()
         if (format != null) executeExport(format) else showExportSheet()
     }
 

--- a/app/src/main/java/ceui/pixiv/ui/novel/reader/NovelReaderV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/reader/NovelReaderV3Fragment.kt
@@ -41,6 +41,7 @@ import ceui.pixiv.ui.detail.showV3Menu
 import ceui.pixiv.ui.novel.reader.model.PageGeometry
 import ceui.pixiv.ui.novel.reader.export.ExportFormat
 import ceui.pixiv.ui.novel.reader.export.ExportResult
+import ceui.pixiv.ui.novel.reader.export.NovelExportManager
 import ceui.pixiv.ui.novel.reader.model.HighlightColor
 import ceui.pixiv.ui.novel.reader.model.HighlightSpan
 import ceui.pixiv.ui.novel.reader.model.SearchHit
@@ -799,8 +800,7 @@ class NovelReaderV3Fragment : Fragment(R.layout.fragment_novel_reader_v3),
                     Toaster.showShort(getString(R.string.msg_novel_not_ready))
                     return@item
                 }
-                val defaultFormat = Shaft.sSettings.defaultNovelExportFormat
-                val format = ExportFormat.entries.firstOrNull { it.name == defaultFormat }
+                val format = NovelExportManager.resolveConfiguredFormat()
                 if (format != null) {
                     executeExport(format)
                 } else {

--- a/app/src/main/java/ceui/pixiv/ui/novel/reader/NovelReaderV3Fragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/reader/NovelReaderV3Fragment.kt
@@ -41,6 +41,7 @@ import ceui.pixiv.ui.detail.showV3Menu
 import ceui.pixiv.ui.novel.reader.model.PageGeometry
 import ceui.pixiv.ui.novel.reader.export.ExportFormat
 import ceui.pixiv.ui.novel.reader.export.ExportResult
+import ceui.pixiv.ui.novel.reader.export.NovelExportManager
 import ceui.pixiv.ui.novel.reader.model.HighlightColor
 import ceui.pixiv.ui.novel.reader.model.HighlightSpan
 import ceui.pixiv.ui.novel.reader.model.SearchHit
@@ -799,10 +800,9 @@ class NovelReaderV3Fragment : Fragment(R.layout.fragment_novel_reader_v3),
                     Toaster.showShort(getString(R.string.msg_novel_not_ready))
                     return@item
                 }
-                val defaultFormat = Shaft.sSettings.defaultNovelExportFormat
-                val format = ExportFormat.entries.firstOrNull { it.name == defaultFormat }
+                val format = NovelExportManager.resolveConfiguredFormat()
                 if (format != null) {
-                    executeExport(format)
+                    executeExport(format, allowAutoEpub = true)
                 } else {
                     showExportSheet()
                 }
@@ -818,10 +818,10 @@ class NovelReaderV3Fragment : Fragment(R.layout.fragment_novel_reader_v3),
         executeExport(format)
     }
 
-    private fun executeExport(format: ExportFormat) {
+    private fun executeExport(format: ExportFormat, allowAutoEpub: Boolean = false) {
         Toaster.showShort(getString(R.string.msg_export_start, getString(format.displayNameResId)))
         viewLifecycleOwner.lifecycleScope.launch {
-            when (val result = viewModel.exportNovel(format)) {
+            when (val result = viewModel.exportNovel(format, allowAutoEpub)) {
                 is ExportResult.Success -> Toaster.showLong(getString(R.string.msg_export_success, result.displayPath))
                 is ExportResult.Failure -> Toaster.showLong(getString(R.string.msg_export_fail, result.message))
             }

--- a/app/src/main/java/ceui/pixiv/ui/novel/reader/NovelReaderV3ViewModel.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/reader/NovelReaderV3ViewModel.kt
@@ -499,12 +499,18 @@ class NovelReaderV3ViewModel(
 
     // ---- Export --------------------------------------------------------------
 
-    suspend fun exportNovel(format: ExportFormat): ExportResult {
+    suspend fun exportNovel(format: ExportFormat, allowAutoEpub: Boolean = false): ExportResult {
         val loaded = _loadState.value as? LoadState.Loaded
             ?: return ExportResult.Failure(ctx().getString(R.string.msg_novel_not_ready))
+        // 仅默认 TXT 快路径允许静默切 EPUB；手动在“每次询问”里选 TXT 不切。
+        val actualFormat = if (allowAutoEpub && NovelExportManager.shouldAutoEpubForDefaultTxt(format, loaded.tokens)) {
+            ExportFormat.Epub
+        } else {
+            format
+        }
         return NovelExportManager.export(
             context = Shaft.getContext(),
-            format = format,
+            format = actualFormat,
             novel = loaded.novel,
             webNovel = loaded.webNovel,
             tokens = loaded.tokens,

--- a/app/src/main/java/ceui/pixiv/ui/novel/reader/export/NovelExportManager.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/reader/export/NovelExportManager.kt
@@ -49,6 +49,7 @@ object NovelExportManager {
      */
     fun shouldAutoEpubForDefaultTxt(format: ExportFormat, tokens: List<ContentToken>): Boolean =
         format == ExportFormat.Txt &&
+            resolveConfiguredFormat() == ExportFormat.Txt &&
             Shaft.sSettings.isDefaultNovelExportEpubOnImages &&
             tokens.any { it is ContentToken.PixivImage || it is ContentToken.UploadedImage }
 

--- a/app/src/main/java/ceui/pixiv/ui/novel/reader/export/NovelExportManager.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/reader/export/NovelExportManager.kt
@@ -33,6 +33,25 @@ object NovelExportManager {
         ExportFormat.Pdf to PdfExporter(),
     )
 
+    /**
+     * 解析「默认小说下载格式」设置。
+     *
+     * @return 非空 = 直接使用该格式；null = 设置为「每次询问」，调用方应弹格式选择。
+     */
+    fun resolveConfiguredFormat(): ExportFormat? {
+        val name = Shaft.sSettings.defaultNovelExportFormat
+        return if (name.isNullOrBlank()) null else ExportFormat.entries.firstOrNull { it.name == name }
+    }
+
+    /**
+     * 默认 TXT 快路径下，正文含插图且用户开启「有插图时存 EPUB」时改用 EPUB。
+     * 手动在“每次询问”里选择 TXT 不应触发。
+     */
+    fun shouldAutoEpubForDefaultTxt(format: ExportFormat, tokens: List<ContentToken>): Boolean =
+        format == ExportFormat.Txt &&
+            Shaft.sSettings.isDefaultNovelExportEpubOnImages &&
+            tokens.any { it is ContentToken.PixivImage || it is ContentToken.UploadedImage }
+
     suspend fun export(
         context: Context,
         format: ExportFormat,

--- a/app/src/main/java/ceui/pixiv/ui/novel/reader/export/NovelExportManager.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/reader/export/NovelExportManager.kt
@@ -33,12 +33,24 @@ object NovelExportManager {
         ExportFormat.Pdf to PdfExporter(),
     )
 
+    /**
+     * 解析「默认小说下载格式」设置。
+     *
+     * @return 非空 = 直接使用该格式；null = 设置为「每次询问」，调用方应弹格式选择。
+     */
+    fun resolveConfiguredFormat(): ExportFormat? {
+        val name = Shaft.sSettings.defaultNovelExportFormat
+        return if (name.isNullOrBlank()) null else ExportFormat.entries.firstOrNull { it.name == name }
+    }
+
     suspend fun export(
         context: Context,
         format: ExportFormat,
         novel: Novel?,
         webNovel: WebNovel,
         tokens: List<ContentToken>,
+        seriesOrder: Int? = null,
+        seriesTotal: Int? = null,
     ): ExportResult = withContext(Dispatchers.IO) {
         val destination: RelativePath = if (novel != null) {
             DownloadItems.novelDestinationFromLoxia(
@@ -46,7 +58,9 @@ object NovelExportManager {
                 extOverride = format.extension,
                 // 序号取「系列可见列表位置」（SeriesCache，reader 场景通常已缓存），
                 // 让单篇下载 / 导出和系列批量下载渲染出同一个文件名（issue #964）。
-                seriesOrder = seriesOrderOf(novel),
+                // 批量/系列下载调用方可直接传 seriesOrder/seriesTotal 覆盖缓存查询。
+                seriesOrder = seriesOrder ?: seriesOrderOf(novel),
+                seriesTotal = seriesTotal,
             )
         } else {
             // No Novel — only the web payload. Best-effort meta;

--- a/app/src/main/java/ceui/pixiv/ui/novel/reader/ui/ExportSheet.kt
+++ b/app/src/main/java/ceui/pixiv/ui/novel/reader/ui/ExportSheet.kt
@@ -14,6 +14,11 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 interface ExportFormatCallback {
     fun onExportFormatChosen(format: ExportFormat)
+
+    /** FragmentManager 会恢复 tag，宿主可据此区分详情导出和列表卡片下载。 */
+    fun onExportFormatChosen(format: ExportFormat, sourceTag: String?) {
+        onExportFormatChosen(format)
+    }
 }
 
 class ExportSheet : BottomSheetDialogFragment() {
@@ -37,7 +42,7 @@ class ExportSheet : BottomSheetDialogFragment() {
         )
         binding.list.layoutManager = LinearLayoutManager(requireContext())
         binding.list.adapter = Adapter(rows) { format ->
-            (parentFragment as? ExportFormatCallback)?.onExportFormatChosen(format)
+            (parentFragment as? ExportFormatCallback)?.onExportFormatChosen(format, tag)
             dismissAllowingStateLoss()
         }
         return binding.root

--- a/app/src/main/java/ceui/pixiv/ui/task/BatchDownloadNovelsTask.kt
+++ b/app/src/main/java/ceui/pixiv/ui/task/BatchDownloadNovelsTask.kt
@@ -13,6 +13,10 @@ import ceui.pixiv.ui.common.getTxtFileIdInDownloads
 import ceui.pixiv.ui.common.saveToDownloadsScopedStorage
 import ceui.pixiv.download.config.DownloadItems
 import ceui.pixiv.download.model.RelativePath
+import ceui.pixiv.ui.novel.reader.export.ExportFormat
+import ceui.pixiv.ui.novel.reader.export.ExportResult
+import ceui.pixiv.ui.novel.reader.export.NovelExportManager
+import ceui.pixiv.ui.novel.reader.paginate.ContentParser
 import com.hjq.toast.Toaster
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -43,6 +47,7 @@ data class FailedNovel(
 class BatchDownloadNovelsTask(
     private val activity: FragmentActivity,
     private val novels: List<Novel>,
+    private val format: ExportFormat,
     private val onProgress: (done: Int, total: Int) -> Unit = { _, _ -> },
     private val onFinished: (failures: List<FailedNovel>) -> Unit,
     /**
@@ -109,6 +114,7 @@ class BatchDownloadNovelsTask(
         val total = seriesTotal.takeIf { seriesIndex != null }
         val destination: RelativePath = DownloadItems.novelDestinationFromLoxia(
             novel,
+            extOverride = format.extension,
             seriesOrder = seriesIndex,
             seriesTotal = total,
         )
@@ -116,7 +122,7 @@ class BatchDownloadNovelsTask(
 
         // Skip already-downloaded files. DownloadNovelTask uses the same
         // pre-check before it hits the network.
-        if (getTxtFileIdInDownloads(ctx, fileName) != null) {
+        if (format == ExportFormat.Txt && getTxtFileIdInDownloads(ctx, fileName) != null) {
             Timber.d("$fileName already exists, skipping")
             return
         }
@@ -124,6 +130,24 @@ class BatchDownloadNovelsTask(
         val html = Client.appApi.getNovelText(novel.id).string()
         val wNovel = WebNovelParser.parsePixivObject(html)?.novel
             ?: throw RuntimeException("invalid web novel")
+
+        // 非 TXT 格式直接复用阅读器导出链路，避免在批量下载里再维护一套 MD/EPUB/PDF 实现。
+        if (format != ExportFormat.Txt) {
+            val tokens = ContentParser.tokenize(wNovel)
+            when (val result = NovelExportManager.export(
+                context = ctx,
+                format = format,
+                novel = novel,
+                webNovel = wNovel,
+                tokens = tokens,
+                seriesOrder = seriesIndex,
+                seriesTotal = total,
+            )) {
+                is ExportResult.Success -> Unit
+                is ExportResult.Failure -> throw RuntimeException(result.message)
+            }
+            return
+        }
 
         val buffer = StringBuffer().apply {
             append("\n\n")

--- a/app/src/main/java/ceui/pixiv/ui/task/MergeDownloadNovelSeriesTask.kt
+++ b/app/src/main/java/ceui/pixiv/ui/task/MergeDownloadNovelSeriesTask.kt
@@ -1,6 +1,7 @@
 package ceui.pixiv.ui.task
 
 import android.content.Context
+import ceui.lisa.activities.Shaft
 import ceui.lisa.fragments.WebNovelParser
 import ceui.loxia.Novel
 import ceui.pixiv.api.Client
@@ -42,6 +43,8 @@ class MergeDownloadNovelSeriesTask(context: Context) {
         knownNovels: List<Novel>,
         format: ExportFormat,
         stopSignal: AtomicBoolean,
+        allowAutoEpub: Boolean = false,
+        confirmFormat: (suspend (ExportFormat) -> ExportFormat?)? = null,
     ): Flow<FetchEvent> = flow {
         val startedAt = System.currentTimeMillis()
         val seriesId = seriesDetail.id
@@ -111,13 +114,29 @@ class MergeDownloadNovelSeriesTask(context: Context) {
             return@flow
         }
 
+        // ── 2.5) 默认 TXT + 开启「有插图时存 EPUB」：检测到插图后交给 UI 质询 ──
+        var effectiveFormat = format
+        if (allowAutoEpub && format == ExportFormat.Txt &&
+            Shaft.sSettings.isDefaultNovelExportEpubOnImages &&
+            chapters.any { it.webNovel?.let(::hasIllustrations) == true }
+        ) {
+            emit(FetchEvent.Log("> 检测到插图，询问导出格式…"))
+            val chosen = confirmFormat?.invoke(format)
+            if (chosen == null) {
+                emit(FetchEvent.Log("> 用户取消 · 未生成文件"))
+                emit(FetchEvent.Errored("用户取消 · 未生成文件", chapters.size))
+                return@flow
+            }
+            effectiveFormat = chosen
+        }
+
         // ── 3) 写文件 ──
         // 目录 + 文件名全部由「小说系列 · 合并下载」模板渲染（issue #964）。章节数
         // 报实抓到的那个：用户中途停止时产物就是截短版，文件名不该谎报全集。
         val destination = DownloadItems.novelSeriesMergeDestination(
             seriesDetail = seriesDetail,
             chapterCount = chapters.size,
-            ext = format.extension,
+            ext = effectiveFormat.extension,
             r18 = allNovels.any { (it.x_restrict ?: 0) > 0 },
         )
         val mergeName = destination.filename
@@ -131,7 +150,7 @@ class MergeDownloadNovelSeriesTask(context: Context) {
             chapters = chapters,
             documentId = "novel_series_$seriesId",
         )
-        val writer = MergedNovelWriters.forFormat(format)
+        val writer = MergedNovelWriters.forFormat(effectiveFormat)
         val ok = writer.write(ctx, content, destination) { key, bytes ->
             emit(FetchEvent.ImageFetched(key, bytes))
         }
@@ -208,3 +227,6 @@ class MergeDownloadNovelSeriesTask(context: Context) {
         const val SERIES_PAGE_DELAY_MS = 1000L
     }
 }
+
+private fun hasIllustrations(webNovel: WebNovel): Boolean =
+    !webNovel.illusts.isNullOrEmpty() || !webNovel.images.isNullOrEmpty()

--- a/app/src/main/java/ceui/pixiv/ui/task/NovelAutoDownload.kt
+++ b/app/src/main/java/ceui/pixiv/ui/task/NovelAutoDownload.kt
@@ -114,9 +114,12 @@ object NovelAutoDownload {
                 NovelTextCache.put(novel.id, it)
             }
         }
+        // 自动下载是收藏的副作用，没有交互入口可「每次询问」：
+        // 显式配置了默认格式就用它，否则回退 TXT，避免静默跳过自动下载。
+        val format = NovelExportManager.resolveConfiguredFormat() ?: ExportFormat.Txt
         when (val result = NovelExportManager.export(
             context = context,
-            format = ExportFormat.Txt,
+            format = format,
             novel = novel,
             webNovel = entry.webNovel,
             tokens = entry.tokens,

--- a/app/src/main/java/ceui/pixiv/ui/task/NovelAutoDownload.kt
+++ b/app/src/main/java/ceui/pixiv/ui/task/NovelAutoDownload.kt
@@ -114,9 +114,15 @@ object NovelAutoDownload {
                 NovelTextCache.put(novel.id, it)
             }
         }
+        // 自动下载属于默认 TXT 快路径：有插图且开关开启时静默改用 EPUB。
+        val format = if (NovelExportManager.shouldAutoEpubForDefaultTxt(ExportFormat.Txt, entry.tokens)) {
+            ExportFormat.Epub
+        } else {
+            ExportFormat.Txt
+        }
         when (val result = NovelExportManager.export(
             context = context,
-            format = ExportFormat.Txt,
+            format = format,
             novel = novel,
             webNovel = entry.webNovel,
             tokens = entry.tokens,

--- a/app/src/main/java/ceui/pixiv/ui/task/NovelAutoDownload.kt
+++ b/app/src/main/java/ceui/pixiv/ui/task/NovelAutoDownload.kt
@@ -114,11 +114,12 @@ object NovelAutoDownload {
                 NovelTextCache.put(novel.id, it)
             }
         }
-        // 自动下载属于默认 TXT 快路径：有插图且开关开启时静默改用 EPUB。
-        val format = if (NovelExportManager.shouldAutoEpubForDefaultTxt(ExportFormat.Txt, entry.tokens)) {
+        // 只有显式默认 TXT 才能转 EPUB；“每次询问”在后台回退 TXT，其他默认格式原样使用。
+        val configuredFormat = NovelExportManager.resolveConfiguredFormat() ?: ExportFormat.Txt
+        val format = if (NovelExportManager.shouldAutoEpubForDefaultTxt(configuredFormat, entry.tokens)) {
             ExportFormat.Epub
         } else {
-            ExportFormat.Txt
+            configuredFormat
         }
         when (val result = NovelExportManager.export(
             context = context,

--- a/app/src/main/java/ceui/pixiv/ui/user/UserNovelSeriesFeedFragment.kt
+++ b/app/src/main/java/ceui/pixiv/ui/user/UserNovelSeriesFeedFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.ViewModel
 import androidx.recyclerview.widget.RecyclerView
 import androidx.viewbinding.ViewBinding
 import ceui.lisa.R
@@ -13,6 +14,7 @@ import ceui.lisa.activities.TemplateActivity
 import ceui.lisa.databinding.FragmentToolbarFeedBinding
 import ceui.lisa.databinding.RecyNovelSeriesOfUserBinding
 import ceui.pixiv.api.Client
+import ceui.pixiv.chat.base.viewModels
 import ceui.lisa.model.ListNovelSeries
 import ceui.lisa.models.NovelSeriesItem
 import ceui.lisa.utils.Common
@@ -31,6 +33,7 @@ import ceui.pixiv.ui.common.viewBinding
 import ceui.pixiv.ui.novel.CrossSeriesDownloadOptionsSheet
 import ceui.pixiv.ui.novel.NovelSeriesFragment
 import ceui.pixiv.ui.novel.reader.export.ExportFormat
+import ceui.pixiv.ui.novel.reader.export.NovelExportManager
 import ceui.pixiv.ui.novel.reader.ui.ExportFormatCallback
 import ceui.pixiv.ui.novel.reader.ui.ExportSheet
 import ceui.pixiv.ui.task.CrossSeriesDownloadTask
@@ -40,6 +43,12 @@ import ceui.pixiv.witstudio.dialog.WitDialog
 import ceui.pixiv.witstudio.dialog.WitDialogAction
 import kotlin.math.floor
 import ceui.pixiv.ui.navigation.TemplateRoute
+
+/** 跨系列下载的待确认请求，跨旋转保留在 Fragment ViewModel 中。 */
+class CrossSeriesDownloadRequestViewModel : ViewModel() {
+    var pendingSeriesList: List<NovelSeriesItem>? = null
+    var mergeAll: Boolean = false
+}
 
 /**
  * 某作者「小说系列」总览页（feeds 框架版，替代 legacy [ceui.lisa.fragments.FragmentNovelSeries] +
@@ -55,12 +64,15 @@ import ceui.pixiv.ui.navigation.TemplateRoute
  *   - 选择下载：多选系列，每个系列各自合并为独立文件；
  *   - 全部下载：全部系列，每个各自合并为独立文件；
  *   - 合并下载：全部系列合并为唯一一个文件。
- * 选完模式再弹 [ExportSheet] 选输出格式（TXT/MD/PDF/EPUB），回调走 [CrossSeriesDownloadTask]。
+ * 选完模式后按「默认小说下载格式」直接执行或弹格式选择（TXT/MD/PDF/EPUB），
+ * 回调走 [CrossSeriesDownloadTask]。
  * 该流程只依赖 [allItems]（当前列表快照）/ activity / childFragmentManager / isAdded，与 legacy 等价。
  */
 class UserNovelSeriesFeedFragment : FeedFragment(), ExportFormatCallback {
 
     private val binding by viewBinding(FragmentToolbarFeedBinding::bind)
+
+    private val novelDownloadRequest by viewModels { CrossSeriesDownloadRequestViewModel() }
 
     /**
      * 两种形态,对齐 [UserNovelFeedFragment]:
@@ -217,16 +229,16 @@ class UserNovelSeriesFeedFragment : FeedFragment(), ExportFormatCallback {
         builder.create().show()
     }
 
-    /**
-     * 用户在 [CrossSeriesDownloadOptionsSheet] 选完模式后，再弹 [ExportSheet] 选输出格式。
-     * 把"要做什么"暂存到 [pendingMergeAction]，等 sheet 回调 [onExportFormatChosen] 拿到 format 再真正启动 task。
-     */
-    private var pendingMergeAction: ((ExportFormat) -> Unit)? = null
-
     private fun runPerSeries(seriesList: List<NovelSeriesItem>) {
         if (!isAdded) return
-        pendingMergeAction = { format -> startPerSeries(seriesList, format) }
-        ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        val format = NovelExportManager.resolveConfiguredFormat()
+        if (format != null) {
+            startPerSeries(seriesList, format)
+        } else {
+            novelDownloadRequest.pendingSeriesList = seriesList
+            novelDownloadRequest.mergeAll = false
+            ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        }
     }
 
     private fun runMergeAll() {
@@ -236,13 +248,26 @@ class UserNovelSeriesFeedFragment : FeedFragment(), ExportFormatCallback {
             return
         }
         if (!isAdded) return
-        pendingMergeAction = { format -> startMergeAll(list, format) }
-        ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        val format = NovelExportManager.resolveConfiguredFormat()
+        if (format != null) {
+            startMergeAll(list, format)
+        } else {
+            novelDownloadRequest.pendingSeriesList = list
+            novelDownloadRequest.mergeAll = true
+            ExportSheet().show(childFragmentManager, ExportSheet.TAG)
+        }
     }
 
     override fun onExportFormatChosen(format: ExportFormat) {
-        pendingMergeAction?.invoke(format)
-        pendingMergeAction = null
+        val seriesList = novelDownloadRequest.pendingSeriesList
+        val mergeAll = novelDownloadRequest.mergeAll
+        novelDownloadRequest.pendingSeriesList = null
+        novelDownloadRequest.mergeAll = false
+        if (mergeAll) {
+            startMergeAll(seriesList ?: allItems(), format)
+        } else if (seriesList != null) {
+            startPerSeries(seriesList, format)
+        }
     }
 
     private fun startPerSeries(seriesList: List<NovelSeriesItem>, format: ExportFormat) {

--- a/app/src/main/res/layout/fragment_settings_download.xml
+++ b/app/src/main/res/layout/fragment_settings_download.xml
@@ -259,6 +259,29 @@
                 </RelativeLayout>
 
                 <RelativeLayout
+                    android:id="@+id/novel_epub_on_images_rela"
+                    style="@style/M3SetRow"
+                    android:background="@drawable/wit_row_mid"
+                    android:visibility="gone">
+
+                    <LinearLayout style="@style/M3SetTexts">
+
+                        <TextView
+                            style="@style/M3SetTitle"
+                            android:text="@string/setting_novel_epub_on_images" />
+
+                        <TextView
+                            style="@style/M3SetDesc"
+                            android:text="@string/setting_novel_epub_on_images_desc" />
+                    </LinearLayout>
+
+                    <androidx.appcompat.widget.SwitchCompat
+                        android:id="@+id/novel_epub_on_images"
+                        style="@style/M3SetSwitch" />
+
+                </RelativeLayout>
+
+                <RelativeLayout
                     android:id="@+id/novel_header_rela"
                     style="@style/M3SetRow"
                     android:background="@drawable/wit_row_bottom">

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1537,6 +1537,8 @@
     <string name="novel_chip_series_content_count">Chapters  %1$s</string>
     <string name="novel_chip_series_char_count">Total length  %1$s</string>
     <string name="setting_default_novel_format">Default novel download format</string>
+    <string name="setting_novel_epub_on_images">Save as EPUB when novel has illustrations</string>
+    <string name="setting_novel_epub_on_images_desc">When default format is TXT, automatically export EPUB if the text contains illustrations</string>
     <string name="setting_default_image_resolution">Default image save resolution</string>
     <string name="option_always_ask">Always ask</string>
     <string name="msg_unknown_format">Unknown format: %s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1537,6 +1537,8 @@
     <string name="novel_chip_series_content_count">話数  %1$s</string>
     <string name="novel_chip_series_char_count">総文字数  %1$s</string>
     <string name="setting_default_novel_format">既定の小説ダウンロード形式</string>
+    <string name="setting_novel_epub_on_images">挿絵がある小説はEPUBで保存</string>
+    <string name="setting_novel_epub_on_images_desc">既定の形式がTXTの場合、本文に挿絵があれば自動的にEPUBで書き出します</string>
     <string name="setting_default_image_resolution">既定の画像保存解像度</string>
     <string name="option_always_ask">毎回確認</string>
     <string name="msg_unknown_format">不明な形式：%s</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -1537,6 +1537,8 @@
     <string name="novel_chip_series_content_count">챕터 수  %1$s</string>
     <string name="novel_chip_series_char_count">총 글자 수  %1$s</string>
     <string name="setting_default_novel_format">기본 소설 다운로드 형식</string>
+    <string name="setting_novel_epub_on_images">소설에 일러스트가 있으면 EPUB로 저장</string>
+    <string name="setting_novel_epub_on_images_desc">기본 형식이 TXT인 경우 본문에 일러스트가 있으면 자동으로 EPUB로 내보냅니다</string>
     <string name="setting_default_image_resolution">기본 이미지 저장 해상도</string>
     <string name="option_always_ask">항상 묻기</string>
     <string name="msg_unknown_format">알 수 없는 형식: %s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1537,6 +1537,8 @@
     <string name="novel_chip_series_content_count">Глав  %1$s</string>
     <string name="novel_chip_series_char_count">Общий объём  %1$s</string>
     <string name="setting_default_novel_format">Формат загрузки романов по умолчанию</string>
+    <string name="setting_novel_epub_on_images">Сохранять как EPUB, если в новелле есть иллюстрации</string>
+    <string name="setting_novel_epub_on_images_desc">Если формат по умолчанию TXT, при наличии иллюстраций в тексте автоматически экспортировать в EPUB</string>
     <string name="setting_default_image_resolution">Качество при скачивании</string>
     <string name="option_always_ask">Всегда спрашивать</string>
     <string name="msg_unknown_format">Неизвестный формат: %s</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1537,6 +1537,8 @@
     <string name="novel_chip_series_content_count">Bölüm sayısı  %1$s</string>
     <string name="novel_chip_series_char_count">Toplam karakter  %1$s</string>
     <string name="setting_default_novel_format">Varsayılan roman indirme biçimi</string>
+    <string name="setting_novel_epub_on_images">Roman içinde çizim varsa EPUB olarak kaydet</string>
+    <string name="setting_novel_epub_on_images_desc">Varsayılan biçim TXT olduğunda, metinde çizim algılanırsa otomatik olarak EPUB olarak dışa aktar</string>
     <string name="setting_default_image_resolution">Varsayılan görsel kayıt çözünürlüğü</string>
     <string name="option_always_ask">Her seferinde sor</string>
     <string name="msg_unknown_format">Bilinmeyen biçim: %s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1539,6 +1539,8 @@
     <string name="novel_chip_series_content_count">章節數  %1$s</string>
     <string name="novel_chip_series_char_count">總字數  %1$s</string>
     <string name="setting_default_novel_format">預設小說下載格式</string>
+    <string name="setting_novel_epub_on_images">小說有插圖時存EPUB</string>
+    <string name="setting_novel_epub_on_images_desc">預設匯出格式為 TXT 時，偵測到正文插圖自動改用 EPUB 匯出</string>
     <string name="setting_default_image_resolution">預設圖片儲存清晰度</string>
     <string name="option_always_ask">每次詢問</string>
     <string name="msg_unknown_format">未知格式：%s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1684,6 +1684,8 @@
     <string name="novel_chip_series_char_count">总字数  %1$s</string>
 
     <string name="setting_default_novel_format">默认小说下载格式</string>
+    <string name="setting_novel_epub_on_images">小说有插图时存EPUB</string>
+    <string name="setting_novel_epub_on_images_desc">默认导出格式为 TXT 时，检测到正文插图自动改用 EPUB 导出</string>
     <string name="setting_default_image_resolution">默认图片保存清晰度</string>
     <string name="option_always_ask">每次询问</string>
     <string name="msg_unknown_format">未知格式: %s</string>

--- a/app/src/test/java/ceui/pixiv/ui/common/NovelExportRoutingTest.kt
+++ b/app/src/test/java/ceui/pixiv/ui/common/NovelExportRoutingTest.kt
@@ -1,0 +1,52 @@
+package ceui.pixiv.ui.common
+
+import android.app.Application
+import androidx.fragment.app.FragmentActivity
+import ceui.pixiv.feeds.FeedViewModel
+import ceui.pixiv.ui.novel.reader.export.ExportFormat
+import ceui.pixiv.ui.novel.reader.ui.ExportFormatCallback
+import ceui.pixiv.ui.novel.reader.ui.ExportSheet
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35], manifest = Config.NONE, application = Application::class)
+class NovelExportRoutingTest {
+    // Same inheritance as NovelTextFragment: a detail export overrides the list callback.
+    class DetailHost : NovelFeedFragment() {
+        override val feedViewModel: FeedViewModel<String> get() = error("No feed needed")
+        val detailExports = mutableListOf<ExportFormat>()
+        override fun onExportFormatChosen(format: ExportFormat) {
+            detailExports += format
+        }
+    }
+
+    @Test fun `card response must not fall through to the detail novel`() {
+        val controller = Robolectric.buildActivity(FragmentActivity::class.java).create()
+        val host = DetailHost()
+        controller.get().supportFragmentManager.beginTransaction().add(host, "detail").commitNow()
+        // A restored sheet without a pending request must be ignored, never export the detail.
+        (host as ExportFormatCallback).onExportFormatChosen(ExportFormat.Epub, "NovelCardExportSheet")
+        assertEquals(emptyList<ExportFormat>(), host.detailExports)
+        controller.destroy()
+    }
+
+    @Test fun `detail sheet still reaches the overridden detail export`() {
+        val host = DetailHost()
+        (host as ExportFormatCallback).onExportFormatChosen(ExportFormat.Txt, ExportSheet.TAG)
+        assertEquals(listOf(ExportFormat.Txt), host.detailExports)
+    }
+
+    @Test fun `existing sheet hosts retain their original callback`() {
+        val received = mutableListOf<ExportFormat>()
+        val host = object : ExportFormatCallback {
+            override fun onExportFormatChosen(format: ExportFormat) { received += format }
+        }
+        host.onExportFormatChosen(ExportFormat.Pdf, ExportSheet.TAG)
+        assertEquals(listOf(ExportFormat.Pdf), received)
+    }
+}

--- a/app/src/test/java/ceui/pixiv/ui/novel/reader/export/NovelExportFormatTest.kt
+++ b/app/src/test/java/ceui/pixiv/ui/novel/reader/export/NovelExportFormatTest.kt
@@ -1,0 +1,68 @@
+package ceui.pixiv.ui.novel.reader.export
+
+import android.app.Application
+import ceui.lisa.activities.Shaft
+import ceui.lisa.utils.Settings
+import ceui.pixiv.ui.novel.reader.paginate.ContentParser
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35], manifest = Config.NONE, application = Application::class)
+class NovelExportFormatTest {
+    private var previous: Settings? = null
+
+    @Before fun setUp() {
+        previous = Shaft.sSettings
+        Shaft.sSettings = Settings().apply { isDefaultNovelExportEpubOnImages = true }
+    }
+
+    @After fun tearDown() { Shaft.sSettings = previous }
+
+    @Test fun `stale enabled switch cannot override another default or always ask fallback`() {
+        val tokens = ContentParser.tokenize("[pixivimage:123]")
+        for (name in listOf("", "Markdown", "Epub", "Pdf", "invalid")) {
+            Shaft.sSettings.defaultNovelExportFormat = name
+            assertFalse(name, NovelExportManager.shouldAutoEpubForDefaultTxt(ExportFormat.Txt, tokens))
+        }
+    }
+
+    @Test fun `default TXT detects both supported illustration markers`() {
+        Shaft.sSettings.defaultNovelExportFormat = "Txt"
+        for (body in listOf("[pixivimage:123-2]", "[uploadedimage:456]")) {
+            assertTrue(body, NovelExportManager.shouldAutoEpubForDefaultTxt(
+                ExportFormat.Txt, ContentParser.tokenize(body),
+            ))
+        }
+    }
+
+    @Test fun `plain text disabled switch and non TXT selections keep their format`() {
+        Shaft.sSettings.defaultNovelExportFormat = "Txt"
+        assertFalse(NovelExportManager.shouldAutoEpubForDefaultTxt(ExportFormat.Txt, emptyList()))
+        assertFalse(NovelExportManager.shouldAutoEpubForDefaultTxt(
+            ExportFormat.Txt, ContentParser.tokenize("plain text"),
+        ))
+        val images = ContentParser.tokenize("[uploadedimage:456]")
+        for (format in ExportFormat.entries.filter { it != ExportFormat.Txt }) {
+            assertFalse(NovelExportManager.shouldAutoEpubForDefaultTxt(format, images))
+        }
+        Shaft.sSettings.isDefaultNovelExportEpubOnImages = false
+        assertFalse(NovelExportManager.shouldAutoEpubForDefaultTxt(ExportFormat.Txt, images))
+    }
+
+    @Test fun `configured formats resolve while always ask and unknown values do not`() {
+        for (format in ExportFormat.entries) {
+            Shaft.sSettings.defaultNovelExportFormat = format.name
+            assertEquals(format, NovelExportManager.resolveConfiguredFormat())
+        }
+        for (name in listOf("", " ", "unknown")) {
+            Shaft.sSettings.defaultNovelExportFormat = name
+            assertNull(NovelExportManager.resolveConfiguredFormat())
+        }
+    }
+}


### PR DESCRIPTION
# 小说有插图时切换为按 EPUB 导出 (#1088)

> 分支：`patch-9-6-4`（wangwang-code fork）
> 目标：`classic`
> 最新提交：`d6367bb1a`

## 背景

Issue #1088：部分用户希望默认导出格式设为 TXT，因为无插图小说用 TXT 更简洁；但遇到有插图小说时，TXT 无法包含图片，希望可以自动改为 EPUB 导出。

## 改动内容

### 1. 新增设置项

- `Settings` 新增 `defaultNovelExportEpubOnImages`，默认关闭；
- 设置页新增「小说有插图时存EPUB」开关：
  - 只在默认小说下载格式为 TXT 时显示；
  - 默认格式切换为其它值时自动隐藏。

### 2. 单篇导出 / 阅读器

- 默认格式为 TXT、开关开启、正文包含插图标记时，**静默改用 EPUB 导出**；
- 手动在“每次询问”里选择 TXT：**不触发切换**，尊重用户选择。

### 3. 收藏后自动下载

- 默认 TXT + 开关开启 + 正文有插图时，自动下载静默改用 EPUB。

### 4. 系列合并下载

- 合并下载支持默认格式快路径；
- 默认 TXT + 开关开启 + 系列任一章节有插图时，抓完章节后弹 `WitDialog` 质询：
  - 选 TXT → 继续按 TXT 合并；
  - 选 EPUB → 改为 EPUB 合并；
  - 取消 / 返回 → 不写文件、不产生文件。
- 手动在“每次询问”里选 TXT：不弹该质询。

### 5. 明确不做

- 批量“分开下载”不纳入本次；
- 跨系列合并下载（`CrossSeriesDownloadTask`）本次未改。

## 涉及文件

- `app/src/main/java/ceui/lisa/utils/Settings.java`
- `app/src/main/java/ceui/lisa/fragments/FragmentSettingsDownload.java`
- `app/src/main/java/ceui/lisa/fragments/SettingsCatalog.kt`
- `app/src/main/res/layout/fragment_settings_download.xml`
- `app/src/main/java/ceui/pixiv/ui/novel/reader/export/NovelExportManager.kt`
- `app/src/main/java/ceui/pixiv/ui/novel/NovelTextFragment.kt`
- `app/src/main/java/ceui/pixiv/ui/novel/reader/NovelReaderV3Fragment.kt`
- `app/src/main/java/ceui/pixiv/ui/novel/reader/NovelReaderV3ViewModel.kt`
- `app/src/main/java/ceui/pixiv/ui/task/NovelAutoDownload.kt`
- `app/src/main/java/ceui/pixiv/ui/task/MergeDownloadNovelSeriesTask.kt`
- `app/src/main/java/ceui/pixiv/ui/novel/NovelSeriesFragment.kt`
- `app/src/main/res/values*/strings.xml`

## 提交

- `d6367bb1a` feat(novel): 默认TXT时含插图自动改存EPUB，合并下载增加质询 (#1088)
