### PR TITLE
fix(image-detail): AI 进度层改挂 Activity 根布局，修转圈叠到相邻页

### DIFF
--- a/app/src/main/res/layout/activity_image_detail.xml
+++ b/app/src/main/res/layout/activity_image_detail.xml
@@ -86,5 +86,11 @@
 
         </FrameLayout>
 
+        <!-- AI 进度层(翻译漫画/圈选翻译/AI 放大/抠图共用)挂在 Activity 根布局上,全局唯一。
+             若随各页 FragmentImageDetail 各带一份,同 id 会有多份,Activity 的
+             findViewById 命中的是 ViewPager 中 child 顺序第一个(通常是相邻页),
+             转圈 + 状态文本就叠到了看不见的页上,表现为「有概率不显示」。 -->
+        <include layout="@layout/view_ai_upscale_overlay" />
+
     </ceui.lisa.view.DragDismissLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_image_detail.xml
+++ b/app/src/main/res/layout/fragment_image_detail.xml
@@ -58,8 +58,6 @@
                 android:textSize="14sp" />
         </LinearLayout>
 
-        <include layout="@layout/view_ai_upscale_overlay" />
-
         <ceui.lisa.view.SeamlessCircularProgressIndicator
             android:id="@+id/progress_circular"
             android:layout_width="wrap_content"


### PR DESCRIPTION
# 看图页 AI 进度层改挂 Activity 根布局，转圈 + 状态文本不再叠到 ViewPager 相邻页

> 分支：`patch-9-9`（wangwang-code fork）
> 目标：`classic`
> 最新提交：`4e1136b88` fix(image-detail): AI 进度层改挂 Activity 根布局，修转圈叠到相邻页

## 背景

二级详情大图页点「翻译漫画」/「圈选翻译」/「AI 放大」/「AI 抠图」时，屏幕上应盖一层半透明遮罩 + 转圈 + 状态文本。

用户反馈：翻译时的这层进度提示**有概率不出现**。业务逻辑完全正常——OCR、翻译、擦字回填都照跑，译图最终也能正常回填显示，属于纯 UI 呈现问题。

## 根因

`view_ai_upscale_overlay` 的根容器 id 是 `ai_overlay_root`，原先 include 在 `fragment_image_detail.xml`，于是 **ViewPager 每页的 FragmentImageDetail 各带一份同 id 子树**。

而 `ImageDetailActivity` 三处入口都从 **Activity 全局视图树**查找：

```kotlin
findViewById<View>(R.id.ai_overlay_root)
```

- `ImageDetailActivity.kt:926` `observeTranslationStatus()` —— 翻译漫画 / 圈选翻译
- `ImageDetailActivity.kt:774` `performAiRembg()` —— AI 抠图
- `ImageDetailActivity.kt:995` `observeUpscaleTask()` —— AI 放大

`ImageDetailActivity` 用 `FragmentPagerAdapter` + `FixedViewPager`，没有调 `setOffscreenPageLimit`（默认 1），当前页 ±1 三页的 Fragment 视图同时挂在 ViewPager 上，因此树上同时存在 2~3 个 `ai_overlay_root`。

`findViewById` 深度优先返回**第一个**匹配实例，命中谁只取决于 ViewPager 子视图的排列顺序（= Fragment 视图被 `addView` 的顺序，由 `ViewPager.populate()` 补页顺序 + 翻页历史决定），**与 `viewPager.currentItem` 没有任何绑定**。

ViewPager 1.0.0 源码佐证：

- `startPos` / `endPos` 只保 ±1 页（`ViewPager.java:1127-1129`），超范围走 `destroyItem()` → `FragmentPagerAdapter` 仅 `detach()`，把 view 从 ViewPager 摘掉；
- 左侧补页循环（`ViewPager.java:1171`）先于右侧补页循环（`ViewPager.java:1205`），补出来的页经 `instantiateItem` → `FragmentTransaction.add()` 追加到子视图末尾。

于是：

- 以页码递增方向翻页时，左邻页的 view 更早存在、排在前面 → 命中的是**左邻页** → 当前页看不到转圈 / 状态文本；
- 以页码递减方向翻页时，左邻页是「刚补出来」的、被追加到末尾 → 可能命中当前页 → 又能看到。

这就是「有概率」的来源。副作用是被命中的那一页（看不见的）overlay 会被置 VISIBLE 并卡住，翻过去能看到残留的转圈层。

## 改动内容

把进度层从「每页 Fragment 一份」提升为「Activity 一份」：

- `fragment_image_detail.xml`：删掉 `<include layout="@layout/view_ai_upscale_overlay" />`；
- `activity_image_detail.xml`：在 `DragDismissLayout` 末尾（`bottom_rela` 之后）加上同一个 include，并留注释说明为什么不能再放回 Fragment。

这样 Activity 的三处 `findViewById(R.id.ai_overlay_root)` 必然命中唯一实例；overlay 是 `match_parent`，覆盖整个 ViewPager，无论当前在哪一页都可见。

其他三个 include 点（`fragment_illust.xml`、`fragment_artwork_v3.xml`、`fragment_ai_upscale.xml`）**不动**——它们都通过 `rootView.findViewById` 在 Fragment 内部访问（`IllustAiHelper` / `FragmentAiUpscale`），不经过 Activity 全局查找，不存在同 id 歧义。

## 涉及文件

- `app/src/main/res/layout/activity_image_detail.xml`
- `app/src/main/res/layout/fragment_image_detail.xml`

## 注意

- 进度层只是 UI 反馈，不参与翻译流水线：OCR → 翻译 → `TextEraser` / `TextRenderer` 回填 → `publishTranslated()` → `MangaBatchTranslateCenter.publish()` → Fragment 的 `translatedPaths` 观察者 `loadImage(译图)`。所以「业务正常、最终能回填」与本次修复不冲突；
- 一处改动同时修好翻译漫画、圈选翻译、AI 放大、AI 抠图四个入口（三处调用点共用同一个查找方式）；
- 顺带修掉 Activity 重建（旋转 / 进程恢复）时 overlay 可能因 Fragment 视图尚未就绪而查不到的问题。

## 提交

- `4e1136b88` fix(image-detail): AI 进度层改挂 Activity 根布局，修转圈叠到相邻页

## 测试情况

- 真机验收：多 P 作品 → 以页码递增方向翻到第 2 页以上 → 点「翻译漫画」。修复前当前页无转圈 / 状态文本，修复后稳定盖在当前页